### PR TITLE
ci: configure Dependabot to target dev with conventional titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+# Dependabot keeps dependencies current by opening PRs against `dev` (not the
+# default `latest` branch). PRs squash-merge into `dev`, so the PR *title* is what
+# matters: it becomes the commit semantic-release analyses. We force a `chore`
+# Conventional Commit prefix so bumps pass the PR Title check and never trigger a
+# release on their own — versions are cut deliberately by promoting dev -> beta ->
+# latest after testing. See .releaserc.json and .github/workflows/pr-title.yml.
+version: 2
+updates:
+  # npm dependencies (production + development)
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      # `include: "scope"` appends (deps) for production and (deps-dev) for dev
+      # deps, yielding e.g. `chore(deps): bump axios` / `chore(deps-dev): bump jest`.
+      prefix: "chore"
+      include: "scope"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+
+  # Pinned GitHub Actions (actions/checkout, setup-node, amannn, ...)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` so dependency update PRs:

- **Target `dev`** (`target-branch: dev`) instead of the default `latest` branch.
- **Use Conventional Commit titles** (`commit-message.prefix: chore` + `include: scope`), e.g. `chore(deps): bump axios`, `chore(deps-dev): bump jest`, `chore(deps): bump actions/checkout`.

## Why

PRs squash-merge into `dev`, so the PR *title* becomes the commit semantic-release analyses. A `chore` prefix passes the existing PR Title check (`amannn/action-semantic-pull-request`) and **never triggers a release on its own** — versions stay deliberate via `dev → beta → latest` promotion after testing.

## Details

- Two ecosystems: **npm** (grouped into production / development) and **github-actions** (grouped), both weekly, both targeting `dev`.
- Branch names stay Dependabot&#39;s defaults (not templatable); only PR titles feed releases, and those are locked to `chore`.