### PR TITLE
chore: merge dev into beta for 0.2.4-beta.0 publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
     branches:
-      - latest
-      - beta
       - dev
   pull_request:
     branches:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Merges the trusted publishing fix (PR #28) into beta to trigger the publish workflow.

- Removes `registry-url` from setup-node to unblock OIDC trusted publishing
- Fixes CI push trigger to dev-only

## Test plan
- [ ] Confirm only `publish.yml` fires (not `ci.yml`) on this push to beta
- [ ] Confirm `homebridge-soundtouchspeaker@0.2.4-beta.0` appears on npm after publish