### PR TITLE
fix: correct config schema so name is optional and port is configurable

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -32,8 +32,8 @@
           "properties": {
             "name": {
               "type": "string",
-              "required": true,
-              "description": "Name of the speaker"
+              "required": false,
+              "description": "Name shown in HomeKit. Defaults to the device's own name."
             },
             "ip": {
               "type": "string",
@@ -41,6 +41,12 @@
               "description": "IP address to use to find accessory",
               "pattern": "^[^{}/ :\\\\]+(?::\\d+)?$",
               "placeholder": "eg. 0.0.0.0"
+            },
+            "port": {
+              "type": "integer",
+              "required": false,
+              "description": "Port to use with ip",
+              "placeholder": "8090"
             },
             "room": {
               "type": "string",


### PR DESCRIPTION
## Summary
The Homebridge UI config form is generated from `config.schema.json`, which didn&#39;t match the plugin&#39;s actual behaviour:

- **`name` was `required: true`** — but the plugin treats it as optional and defaults to the device&#39;s own reported name. Matching a device actually needs `ip` or `room`, not `name`, so requiring `name` is wrong and forces users to invent one.
- **`port` was missing** — the plugin supports a per-accessory `port` (used with `ip`, default `8090`), but it couldn&#39;t be set from the UI.

## Changes
- `name`: `required: false`, clearer description
- add `port` (integer, optional, placeholder `8090`)

## Test plan
- [x] `config.schema.json` is valid JSON
- [x] `npm run build` passes
