### PR TITLE
fix: add --provenance to npm publish to trigger OIDC token exchange

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
     branches:
-      - latest
-      - beta
       - dev
   pull_request:
     branches:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Publish to npm (latest)
         if: github.ref == 'refs/heads/latest'
-        run: npm publish --access public
+        run: npm publish --provenance --access public
 
       - name: Publish to npm (beta)
         if: github.ref == 'refs/heads/beta'
-        run: npm publish --tag beta --access public
+        run: npm publish --provenance --tag beta --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Problem

Removing `registry-url` from `setup-node` (PR #28) was not enough. `npm publish` now returns `ENEEDAUTH` — npm makes a completely unauthenticated request, ignoring the trusted publisher configuration.

## Root Cause

npm only triggers the OIDC token exchange — requesting a GitHub OIDC token and exchanging it for temporary npm credentials — when the `--provenance` flag is passed. Without it, npm doesn&#39;t know to use OIDC at all.

## Fix

Added `--provenance` to both `npm publish` commands. With `id-token: write` + `--provenance`, npm will:
1. Request a GitHub OIDC token
2. Exchange it with the npm registry for temporary credentials
3. Publish the package and attach provenance attestation

No `NPM_TOKEN` secret needed.

## Test plan
- [ ] Merge to beta
- [ ] Confirm `publish.yml` succeeds (not ENEEDAUTH)
- [ ] Confirm `homebridge-soundtouchspeaker@0.2.4-beta.0` appears on npm
