### PR TITLE
fix: remove registry-url from setup-node to unblock OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
     branches:
-      - latest
-      - beta
       - dev
   pull_request:
     branches:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

- Removes `registry-url` from `actions/setup-node` in `publish.yml` — this was writing an `.npmrc` that injected `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`, which conflicted with npm&#39;s OIDC trusted publishing flow and caused E404 on every publish attempt
- Fixes `ci.yml` push trigger to only run on `dev` (removes `beta`/`latest`), preventing CI and publish workflows from double-firing on release branch pushes

## Test plan

- [ ] Merge to dev, then merge dev → beta
- [ ] Confirm only `publish.yml` fires on the beta push (not ci.yml)
- [ ] Confirm publish succeeds without `NODE_AUTH_TOKEN` in env
- [ ] Verify npm package version appears on registry after publish
