### PR TITLE
chore: backfill unit tests for SoundTouch API layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@types/jest": "^30.0.0",
         "@types/node": "^22.14.1",
         "@types/xml2js": "^0.4.9",
+        "axios-mock-adapter": "^2.1.0",
         "eslint": "^10.5.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-jest": "^29.15.2",
@@ -4810,6 +4811,20 @@
         "proxy-from-env": "^2.1.0"
       }
     },
+    "node_modules/axios-mock-adapter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-2.1.0.tgz",
+      "integrity": "sha512-AZUe4OjECGCNNssH8SOdtneiQELsqTsat3SQQCWLPjN436/H+L9AjWfV7bF+Zg/YL9cgbhrz5671hoh+Tbn98w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "is-buffer": "^2.0.5"
+      },
+      "peerDependencies": {
+        "axios": ">= 0.17.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
@@ -7486,6 +7501,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-extglob": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^22.14.1",
     "@types/xml2js": "^0.4.9",
+    "axios-mock-adapter": "^2.1.0",
     "eslint": "^10.5.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-jest": "^29.15.2",

--- a/src/devices/SoundTouch/api/__tests__/api.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/api.test.ts
@@ -1,0 +1,344 @@
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { API } from '../api.js';
+import { APIErrors } from '../error.js';
+import { KeyValue } from '../special-types.js';
+
+const HOST = '192.168.1.50';
+const BASE = `http://${HOST}:8090`;
+
+describe('API', () => {
+  let mock: MockAdapter;
+  let api: API;
+
+  beforeEach(() => {
+    const instance = axios.create();
+    mock = new MockAdapter(instance);
+    api = new API(HOST, 8090, instance);
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  describe('request plumbing', () => {
+    test('GET targets the host, default port and endpoint', async () => {
+      mock.onGet(`${BASE}/info`).reply(200, '<info deviceID="D"></info>');
+      await api.getInfo();
+      expect(mock.history.get[0].url).toBe(`${BASE}/info`);
+    });
+
+    test('honours a custom port', async () => {
+      const instance = axios.create();
+      const customMock = new MockAdapter(instance);
+      const customApi = new API('10.0.0.9', 9999, instance);
+      customMock
+        .onGet('http://10.0.0.9:9999/volume')
+        .reply(200, '<volume deviceID="D"></volume>');
+      await customApi.getVolume();
+      expect(customMock.history.get[0].url).toBe('http://10.0.0.9:9999/volume');
+      customMock.restore();
+    });
+
+    test('re-throws network errors that carry no response', async () => {
+      mock.onGet(`${BASE}/info`).networkError();
+      await expect(api.getInfo()).rejects.toThrow();
+    });
+
+    test('parses the body of an error (non-2xx) response instead of throwing it', async () => {
+      // A 4xx with a parseable (but non-error) body should resolve, not reject.
+      mock
+        .onGet(`${BASE}/info`)
+        .reply(400, '<info deviceID="D"><name>x</name></info>');
+      await expect(api.getInfo()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('error handling', () => {
+    test('throws APIErrors when the response contains an <errors> block', async () => {
+      mock
+        .onGet(`${BASE}/info`)
+        .reply(
+          200,
+          '<errors deviceID="D"><error value="401" name="HTTP_ERROR" severity="High">no</error></errors>'
+        );
+      await expect(api.getInfo()).rejects.toBeInstanceOf(APIErrors);
+    });
+
+    test('throws APIErrors when the response contains a single <Error>', async () => {
+      mock
+        .onGet(`${BASE}/info`)
+        .reply(200, '<Error value="1" name="X" severity="Low">bad</Error>');
+      await expect(api.getInfo()).rejects.toBeInstanceOf(APIErrors);
+    });
+
+    test('surfaces APIErrors carried in a 4xx error response body', async () => {
+      mock
+        .onGet(`${BASE}/info`)
+        .reply(
+          500,
+          '<errors deviceID="D"><error value="500" name="ERR" severity="High">boom</error></errors>'
+        );
+      await expect(api.getInfo()).rejects.toBeInstanceOf(APIErrors);
+    });
+  });
+
+  describe('getInfo', () => {
+    test('parses an info document', async () => {
+      mock
+        .onGet(`${BASE}/info`)
+        .reply(
+          200,
+          '<info deviceID="DEV1"><name>Kitchen</name><type>SoundTouch 10</type>' +
+            '<components><component><softwareVersion>1.0</softwareVersion>' +
+            '<serialNumber>DEV1</serialNumber></component></components>' +
+            '<networkInfo><macAddress>AA</macAddress><ipAddress>10.0.0.1</ipAddress></networkInfo></info>'
+        );
+      const info = await api.getInfo();
+      expect(info).toMatchObject({
+        deviceId: 'DEV1',
+        name: 'Kitchen',
+        type: 'SoundTouch 10',
+      });
+    });
+
+    test('returns undefined when there is no info element', async () => {
+      mock.onGet(`${BASE}/info`).reply(200, '<nothing/>');
+      await expect(api.getInfo()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getVolume / setVolume', () => {
+    test('parses a volume document', async () => {
+      mock
+        .onGet(`${BASE}/volume`)
+        .reply(
+          200,
+          '<volume deviceID="DEV1"><targetvolume>40</targetvolume>' +
+            '<actualvolume>38</actualvolume><muteenabled>false</muteenabled></volume>'
+        );
+      await expect(api.getVolume()).resolves.toEqual({
+        deviceId: 'DEV1',
+        target: 40,
+        actual: 38,
+        isMuted: false,
+      });
+    });
+
+    test('setVolume posts the value and reports success on a status reply', async () => {
+      mock.onPost(`${BASE}/volume`).reply(200, '<status>/volume</status>');
+      await expect(api.setVolume(30)).resolves.toBe(true);
+      expect(mock.history.post[0].data).toContain('<volume>30</volume>');
+    });
+
+    test('setVolume reports failure when there is no status reply', async () => {
+      mock.onPost(`${BASE}/volume`).reply(200, '<nope/>');
+      await expect(api.setVolume(30)).resolves.toBe(false);
+    });
+  });
+
+  describe('now playing', () => {
+    const nowPlayingXml =
+      '<nowPlaying deviceID="DEV1" source="SPOTIFY">' +
+      '<ContentItem source="SPOTIFY" sourceAccount="a"><itemName>Song</itemName></ContentItem>' +
+      '<track>T</track><art artImageStatus="IMAGE_PRESENT">http://art</art>' +
+      '<time total="200">5</time></nowPlaying>';
+
+    test('getNowPlaying parses a playing document', async () => {
+      mock.onGet(`${BASE}/now_playing`).reply(200, nowPlayingXml);
+      const np = await api.getNowPlaying();
+      expect(np).toMatchObject({
+        deviceId: 'DEV1',
+        source: 'SPOTIFY',
+        track: 'T',
+      });
+    });
+
+    test('getSource returns the source attribute', async () => {
+      mock
+        .onGet(`${BASE}/now_playing`)
+        .reply(
+          200,
+          '<nowPlaying deviceID="DEV1" source="STANDBY"><ContentItem source="STANDBY"/></nowPlaying>'
+        );
+      await expect(api.getSource()).resolves.toBe('STANDBY');
+    });
+
+    test('getNowPlaying returns undefined in STANDBY because art/time are absent', async () => {
+      // FLAG: nowPlayingFromElement treats <art> and <time> as required even
+      // though the NowPlaying interface marks them optional. A standby (or AUX)
+      // response with no art/time parses to undefined rather than a NowPlaying.
+      mock
+        .onGet(`${BASE}/now_playing`)
+        .reply(
+          200,
+          '<nowPlaying deviceID="DEV1" source="STANDBY"><ContentItem source="STANDBY"/></nowPlaying>'
+        );
+      await expect(api.getNowPlaying()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('sources / select', () => {
+    test('getSources parses the source list', async () => {
+      mock
+        .onGet(`${BASE}/sources`)
+        .reply(
+          200,
+          '<sources deviceID="DEV1"><sourceItem source="AUX" status="READY">AUX IN</sourceItem></sources>'
+        );
+      const sources = await api.getSources();
+      expect(sources?.deviceId).toBe('DEV1');
+      expect(sources?.items[0]).toMatchObject({
+        source: 'AUX',
+        name: 'AUX IN',
+      });
+    });
+
+    test('selectSource posts a ContentItem and reports success', async () => {
+      mock.onPost(`${BASE}/select`).reply(200, '<status>/select</status>');
+      await expect(
+        api.selectSource({ source: 'AUX', sourceAccount: '' })
+      ).resolves.toBe(true);
+      expect(mock.history.post[0].data).toContain('source="AUX"');
+    });
+  });
+
+  describe('zones', () => {
+    test('getZone parses master and members', async () => {
+      mock
+        .onGet(`${BASE}/getZone`)
+        .reply(
+          200,
+          '<zone master="M1"><member ipaddress="10.0.0.1">DEV1</member></zone>'
+        );
+      await expect(api.getZone()).resolves.toEqual({
+        master: 'M1',
+        members: [{ deviceId: 'DEV1', ipAddress: '10.0.0.1' }],
+      });
+    });
+
+    test('setZone posts the serialized zone', async () => {
+      mock.onPost(`${BASE}/setZone`).reply(200, '<status>/setZone</status>');
+      const zone = {
+        master: 'M1',
+        members: [{ deviceId: 'DEV1', ipAddress: '10.0.0.1' }],
+      };
+      await expect(api.setZone(zone)).resolves.toBe(true);
+      expect(mock.history.post[0].data).toContain('master="M1"');
+    });
+  });
+
+  describe('bass', () => {
+    test('getBassCapabilities parses the capabilities', async () => {
+      mock
+        .onGet(`${BASE}/bassCapabilities`)
+        .reply(
+          200,
+          '<bassCapabilities deviceID="DEV1"><bassAvailable>true</bassAvailable>' +
+            '<bassMin>-9</bassMin><bassMax>0</bassMax><bassDefault>-5</bassDefault></bassCapabilities>'
+        );
+      await expect(api.getBassCapabilities()).resolves.toEqual({
+        deviceId: 'DEV1',
+        isAvailable: true,
+        min: -9,
+        max: 0,
+        default: -5,
+      });
+    });
+
+    test('getBass parses the current bass', async () => {
+      mock
+        .onGet(`${BASE}/bass`)
+        .reply(
+          200,
+          '<bass deviceID="DEV1"><targetbass>-5</targetbass><actualbass>-5</actualbass></bass>'
+        );
+      await expect(api.getBass()).resolves.toEqual({
+        deviceId: 'DEV1',
+        target: -5,
+        actual: -5,
+      });
+    });
+
+    test('setBass posts the value', async () => {
+      mock.onPost(`${BASE}/bass`).reply(200, '<status>/bass</status>');
+      await expect(api.setBass(-3)).resolves.toBe(true);
+      expect(mock.history.post[0].data).toContain('<bass>-3</bass>');
+    });
+  });
+
+  describe('presets', () => {
+    test('parses presets when present', async () => {
+      mock
+        .onGet(`${BASE}/presets`)
+        .reply(
+          200,
+          '<presets><preset id="1" createdOn="1600000000" updatedOn="1600000000">' +
+            '<ContentItem source="SPOTIFY" sourceAccount="a"><itemName>Mix</itemName></ContentItem></preset></presets>'
+        );
+      const presets = await api.getPresets();
+      expect(presets).toHaveLength(1);
+      expect(presets?.[0]).toMatchObject({ id: 1 });
+    });
+
+    test('returns undefined when there are no presets', async () => {
+      mock.onGet(`${BASE}/presets`).reply(200, '<presets></presets>');
+      await expect(api.getPresets()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('group', () => {
+    test('parses the active group', async () => {
+      mock
+        .onGet(`${BASE}/getGroup`)
+        .reply(
+          200,
+          '<group id="G1"><name>Stereo</name><masterDeviceId>DEV1</masterDeviceId>' +
+            '<status>GROUP_OK</status><roles><groupRole><deviceId>DEV1</deviceId>' +
+            '<role>LEFT</role><ipAddress>10.0.0.1</ipAddress></groupRole></roles></group>'
+        );
+      const group = await api.getGroup();
+      expect(group).toMatchObject({
+        id: 'G1',
+        name: 'Stereo',
+        masterDeviceId: 'DEV1',
+      });
+      expect(group?.roles).toHaveLength(1);
+    });
+  });
+
+  describe('keys', () => {
+    test('pressKey sends a press then a release', async () => {
+      mock.onPost(`${BASE}/key`).reply(200, '<status>/key</status>');
+      await expect(api.pressKey(KeyValue.play)).resolves.toBe(true);
+      expect(mock.history.post).toHaveLength(2);
+      expect(mock.history.post[0].data).toContain('state="press"');
+      expect(mock.history.post[1].data).toContain('state="release"');
+      expect(mock.history.post[0].data).toContain('PLAY');
+    });
+
+    test('pressKey aborts before the release when the press fails', async () => {
+      mock.onPost(`${BASE}/key`).reply(200, '<nope/>');
+      await expect(api.pressKey(KeyValue.play)).resolves.toBe(false);
+      expect(mock.history.post).toHaveLength(1);
+    });
+  });
+
+  describe('setName', () => {
+    test('posts the new name and returns the updated info', async () => {
+      mock
+        .onPost(`${BASE}/name`)
+        .reply(
+          200,
+          '<info deviceID="DEV1"><name>New Name</name><type>SoundTouch 10</type>' +
+            '<components><component><softwareVersion>1.0</softwareVersion>' +
+            '<serialNumber>DEV1</serialNumber></component></components>' +
+            '<networkInfo><macAddress>AA</macAddress><ipAddress>10.0.0.1</ipAddress></networkInfo></info>'
+        );
+      const info = await api.setName('New Name');
+      expect(info?.name).toBe('New Name');
+      expect(mock.history.post[0].data).toContain('<name>New Name</name>');
+    });
+  });
+});

--- a/src/devices/SoundTouch/api/__tests__/art.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/art.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from '@jest/globals';
+import { artFromElement } from '../art.js';
+import { ArtStatus } from '../special-types.js';
+import { XMLElement } from '../utils/xml-element.js';
+
+describe('artFromElement', () => {
+  test('parses art url and status', () => {
+    const el = new XMLElement({
+      $: { artImageStatus: 'IMAGE_PRESENT' },
+      _: 'http://example.com/art.jpg',
+    });
+    expect(artFromElement(el)).toEqual({
+      url: 'http://example.com/art.jpg',
+      status: ArtStatus.imagePresent,
+    });
+  });
+
+  test('returns undefined when the status attribute is missing', () => {
+    const el = new XMLElement({ _: 'http://example.com/art.jpg' });
+    expect(artFromElement(el)).toBeUndefined();
+  });
+
+  test('returns undefined when there is no url text', () => {
+    const el = new XMLElement({ $: { artImageStatus: 'IMAGE_PRESENT' } });
+    expect(artFromElement(el)).toBeUndefined();
+  });
+});

--- a/src/devices/SoundTouch/api/__tests__/bass-capabilities.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/bass-capabilities.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from '@jest/globals';
+import { bassCapabilitiesFromElement } from '../bass-capabilities.js';
+import { XMLElement } from '../utils/xml-element.js';
+
+describe('bassCapabilitiesFromElement', () => {
+  test('parses availability and bass range', () => {
+    const el = new XMLElement({
+      $: { deviceID: 'DEV1' },
+      bassAvailable: ['true'],
+      bassMin: ['-9'],
+      bassMax: ['0'],
+      bassDefault: ['-5'],
+    });
+    expect(bassCapabilitiesFromElement(el)).toEqual({
+      deviceId: 'DEV1',
+      isAvailable: true,
+      min: -9,
+      max: 0,
+      default: -5,
+    });
+  });
+
+  test('marks unavailable and leaves range undefined when absent', () => {
+    const el = new XMLElement({
+      $: { deviceID: 'DEV1' },
+      bassAvailable: ['false'],
+    });
+    expect(bassCapabilitiesFromElement(el)).toEqual({
+      deviceId: 'DEV1',
+      isAvailable: false,
+      min: undefined,
+      max: undefined,
+      default: undefined,
+    });
+  });
+
+  test('returns undefined when the deviceID attribute is missing', () => {
+    const el = new XMLElement({ bassAvailable: ['true'] });
+    expect(bassCapabilitiesFromElement(el)).toBeUndefined();
+  });
+});

--- a/src/devices/SoundTouch/api/__tests__/bass.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/bass.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from '@jest/globals';
+import { bassFromElement } from '../bass.js';
+import { XMLElement } from '../utils/xml-element.js';
+
+describe('bassFromElement', () => {
+  test('parses target and actual bass', () => {
+    const el = new XMLElement({
+      $: { deviceID: 'DEV1' },
+      targetbass: ['-3'],
+      actualbass: ['-2'],
+    });
+    expect(bassFromElement(el)).toEqual({
+      deviceId: 'DEV1',
+      target: -3,
+      actual: -2,
+    });
+  });
+
+  test('defaults target and actual to 0 when absent', () => {
+    const el = new XMLElement({ $: { deviceID: 'DEV1' } });
+    expect(bassFromElement(el)).toEqual({
+      deviceId: 'DEV1',
+      target: 0,
+      actual: 0,
+    });
+  });
+
+  test('returns undefined when the deviceID attribute is missing', () => {
+    const el = new XMLElement({ targetbass: ['0'], actualbass: ['0'] });
+    expect(bassFromElement(el)).toBeUndefined();
+  });
+});

--- a/src/devices/SoundTouch/api/__tests__/component.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/component.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from '@jest/globals';
+import { componentFromElement } from '../component.js';
+import { XMLElement } from '../utils/xml-element.js';
+
+describe('componentFromElement', () => {
+  test('parses a component with software version and serial number', () => {
+    const el = new XMLElement({
+      softwareVersion: ['1.2.3'],
+      serialNumber: ['SN-001'],
+    });
+    expect(componentFromElement(el)).toEqual({
+      softwareVersion: '1.2.3',
+      serialNumber: 'SN-001',
+    });
+  });
+
+  test('returns undefined when children are missing', () => {
+    const el = new XMLElement({ softwareVersion: ['1.2.3'] });
+    expect(componentFromElement(el)).toBeUndefined();
+  });
+
+  test('returns undefined when a child is empty', () => {
+    const el = new XMLElement({ softwareVersion: [], serialNumber: [] });
+    expect(componentFromElement(el)).toBeUndefined();
+  });
+});

--- a/src/devices/SoundTouch/api/__tests__/connection-status-info.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/connection-status-info.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from '@jest/globals';
+import { connectionStatusInfoFromElement } from '../connection-status-info.js';
+import { XMLElement } from '../utils/xml-element.js';
+
+describe('connectionStatusInfoFromElement', () => {
+  test('parses status and device name attributes', () => {
+    const el = new XMLElement({
+      $: { status: 'CONNECTED', deviceName: 'Phone' },
+    });
+    expect(connectionStatusInfoFromElement(el)).toEqual({
+      status: 'CONNECTED',
+      deviceName: 'Phone',
+    });
+  });
+
+  test('returns undefined fields when attributes are absent', () => {
+    const el = new XMLElement({});
+    expect(connectionStatusInfoFromElement(el)).toEqual({
+      status: undefined,
+      deviceName: undefined,
+    });
+  });
+});

--- a/src/devices/SoundTouch/api/__tests__/content-item.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/content-item.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  contentItemFromElement,
+  contentItemToElement,
+} from '../content-item.js';
+import { XMLElement } from '../utils/xml-element.js';
+
+describe('contentItemFromElement', () => {
+  test('parses a full content item', () => {
+    const el = new XMLElement({
+      $: {
+        source: 'SPOTIFY',
+        sourceAccount: 'user@example.com',
+        location: '/playback',
+        isPresetable: 'true',
+        containerArt: 'http://art',
+      },
+      itemName: ['My Playlist'],
+    });
+    expect(contentItemFromElement(el)).toEqual({
+      source: 'SPOTIFY',
+      sourceAccount: 'user@example.com',
+      location: '/playback',
+      isPresetable: true,
+      containerArt: 'http://art',
+      itemName: 'My Playlist',
+    });
+  });
+
+  test('defaults sourceAccount and isPresetable when absent', () => {
+    const el = new XMLElement({ $: { source: 'AUX' } });
+    expect(contentItemFromElement(el)).toEqual({
+      source: 'AUX',
+      sourceAccount: '',
+      location: undefined,
+      isPresetable: false,
+      itemName: undefined,
+      containerArt: undefined,
+    });
+  });
+
+  test('returns undefined when the source attribute is missing', () => {
+    const el = new XMLElement({ $: { sourceAccount: 'x' } });
+    expect(contentItemFromElement(el)).toBeUndefined();
+  });
+});
+
+describe('contentItemToElement', () => {
+  test('serializes required attributes', () => {
+    const el = contentItemToElement({ source: 'AUX', sourceAccount: '' });
+    // toElement wraps the data in a <ContentItem> node.
+    expect(el.data.ContentItem.$).toEqual({ source: 'AUX', sourceAccount: '' });
+  });
+
+  test('serializes optional attributes and item name when present', () => {
+    const el = contentItemToElement({
+      source: 'SPOTIFY',
+      sourceAccount: 'user',
+      isPresetable: true,
+      location: '/loc',
+      containerArt: 'http://art',
+      itemName: 'Name',
+    });
+    expect(el.data.ContentItem.$).toEqual({
+      source: 'SPOTIFY',
+      sourceAccount: 'user',
+      isPresetable: true,
+      location: '/loc',
+      containerArt: 'http://art',
+    });
+    expect(el.data.ContentItem.itemName).toBe('Name');
+  });
+
+  test('round-trips through fromElement', () => {
+    const el = contentItemToElement({
+      source: 'SPOTIFY',
+      sourceAccount: 'user',
+      isPresetable: true,
+      location: '/loc',
+      itemName: 'Name',
+    });
+    const inner = new XMLElement(el.data.ContentItem);
+    expect(contentItemFromElement(inner)).toEqual({
+      source: 'SPOTIFY',
+      sourceAccount: 'user',
+      // NOTE: known asymmetry — toElement writes isPresetable as a boolean,
+      // but fromElement compares against the string 'true', so an in-memory
+      // round trip loses the flag. It only survives if serialized to XML text
+      // in between (xml2js stringifies the boolean to "true").
+      isPresetable: false,
+      location: '/loc',
+      itemName: 'Name',
+      containerArt: undefined,
+    });
+  });
+});

--- a/src/devices/SoundTouch/api/__tests__/error.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/error.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from '@jest/globals';
+import { APIErrors, errorFromElement } from '../error.js';
+import { XMLElement } from '../utils/xml-element.js';
+
+describe('errorFromElement', () => {
+  test('parses value, name, severity and message', () => {
+    const el = new XMLElement({
+      $: { value: '401', name: 'HTTP_ERROR', severity: 'High' },
+      _: 'Unauthorized',
+    });
+    expect(errorFromElement(el)).toEqual({
+      value: 401,
+      name: 'HTTP_ERROR',
+      severity: 'High',
+      message: 'Unauthorized',
+    });
+  });
+
+  test('falls back to value 0 when the value is not numeric', () => {
+    const el = new XMLElement({
+      $: { value: 'NaN', name: 'X', severity: 'Low' },
+    });
+    expect(errorFromElement(el)?.value).toBe(0);
+  });
+
+  test('returns undefined when required attributes are missing', () => {
+    const el = new XMLElement({ $: { value: '1', name: 'X' } });
+    expect(errorFromElement(el)).toBeUndefined();
+  });
+});
+
+describe('APIErrors', () => {
+  test('fromElement collects all errors and the device id', () => {
+    const el = new XMLElement({
+      $: { deviceID: 'DEV1' },
+      error: [
+        { $: { value: '1', name: 'A', severity: 'High' }, _: 'msg a' },
+        { $: { value: '2', name: 'B', severity: 'Low' }, _: 'msg b' },
+      ],
+    });
+    const errors = APIErrors.fromElement(el);
+    expect(errors?.deviceId).toBe('DEV1');
+    expect(errors?.errors).toHaveLength(2);
+  });
+
+  test('fromElement skips malformed error entries', () => {
+    const el = new XMLElement({
+      $: { deviceID: 'DEV1' },
+      error: [
+        { $: { value: '1', name: 'A', severity: 'High' } },
+        { $: { value: '2' } },
+      ],
+    });
+    expect(APIErrors.fromElement(el)?.errors).toHaveLength(1);
+  });
+
+  test('is an Error carrying device id and a descriptive message', () => {
+    const errors = new APIErrors(
+      [{ value: 1, name: 'A', severity: 'High' }],
+      'DEV1'
+    );
+    expect(errors).toBeInstanceOf(Error);
+    expect(errors.deviceId).toBe('DEV1');
+    expect(errors.message).toContain('DEV1');
+    expect(errors.message).toContain('"name":"A"');
+  });
+});

--- a/src/devices/SoundTouch/api/__tests__/group.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/group.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from '@jest/globals';
+import { groupFromElement, roleFromElement } from '../group.js';
+import { GroupLocation } from '../special-types.js';
+import { XMLElement } from '../utils/xml-element.js';
+
+describe('roleFromElement', () => {
+  test('parses a role into device id, location and ip address', () => {
+    const el = new XMLElement({
+      deviceId: ['DEV-1'],
+      role: ['LEFT'],
+      ipAddress: ['10.0.0.1'],
+    });
+    expect(roleFromElement(el)).toEqual({
+      deviceId: 'DEV-1',
+      ipAddress: '10.0.0.1',
+      location: GroupLocation.left,
+    });
+  });
+
+  test('returns undefined when children are missing', () => {
+    const el = new XMLElement({ deviceId: ['DEV-1'] });
+    expect(roleFromElement(el)).toBeUndefined();
+  });
+});
+
+describe('groupFromElement', () => {
+  function makeGroupData() {
+    return {
+      $: { id: 'GROUP-1' },
+      name: ['Downstairs'],
+      masterDeviceId: ['DEV-1'],
+      status: ['GROUP_OK'],
+      roles: [
+        {
+          groupRole: [
+            { deviceId: ['DEV-1'], role: ['LEFT'], ipAddress: ['10.0.0.1'] },
+            { deviceId: ['DEV-2'], role: ['RIGHT'], ipAddress: ['10.0.0.2'] },
+          ],
+        },
+      ],
+    };
+  }
+
+  test('parses a full group with its roles', () => {
+    const result = groupFromElement(new XMLElement(makeGroupData()));
+    expect(result).toEqual({
+      id: 'GROUP-1',
+      name: 'Downstairs',
+      masterDeviceId: 'DEV-1',
+      status: 'GROUP_OK',
+      roles: [
+        {
+          deviceId: 'DEV-1',
+          ipAddress: '10.0.0.1',
+          location: GroupLocation.left,
+        },
+        {
+          deviceId: 'DEV-2',
+          ipAddress: '10.0.0.2',
+          location: GroupLocation.right,
+        },
+      ],
+    });
+  });
+
+  test('skips malformed roles', () => {
+    const data = makeGroupData();
+    data.roles[0].groupRole.push({ deviceId: ['DEV-3'] } as never);
+    expect(groupFromElement(new XMLElement(data))?.roles).toHaveLength(2);
+  });
+
+  test('returns undefined when the id attribute is missing', () => {
+    const data = makeGroupData();
+    data.$ = {} as never;
+    expect(groupFromElement(new XMLElement(data))).toBeUndefined();
+  });
+
+  test('returns undefined when required children are missing', () => {
+    const el = new XMLElement({ $: { id: 'GROUP-1' } });
+    expect(groupFromElement(el)).toBeUndefined();
+  });
+});

--- a/src/devices/SoundTouch/api/__tests__/info.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/info.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from '@jest/globals';
+import { infoFromElement } from '../info.js';
+import { XMLElement } from '../utils/xml-element.js';
+
+function makeInfoData() {
+  return {
+    $: { deviceID: 'DEV123' },
+    name: ['Kitchen Speaker'],
+    type: ['SoundTouch 10'],
+    components: [
+      {
+        component: [
+          { softwareVersion: ['1.0.0'], serialNumber: ['SN-1'] },
+          { softwareVersion: ['2.0.0'], serialNumber: ['SN-2'] },
+        ],
+      },
+    ],
+    networkInfo: [
+      { macAddress: ['AA:BB'], ipAddress: ['10.0.0.1'] },
+      { macAddress: ['CC:DD'], ipAddress: ['10.0.0.2'] },
+    ],
+  };
+}
+
+describe('infoFromElement', () => {
+  test('parses a full info element', () => {
+    const result = infoFromElement(new XMLElement(makeInfoData()));
+    expect(result).toEqual({
+      deviceId: 'DEV123',
+      name: 'Kitchen Speaker',
+      type: 'SoundTouch 10',
+      components: [
+        { softwareVersion: '1.0.0', serialNumber: 'SN-1' },
+        { softwareVersion: '2.0.0', serialNumber: 'SN-2' },
+      ],
+      networkInfo: [
+        { macAddress: 'AA:BB', ipAddress: '10.0.0.1' },
+        { macAddress: 'CC:DD', ipAddress: '10.0.0.2' },
+      ],
+    });
+  });
+
+  test('skips malformed components and network info entries', () => {
+    const data = makeInfoData();
+    data.components[0].component.push({
+      softwareVersion: ['3.0.0'],
+    } as never);
+    data.networkInfo.push({ macAddress: ['EE:FF'] } as never);
+    const result = infoFromElement(new XMLElement(data));
+    expect(result?.components).toHaveLength(2);
+    expect(result?.networkInfo).toHaveLength(2);
+  });
+
+  test('returns undefined when the deviceID attribute is missing', () => {
+    const data = makeInfoData();
+    data.$ = {} as never;
+    expect(infoFromElement(new XMLElement(data))).toBeUndefined();
+  });
+
+  test('returns undefined when required children are missing', () => {
+    const el = new XMLElement({ $: { deviceID: 'DEV123' } });
+    expect(infoFromElement(el)).toBeUndefined();
+  });
+});

--- a/src/devices/SoundTouch/api/__tests__/member.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/member.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from '@jest/globals';
+import { memberFromElement } from '../member.js';
+import { XMLElement } from '../utils/xml-element.js';
+
+describe('memberFromElement', () => {
+  test('parses device id from text and ip from attribute', () => {
+    const el = new XMLElement({ $: { ipaddress: '10.0.0.5' }, _: 'DEV-A' });
+    expect(memberFromElement(el)).toEqual({
+      deviceId: 'DEV-A',
+      ipAddress: '10.0.0.5',
+    });
+  });
+
+  test('returns undefined when the ipaddress attribute is missing', () => {
+    const el = new XMLElement({ _: 'DEV-A' });
+    expect(memberFromElement(el)).toBeUndefined();
+  });
+
+  test('returns undefined when the device id text is missing', () => {
+    const el = new XMLElement({ $: { ipaddress: '10.0.0.5' } });
+    expect(memberFromElement(el)).toBeUndefined();
+  });
+});

--- a/src/devices/SoundTouch/api/__tests__/network-info.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/network-info.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from '@jest/globals';
+import { networkInfoFromElement } from '../network-info.js';
+import { XMLElement } from '../utils/xml-element.js';
+
+describe('networkInfoFromElement', () => {
+  test('parses mac and ip addresses', () => {
+    const el = new XMLElement({
+      macAddress: ['AA:BB:CC:DD:EE:FF'],
+      ipAddress: ['192.168.1.50'],
+    });
+    expect(networkInfoFromElement(el)).toEqual({
+      macAddress: 'AA:BB:CC:DD:EE:FF',
+      ipAddress: '192.168.1.50',
+    });
+  });
+
+  test('returns undefined when children are missing', () => {
+    const el = new XMLElement({ macAddress: ['AA:BB:CC:DD:EE:FF'] });
+    expect(networkInfoFromElement(el)).toBeUndefined();
+  });
+
+  test('returns undefined when a child is empty', () => {
+    const el = new XMLElement({ macAddress: [], ipAddress: [] });
+    expect(networkInfoFromElement(el)).toBeUndefined();
+  });
+});

--- a/src/devices/SoundTouch/api/__tests__/now-playing.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/now-playing.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from '@jest/globals';
+import { nowPlayingFromElement } from '../now-playing.js';
+import {
+  PlayStatus,
+  Rate,
+  RepeatStatus,
+  ShuffleStatus,
+  StreamStatus,
+} from '../special-types.js';
+import { XMLElement } from '../utils/xml-element.js';
+
+function makeFullData() {
+  return {
+    $: { deviceID: 'DEV1', source: 'SPOTIFY', sourceAccount: 'acct' },
+    ContentItem: [
+      { $: { source: 'SPOTIFY', sourceAccount: 'acct' }, itemName: ['Song'] },
+    ],
+    art: [{ $: { artImageStatus: 'IMAGE_PRESENT' }, _: 'http://art' }],
+    time: [{ $: { total: '240' }, _: '57' }],
+    ConnectionStatusInfo: [{ $: { status: 'CONNECTED', deviceName: 'Phone' } }],
+    track: ['Track Name'],
+    artist: ['Artist Name'],
+    album: ['Album Name'],
+    genre: ['Pop'],
+    stationName: ['Station'],
+    stationLocation: ['Location'],
+    rating: ['UP'],
+    playStatus: ['PLAY_STATE'],
+    shuffleSetting: ['SHUFFLE_ON'],
+    repeatSetting: ['REPEAT_ALL'],
+    streamType: ['TRACK_ONDEMAND'],
+    skipEnabled: [''],
+    skipPreviousEnabled: [''],
+    favoriteEnabled: [''],
+    isFavorite: [''],
+    rateEnabled: [''],
+  };
+}
+
+describe('nowPlayingFromElement', () => {
+  test('parses a fully populated now playing element', () => {
+    const result = nowPlayingFromElement(new XMLElement(makeFullData()));
+    expect(result).toMatchObject({
+      deviceId: 'DEV1',
+      source: 'SPOTIFY',
+      sourceAccount: 'acct',
+      track: 'Track Name',
+      artist: 'Artist Name',
+      album: 'Album Name',
+      genre: 'Pop',
+      stationName: 'Station',
+      stationLocation: 'Location',
+      rating: Rate.up,
+      playStatus: PlayStatus.play,
+      shuffleSetting: ShuffleStatus.on,
+      repeatSetting: RepeatStatus.all,
+      streamType: StreamStatus.trackOndemand,
+      canGoForward: true,
+      canGoBackward: true,
+      isFavoriteEnabled: true,
+      isFavorite: true,
+      isRateEnabled: true,
+    });
+    expect(result?.contentItem.itemName).toBe('Song');
+    expect(result?.art?.url).toBe('http://art');
+    expect(result?.time).toEqual({ current: 57, total: 240 });
+    expect(result?.connectionStatusInfo).toEqual({
+      status: 'CONNECTED',
+      deviceName: 'Phone',
+    });
+  });
+
+  test('applies defaults for absent optional fields', () => {
+    const data = {
+      $: { deviceID: 'DEV1', source: 'SPOTIFY' },
+      ContentItem: [{ $: { source: 'SPOTIFY' } }],
+      art: [{ $: { artImageStatus: 'IMAGE_PRESENT' }, _: 'http://art' }],
+      time: [{ $: { total: '0' }, _: '0' }],
+    };
+    const result = nowPlayingFromElement(new XMLElement(data));
+    expect(result).toMatchObject({
+      sourceAccount: '',
+      rating: Rate.none,
+      canGoForward: false,
+      canGoBackward: false,
+      isFavoriteEnabled: false,
+      isFavorite: false,
+      isRateEnabled: false,
+    });
+    expect(result?.playStatus).toBeUndefined();
+    expect(result?.shuffleSetting).toBeUndefined();
+    expect(result?.repeatSetting).toBeUndefined();
+    expect(result?.streamType).toBeUndefined();
+    expect(result?.connectionStatusInfo).toBeUndefined();
+  });
+
+  test('returns undefined when required attributes are missing', () => {
+    const el = new XMLElement({ $: { deviceID: 'DEV1' } });
+    expect(nowPlayingFromElement(el)).toBeUndefined();
+  });
+
+  test('returns undefined when the ContentItem child is missing', () => {
+    const data = makeFullData();
+    delete (data as Record<string, unknown>).ContentItem;
+    expect(nowPlayingFromElement(new XMLElement(data))).toBeUndefined();
+  });
+
+  test('returns undefined when the art or time children are missing', () => {
+    const data = makeFullData();
+    delete (data as Record<string, unknown>).art;
+    expect(nowPlayingFromElement(new XMLElement(data))).toBeUndefined();
+  });
+
+  test('returns undefined when the content item is malformed', () => {
+    const data = makeFullData();
+    data.ContentItem = [{ $: {} } as never];
+    expect(nowPlayingFromElement(new XMLElement(data))).toBeUndefined();
+  });
+});

--- a/src/devices/SoundTouch/api/__tests__/preset.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/preset.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from '@jest/globals';
+import { presetFromElement } from '../preset.js';
+import { XMLElement } from '../utils/xml-element.js';
+
+describe('presetFromElement', () => {
+  test('parses id, dates and content item', () => {
+    const el = new XMLElement({
+      $: { id: '3', createdOn: '1600000000', updatedOn: '1600000500' },
+      ContentItem: [
+        { $: { source: 'SPOTIFY', sourceAccount: 'acct' }, itemName: ['Mix'] },
+      ],
+    });
+    const result = presetFromElement(el);
+    expect(result?.id).toBe(3);
+    expect(result?.createdDate).toEqual(new Date(1600000000 * 1000));
+    expect(result?.updatedDate).toEqual(new Date(1600000500 * 1000));
+    expect(result?.contentItem.source).toBe('SPOTIFY');
+    expect(result?.contentItem.itemName).toBe('Mix');
+  });
+
+  test('returns undefined when attributes are missing', () => {
+    const el = new XMLElement({
+      $: { id: '3' },
+      ContentItem: [{ $: { source: 'SPOTIFY' } }],
+    });
+    expect(presetFromElement(el)).toBeUndefined();
+  });
+
+  test('returns undefined when the ContentItem child is missing', () => {
+    const el = new XMLElement({
+      $: { id: '3', createdOn: '1', updatedOn: '2' },
+    });
+    expect(presetFromElement(el)).toBeUndefined();
+  });
+
+  test('returns undefined when the content item is malformed', () => {
+    const el = new XMLElement({
+      $: { id: '3', createdOn: '1', updatedOn: '2' },
+      ContentItem: [{ $: {} }],
+    });
+    expect(presetFromElement(el)).toBeUndefined();
+  });
+});

--- a/src/devices/SoundTouch/api/__tests__/source.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/source.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from '@jest/globals';
+import { sourceFromElement, sourcesFromElement } from '../source.js';
+import { SourceStatus } from '../special-types.js';
+import { XMLElement } from '../utils/xml-element.js';
+
+describe('sourceFromElement', () => {
+  test('parses a source item with all flags', () => {
+    const el = new XMLElement({
+      $: {
+        source: 'AUX',
+        status: 'READY',
+        sourceAccount: 'acct',
+        isLocal: 'true',
+        multiroomallowed: 'true',
+      },
+      _: 'AUX IN',
+    });
+    expect(sourceFromElement(el)).toEqual({
+      source: 'AUX',
+      name: 'AUX IN',
+      sourceAccount: 'acct',
+      status: SourceStatus.ready,
+      isLocal: true,
+      isMultiroomAllowed: true,
+    });
+  });
+
+  test('defaults flags and account when absent', () => {
+    const el = new XMLElement({
+      $: { source: 'BLUETOOTH', status: 'UNAVAILABLE' },
+      _: 'Bluetooth',
+    });
+    expect(sourceFromElement(el)).toEqual({
+      source: 'BLUETOOTH',
+      name: 'Bluetooth',
+      sourceAccount: '',
+      status: SourceStatus.unavailable,
+      isLocal: false,
+      isMultiroomAllowed: false,
+    });
+  });
+
+  test('returns undefined when required attributes are missing', () => {
+    const el = new XMLElement({ $: { source: 'AUX' }, _: 'AUX' });
+    expect(sourceFromElement(el)).toBeUndefined();
+  });
+
+  test('returns undefined when the name text is missing', () => {
+    const el = new XMLElement({ $: { source: 'AUX', status: 'READY' } });
+    expect(sourceFromElement(el)).toBeUndefined();
+  });
+});
+
+describe('sourcesFromElement', () => {
+  test('parses the device id and its source items', () => {
+    const el = new XMLElement({
+      $: { deviceID: 'DEV1' },
+      sourceItem: [
+        { $: { source: 'AUX', status: 'READY' }, _: 'AUX IN' },
+        { $: { source: 'BLUETOOTH', status: 'READY' }, _: 'Bluetooth' },
+      ],
+    });
+    const result = sourcesFromElement(el);
+    expect(result?.deviceId).toBe('DEV1');
+    expect(result?.items).toHaveLength(2);
+    expect(result?.items[0].source).toBe('AUX');
+  });
+
+  test('skips malformed source items', () => {
+    const el = new XMLElement({
+      $: { deviceID: 'DEV1' },
+      sourceItem: [
+        { $: { source: 'AUX', status: 'READY' }, _: 'AUX IN' },
+        { $: { source: 'BAD' }, _: 'Bad' },
+      ],
+    });
+    expect(sourcesFromElement(el)?.items).toHaveLength(1);
+  });
+
+  test('returns undefined when the deviceID attribute is missing', () => {
+    const el = new XMLElement({ sourceItem: [] });
+    expect(sourcesFromElement(el)).toBeUndefined();
+  });
+});

--- a/src/devices/SoundTouch/api/__tests__/time.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/time.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from '@jest/globals';
+import { timeFromElement } from '../time.js';
+import { XMLElement } from '../utils/xml-element.js';
+
+describe('timeFromElement', () => {
+  test('parses current text and total attribute', () => {
+    const el = new XMLElement({ $: { total: '240' }, _: '57' });
+    expect(timeFromElement(el)).toEqual({ current: 57, total: 240 });
+  });
+
+  test('defaults to zero when values are absent', () => {
+    const el = new XMLElement({});
+    expect(timeFromElement(el)).toEqual({ current: 0, total: 0 });
+  });
+});

--- a/src/devices/SoundTouch/api/__tests__/volume.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/volume.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from '@jest/globals';
+import { volumeFromElement } from '../volume.js';
+import { XMLElement } from '../utils/xml-element.js';
+
+describe('volumeFromElement', () => {
+  test('parses target, actual and mute state', () => {
+    const el = new XMLElement({
+      $: { deviceID: 'DEV1' },
+      targetvolume: ['40'],
+      actualvolume: ['38'],
+      muteenabled: ['true'],
+    });
+    expect(volumeFromElement(el)).toEqual({
+      deviceId: 'DEV1',
+      target: 40,
+      actual: 38,
+      isMuted: true,
+    });
+  });
+
+  test('treats missing mute flag as not muted', () => {
+    const el = new XMLElement({
+      $: { deviceID: 'DEV1' },
+      targetvolume: ['40'],
+      actualvolume: ['38'],
+    });
+    expect(volumeFromElement(el)?.isMuted).toBe(false);
+  });
+
+  test('returns undefined when volume values are missing', () => {
+    const el = new XMLElement({ $: { deviceID: 'DEV1' } });
+    expect(volumeFromElement(el)).toBeUndefined();
+  });
+
+  test('returns undefined when the deviceID attribute is missing', () => {
+    const el = new XMLElement({ targetvolume: ['40'], actualvolume: ['38'] });
+    expect(volumeFromElement(el)).toBeUndefined();
+  });
+});

--- a/src/devices/SoundTouch/api/__tests__/zone.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/zone.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from '@jest/globals';
+import { zoneFromElement, zoneToElement } from '../zone.js';
+import { XMLElement } from '../utils/xml-element.js';
+
+describe('zoneFromElement', () => {
+  test('parses master and members', () => {
+    const el = new XMLElement({
+      $: { master: 'MASTER-1' },
+      member: [
+        { $: { ipaddress: '10.0.0.1' }, _: 'DEV-1' },
+        { $: { ipaddress: '10.0.0.2' }, _: 'DEV-2' },
+      ],
+    });
+    expect(zoneFromElement(el)).toEqual({
+      master: 'MASTER-1',
+      members: [
+        { deviceId: 'DEV-1', ipAddress: '10.0.0.1' },
+        { deviceId: 'DEV-2', ipAddress: '10.0.0.2' },
+      ],
+    });
+  });
+
+  test('skips malformed members', () => {
+    const el = new XMLElement({
+      $: { master: 'MASTER-1' },
+      member: [{ $: { ipaddress: '10.0.0.1' }, _: 'DEV-1' }, { _: 'DEV-2' }],
+    });
+    expect(zoneFromElement(el)?.members).toEqual([
+      { deviceId: 'DEV-1', ipAddress: '10.0.0.1' },
+    ]);
+  });
+
+  test('returns an empty member list when there are none', () => {
+    const el = new XMLElement({ $: { master: 'MASTER-1' } });
+    expect(zoneFromElement(el)).toEqual({ master: 'MASTER-1', members: [] });
+  });
+
+  test('returns undefined when the master attribute is missing', () => {
+    const el = new XMLElement({ member: [] });
+    expect(zoneFromElement(el)).toBeUndefined();
+  });
+});
+
+describe('zoneToElement', () => {
+  test('serializes master and members and round-trips', () => {
+    const zone = {
+      master: 'MASTER-1',
+      members: [
+        { deviceId: 'DEV-1', ipAddress: '10.0.0.1' },
+        { deviceId: 'DEV-2', ipAddress: '10.0.0.2' },
+      ],
+    };
+    const el = zoneToElement(zone);
+    expect(el.data.zone.$).toEqual({ master: 'MASTER-1' });
+    expect(zoneFromElement(new XMLElement(el.data.zone))).toEqual(zone);
+  });
+});

--- a/src/devices/SoundTouch/api/api.ts
+++ b/src/devices/SoundTouch/api/api.ts
@@ -43,15 +43,21 @@ export class API {
   private readonly builder: XMLBuilder;
   private readonly axiosInstance: AxiosInstance;
 
-  constructor(host: string, port: number = 8090) {
+  constructor(
+    host: string,
+    port: number = 8090,
+    axiosInstance?: AxiosInstance
+  ) {
     this.host = host;
     this.port = port;
-    this.axiosInstance = axiosCreate({
-      timeout: 10000,
-      headers: {
-        'content-type': 'application/xml',
-      },
-    });
+    this.axiosInstance =
+      axiosInstance ??
+      axiosCreate({
+        timeout: 10000,
+        headers: {
+          'content-type': 'application/xml',
+        },
+      });
     this.builder = new XMLBuilder();
   }
 

--- a/src/devices/SoundTouch/api/utils/__tests__/array-compact-map.test.ts
+++ b/src/devices/SoundTouch/api/utils/__tests__/array-compact-map.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from '@jest/globals';
+import { compactMap } from '../array-compact-map.js';
+
+describe('compactMap', () => {
+  test('maps values like Array.map when transform never returns undefined', () => {
+    const result = compactMap([1, 2, 3], (n) => n * 2);
+    expect(result).toEqual([2, 4, 6]);
+  });
+
+  test('drops entries for which transform returns undefined', () => {
+    const result = compactMap([1, 2, 3, 4], (n) =>
+      n % 2 === 0 ? n : undefined
+    );
+    expect(result).toEqual([2, 4]);
+  });
+
+  test('returns an empty array for an empty input', () => {
+    const result = compactMap<number, number>([], (n) => n);
+    expect(result).toEqual([]);
+  });
+
+  test('returns an empty array when every entry maps to undefined', () => {
+    const result = compactMap([1, 2, 3], () => undefined);
+    expect(result).toEqual([]);
+  });
+
+  test('passes index and source array to the transform', () => {
+    const indexes: number[] = [];
+    const arrays: number[][] = [];
+    const source = [10, 20];
+    compactMap(source, (e, index, array) => {
+      indexes.push(index);
+      arrays.push(array);
+      return e;
+    });
+    expect(indexes).toEqual([0, 1]);
+    expect(arrays).toEqual([source, source]);
+  });
+
+  test('keeps falsy values other than undefined', () => {
+    const result = compactMap([0, null, '', false, undefined], (e) => e);
+    expect(result).toEqual([0, null, '', false]);
+  });
+});

--- a/src/devices/SoundTouch/api/utils/__tests__/xml-element.test.ts
+++ b/src/devices/SoundTouch/api/utils/__tests__/xml-element.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from '@jest/globals';
+import { XMLElement } from '../xml-element.js';
+
+describe('XMLElement', () => {
+  describe('getAttribute', () => {
+    test('returns the attribute value when present', () => {
+      const el = new XMLElement({ $: { deviceID: 'abc' } });
+      expect(el.getAttribute('deviceID')).toBe('abc');
+    });
+
+    test('returns undefined when the attribute is missing', () => {
+      const el = new XMLElement({ $: { deviceID: 'abc' } });
+      expect(el.getAttribute('other')).toBeUndefined();
+    });
+
+    test('returns undefined when there are no attributes', () => {
+      const el = new XMLElement({});
+      expect(el.getAttribute('deviceID')).toBeUndefined();
+    });
+  });
+
+  describe('getText', () => {
+    test('reads text from a child field stored as an array', () => {
+      const el = new XMLElement({ name: ['Kitchen'] });
+      expect(el.getText('name')).toBe('Kitchen');
+    });
+
+    test('reads text of the element itself when no field is given', () => {
+      const el = new XMLElement({ $: { total: '5' }, _: 'hello' });
+      expect(el.getText()).toBe('hello');
+    });
+
+    test('reads text from a plain string field', () => {
+      const el = new XMLElement({ name: 'Kitchen' });
+      expect(el.getText('name')).toBe('Kitchen');
+    });
+
+    test('reads text from an object field with a _ property', () => {
+      const el = new XMLElement({ name: [{ _: 'Kitchen', $: { a: '1' } }] });
+      expect(el.getText('name')).toBe('Kitchen');
+    });
+
+    test('returns undefined for an empty array field', () => {
+      const el = new XMLElement({ name: [] });
+      expect(el.getText('name')).toBeUndefined();
+    });
+
+    test('returns undefined for a missing field', () => {
+      const el = new XMLElement({});
+      expect(el.getText('name')).toBeUndefined();
+    });
+
+    test('returns undefined when the element itself has no text', () => {
+      const el = new XMLElement(42);
+      expect(el.getText()).toBeUndefined();
+    });
+  });
+
+  describe('hasAttribute', () => {
+    test('returns true when the attribute exists', () => {
+      const el = new XMLElement({ $: { source: 'AUX' } });
+      expect(el.hasAttribute('source')).toBe(true);
+    });
+
+    test('returns false when the attribute is missing', () => {
+      const el = new XMLElement({ $: { source: 'AUX' } });
+      expect(el.hasAttribute('status')).toBe(false);
+    });
+
+    test('returns false when there are no attributes', () => {
+      const el = new XMLElement({});
+      expect(el.hasAttribute('source')).toBe(false);
+    });
+  });
+
+  describe('hasAttributes', () => {
+    test('returns true when all attributes exist', () => {
+      const el = new XMLElement({ $: { source: 'AUX', status: 'READY' } });
+      expect(el.hasAttributes(['source', 'status'])).toBe(true);
+    });
+
+    test('returns false when any attribute is missing', () => {
+      const el = new XMLElement({ $: { source: 'AUX' } });
+      expect(el.hasAttributes(['source', 'status'])).toBe(false);
+    });
+
+    test('returns false when there are no attributes', () => {
+      const el = new XMLElement({});
+      expect(el.hasAttributes(['source'])).toBe(false);
+    });
+  });
+
+  describe('hasChild / hasChildren', () => {
+    test('hasChild returns true for an object/array child', () => {
+      const el = new XMLElement({ ContentItem: [{ $: {} }] });
+      expect(el.hasChild('ContentItem')).toBe(true);
+    });
+
+    test('hasChild returns false for a missing child', () => {
+      const el = new XMLElement({});
+      expect(el.hasChild('ContentItem')).toBe(false);
+    });
+
+    test('hasChildren returns true when all children are present', () => {
+      const el = new XMLElement({ name: ['x'], type: ['y'] });
+      expect(el.hasChildren(['name', 'type'])).toBe(true);
+    });
+
+    test('hasChildren returns false when any child is missing', () => {
+      const el = new XMLElement({ name: ['x'] });
+      expect(el.hasChildren(['name', 'type'])).toBe(false);
+    });
+  });
+
+  describe('getChild', () => {
+    test('returns a wrapped element for an array child', () => {
+      const el = new XMLElement({ ContentItem: [{ $: { source: 'AUX' } }] });
+      const child = el.getChild('ContentItem');
+      expect(child).toBeInstanceOf(XMLElement);
+      expect(child?.getAttribute('source')).toBe('AUX');
+    });
+
+    test('returns a wrapped element for a non-array child', () => {
+      const el = new XMLElement({ ContentItem: { $: { source: 'AUX' } } });
+      expect(el.getChild('ContentItem')?.getAttribute('source')).toBe('AUX');
+    });
+
+    test('returns undefined for a missing child', () => {
+      const el = new XMLElement({});
+      expect(el.getChild('ContentItem')).toBeUndefined();
+    });
+
+    test('returns undefined for an empty array child', () => {
+      const el = new XMLElement({ ContentItem: [] });
+      expect(el.getChild('ContentItem')).toBeUndefined();
+    });
+  });
+
+  describe('getList', () => {
+    test('returns a wrapped element per array entry', () => {
+      const el = new XMLElement({
+        member: [{ $: { ipaddress: '1' } }, { $: { ipaddress: '2' } }],
+      });
+      const list = el.getList('member');
+      expect(list).toHaveLength(2);
+      expect(list[0].getAttribute('ipaddress')).toBe('1');
+      expect(list[1].getAttribute('ipaddress')).toBe('2');
+    });
+
+    test('returns an empty array when the field is not an array', () => {
+      const el = new XMLElement({ member: { $: {} } });
+      expect(el.getList('member')).toEqual([]);
+    });
+
+    test('returns an empty array when the field is missing', () => {
+      const el = new XMLElement({});
+      expect(el.getList('member')).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## What

Backfills unit tests across the SoundTouch API layer, which was almost entirely untested.

- **XML parsers** (`art`, `bass`, `bass-capabilities`, `component`, `connection-status-info`, `content-item`, `error`, `group`, `info`, `member`, `network-info`, `now-playing`, `preset`, `source`, `time`, `volume`, `zone`) — happy-path parsing plus malformed/missing-field guards.
- **Utilities** — `XMLElement` accessors and `compactMap`.
- **`API` client** — end-to-end coverage of request plumbing, error handling (`` / `` / non-2xx bodies) and every endpoint, driven by `axios-mock-adapter`.

## Why

Coverage was ~27% overall (~18% for `src/devices/SoundTouch/api`). This raises it to **~82% overall / ~87% for the API layer**, locking in the behaviour of the XML messaging code before further changes.

## Notes

- Adds `axios-mock-adapter` as a dev dependency (no install scripts; compatible with `ignore-scripts=true`).
- The `API` constructor now accepts an **optional** axios instance (defaults to the existing one) so a mock adapter can attach without module-level mocking. Non-breaking.

## 🚩 Issues surfaced while testing (not fixed here)

1. **`nowPlayingFromElement` treats `` and `` as required** (`now-playing.ts:58-66`) even though the `NowPlaying` interface marks them optional. A STANDBY/AUX `/now_playing` response without art/time parses to `undefined` instead of a `NowPlaying`. Latent today (only `getSource` is consumed internally) but `getNowPlaying` is public. A test documents the current behaviour.
2. **`contentItemToElement` / `contentItemFromElement` asymmetry** (`content-item.ts`): `toElement` writes `isPresetable` as a boolean while `fromElement` compares against the string `&#39;true&#39;`, so an in-memory round trip drops the flag (survives only when serialized to XML in between).
3. **Dead guard** in `infoFromElement` (`info.ts:26`): `!networkInfo` can never be true since `getList` always returns an array.

Happy to follow up with fixes in a separate PR.