### PR TITLE
ci: switch to npm trusted publishing — remove NPM_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,12 +34,8 @@ jobs:
 
       - name: Publish to npm (latest)
         if: github.ref == 'refs/heads/latest'
-        run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
 
       - name: Publish to npm (beta)
         if: github.ref == 'refs/heads/beta'
-        run: npm publish --tag beta --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --tag beta --access public


### PR DESCRIPTION
## Summary

Removes `NPM_TOKEN` / `NODE_AUTH_TOKEN` from the publish workflow entirely. Authentication and provenance attestations are handled automatically via GitHub Actions OIDC (`id-token: write` is already present on the job).

## Required one-time setup on npmjs.com (if not done yet)

Package → **Settings** → **Trusted Publishers** → **Add a trusted publisher**

| Field | Value |
|---|---|
| User / Organization | `forktrucka` |
| Repository | `homebridge-soundtouch-speaker` |
| Workflow filename | `publish.yml` |
| Environment | *(leave blank)* |

Once saved, pushes to `beta` or `latest` will publish without any stored secret.
