### PR TITLE
fix: error handling resilience and ESM import consistency

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -89,8 +89,10 @@ const config: Config = {
   //   "node"
   // ],
 
-  // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+  // Redirect .js imports to their TypeScript source so ts-jest can resolve them
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   // modulePathIgnorePatterns: [],

--- a/src/__tests__/ExternalPlatformConfig.test.ts
+++ b/src/__tests__/ExternalPlatformConfig.test.ts
@@ -1,4 +1,4 @@
-import { flattenAccessoryConfiguration } from '../ExternalPlatformConfig';
+import { flattenAccessoryConfiguration } from '../ExternalPlatformConfig.js';
 
 describe('calculateResultingAccessoryConfiguration', () => {
   test('it merges accessory and global configurations', () => {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -68,7 +68,7 @@ export class SoundTouchHomebridgePlatform implements DynamicPlatformPlugin {
       });
     }
 
-    return Promise.all(
+    const results = await Promise.allSettled(
       this.configuration.accessories.map((accessoryConfig) =>
         SoundTouchDevice.fromConfiguredAccessory({
           accessoryConfig,
@@ -76,55 +76,68 @@ export class SoundTouchHomebridgePlatform implements DynamicPlatformPlugin {
         })
       )
     );
+
+    return results.flatMap((result) => {
+      if (result.status === 'fulfilled') {
+        return [result.value];
+      }
+      this.logger.error('Failed to load configured accessory', result.reason);
+      return [];
+    });
   }
 
   async discoverDevices() {
     this.logger.debug('searching for devices', this.configuration);
 
-    const accessories = await this.searchDevices();
+    let accessories: SoundTouchDevice[];
+    try {
+      accessories = await this.searchDevices();
+    } catch (e: unknown) {
+      this.logger.error('Device discovery failed', e);
+      return;
+    }
 
     this.logger.debug('loaded devices', accessories);
 
     for (const device of accessories) {
       const uuid = this.api.hap.uuid.generate(device.id);
 
-      // see if an accessory with the same uuid has already been registered and restored from
-      // the cached devices we stored in the `configureAccessory` method above
       const existingAccessory = this._accessories.get(uuid);
 
-      if (existingAccessory) {
-        // the accessory already exists
-        this.logger.info(
-          'Restoring existing accessory from cache:',
-          existingAccessory.displayName
-        );
+      try {
+        if (existingAccessory) {
+          this.logger.info(
+            'Restoring existing accessory from cache:',
+            existingAccessory.displayName
+          );
 
-        await SoundTouchSpeakerPlatformAccessory.create({
-          platform: this,
-          accessory: existingAccessory,
-          device,
-        });
-      } else {
-        this.logger.info('Adding new accessory:', device.name);
+          await SoundTouchSpeakerPlatformAccessory.create({
+            platform: this,
+            accessory: existingAccessory,
+            device,
+          });
+        } else {
+          this.logger.info('Adding new accessory:', device.name);
 
-        const accessory = new this.api.platformAccessory(device.name, uuid);
+          const accessory = new this.api.platformAccessory(device.name, uuid);
 
-        accessory.context.device = device;
+          accessory.context.device = device;
 
-        await SoundTouchSpeakerPlatformAccessory.create({
-          platform: this,
-          accessory,
-          device,
-        });
+          await SoundTouchSpeakerPlatformAccessory.create({
+            platform: this,
+            accessory,
+            device,
+          });
 
-        // link the accessory to your platform
-        this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [
-          accessory,
-        ]);
+          this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [
+            accessory,
+          ]);
+        }
+
+        this._discoveredCacheUUIDs.push(uuid);
+      } catch (e: unknown) {
+        this.logger.error(`Failed to initialise accessory: ${device.name}`, e);
       }
-
-      // push into _discoveredCacheUUIDs
-      this._discoveredCacheUUIDs.push(uuid);
     }
 
     for (const [uuid, accessory] of this._accessories) {

--- a/src/utils/__tests__/FormattedLogger.test.ts
+++ b/src/utils/__tests__/FormattedLogger.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { Logger } from '../FormattedLogger';
+import { Logger } from '../FormattedLogger.js';
 import { LogLevel } from 'homebridge';
 
 describe('FormattedLogger', () => {


### PR DESCRIPTION
## Summary

- **`Promise.all` → `Promise.allSettled` in `searchDevices`** — previously, if any single configured accessory failed to resolve (device offline, bad IP, etc.) the entire discovery run would throw and no accessories would register. Now each failure is logged individually and skipped, letting the rest load normally.
- **Per-device try/catch in `discoverDevices`** — accessory initialisation (info fetch, service setup, HAP registration) is now wrapped per device. A failure on one device no longer prevents others from registering. UUID is only pushed to `_discoveredCacheUUIDs` on success to keep the stale-accessory cleanup logic correct.
- **Top-level `searchDevices` guard** — catastrophic discovery failures (e.g. mDNS unavailable) are now caught and logged instead of propagating as an unhandled rejection to Homebridge.
- **`moduleNameMapper` in jest.config.ts** — strips `.js` extensions from relative imports so `ts-jest` can resolve ESM-style paths. Test files updated to use `.js` suffixes, consistent with all source files.

## Test plan

- [x] `npm test` — 20 tests pass
- [x] `npm run lint` — 0 warnings
- [ ] Manual: configure a device with a bad IP; confirm other devices still register
- [ ] Manual: disconnect a device mid-session; confirm polling continues for remaining devices
