### PR TITLE
chore: bump version to 0.2.4-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-soundtouchspeaker",
-  "version": "0.2.4-beta.0",
+  "version": "0.2.4-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-soundtouchspeaker",
-      "version": "0.2.4-beta.0",
+      "version": "0.2.4-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "homebridge-soundtouchspeaker",
   "displayName": "SoundTouch Speaker",
   "type": "module",
-  "version": "0.2.4-beta.0",
+  "version": "0.2.4-beta.1",
   "description": "Updates homebridge-soundtouch-platform to work on latest homebridge.",
   "author": "Andrew Trainor",
   "license": "Apache-2.0",


### PR DESCRIPTION
Increment prerelease version to fix npm 400 error caused by attempting to publish over already-published 0.2.4-beta.0.