### PR TITLE
fix: correct publish auth — npm_token required, provenance for attestation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,13 +24,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-
-      - name: Diagnostics
-        run: |
-          node --version
-          npm --version
-          echo "ACTIONS_ID_TOKEN_REQUEST_URL set: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL != '' }}"
-          printenv | grep -E "^ACTIONS_|^NODE_AUTH" || true
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
@@ -41,14 +35,11 @@ jobs:
       - name: Publish to npm (latest)
         if: github.ref == 'refs/heads/latest'
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to npm (beta)
         if: github.ref == 'refs/heads/beta'
-        run: npm publish --provenance --tag beta --access public || true
-
-      - name: Upload npm debug log
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: npm-debug-log
-          path: ~/.npm/_logs/*.log
+        run: npm publish --provenance --tag beta --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Root Cause (definitive, from npm debug log)

npm 10.9.8 throws `ENEEDAUTH` at `publish.js:149` — an auth check that runs **before** the provenance/OIDC step. The `--provenance` flag adds SLSA attestation metadata using the OIDC token, but it does NOT replace registry authentication.

npm&#39;s &#34;trusted publishers&#34; on npmjs.com is not the same as PyPI&#39;s tokenless OIDC publishing. npm still requires a stored auth token.

## Fix

1. Restore `registry-url` in `setup-node` so it writes `.npmrc` with the `_authToken` template
2. Pass `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to each publish step
3. Keep `--provenance` for SLSA attestation (best practice, uses `id-token: write`)

## Required manual step

Add `NPM_TOKEN` as a GitHub secret:
- Go to npmjs.com → Access Tokens → Generate a **Granular access token**
- Scope: `homebridge-soundtouchspeaker` package, Read and write
- Add to repo: Settings → Secrets → `NPM_TOKEN`

## Test plan
- [x] Add NPM_TOKEN secret to repo
- [ ] Merge this PR to beta
- [ ] Confirm publish succeeds and `homebridge-soundtouchspeaker@0.2.4-beta.0` appears on npm
