### PR TITLE
fix: add --access public to beta publish and correct repository.url

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,6 @@ jobs:
 
       - name: Publish to npm (beta)
         if: github.ref == 'refs/heads/beta'
-        run: npm publish --tag beta --provenance
+        run: npm publish --tag beta --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://github.com/forktrucka/homebridge-soundtouch-speaker#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/forktrucka/homebridge-soundtouch-speaker.git"
+    "url": "git+https://github.com/forktrucka/homebridge-soundtouch-speaker.git"
   },
   "bugs": {
     "url": "https://github.com/forktrucka/homebridge-soundtouch-speaker/issues"


### PR DESCRIPTION
## Summary

Two fixes for the failed beta publish run in [#27487255753](https://github.com/forktrucka/homebridge-soundtouch-speaker/actions/runs/27487255753):

- **`--access public` on beta publish** — npm returns E404 on first publish of a new package without this flag; it was already on the `latest` step but missing from `beta`
- **`repository.url` corrected to `git+https://`** — npm was auto-correcting this on every publish run and warning; `npm pkg fix` writes the normalised value permanently
