### PR TITLE
chore: link SoundTouch Web API spec, remove dead Bose link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,6 @@ Default configuration applied to all accessories. Any value here can be overridd
 *Optional fields*
 * `verbose`: Log all device information __default__: **false**
 * `pollingInterval`: Poll each device every interval in milliseconds __default__: **2000**
+
+## References
+* [SoundTouch Web API](https://assets.bosecreative.com/m/496577402d128874/original/SoundTouch-Web-API.pdf) — Bose's official API specification this plugin is built against.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/homebridge-soundtouchspeaker.svg)](https://badge.fury.io/js/homebridge-soundtouchspeaker)
 [![npm downloads](https://badgen.net/npm/dt/homebridge-soundtouchspeaker)](https://badgen.net/npm/dt/homebridge-soundtouchspeaker)
 
-[Bose SoundTouch](https://www.bose.com/soundtouch-systems.html) plugin for [Homebridge](https://github.com/homebridge/homebridge).
+Bose SoundTouch plugin for [Homebridge](https://github.com/homebridge/homebridge).
 
 This allows you to control your SoundTouch devices with HomeKit and Siri.
 


### PR DESCRIPTION
## What
README maintenance:
- Add a **References** section linking Bose&#39;s official [SoundTouch Web API](https://assets.bosecreative.com/m/496577402d128874/original/SoundTouch-Web-API.pdf) PDF — the spec this plugin is built against.
- Remove the dead `bose.com/soundtouch-systems.html` hyperlink (now a hard 404 since Bose discontinued SoundTouch). Kept the &#34;Bose SoundTouch&#34; text, dropped the link.

## Why
I checked every URL in the README; all others resolve. The Bose product link was the only genuinely broken one.