### PR TITLE
debug: diagnose OIDC env in publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
     branches:
-      - latest
-      - beta
       - dev
   pull_request:
     branches:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,13 @@ jobs:
         with:
           node-version: 22
 
+      - name: Diagnostics
+        run: |
+          node --version
+          npm --version
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL set: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL != '' }}"
+          printenv | grep -E "^ACTIONS_|^NODE_AUTH" || true
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Publish to npm (latest)
         if: github.ref == 'refs/heads/latest'
-        run: npm publish --access public
+        run: npm publish --provenance --access public
 
       - name: Publish to npm (beta)
         if: github.ref == 'refs/heads/beta'
-        run: npm publish --tag beta --access public
+        run: npm publish --provenance --tag beta --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Adds a diagnostics step to show npm version, node version, and OIDC env vars to understand why --provenance is not triggering OIDC auth. Will remove once root cause is found.