### PR TITLE
chore: add skills and CLAUDE.md router

### DIFF
--- a/.claude/skills/architect/SKILL.md
+++ b/.claude/skills/architect/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: architect
+description: Plan and track a new feature rollout for this Homebridge SoundTouch plugin. Use when the user runs /architect with a feature idea — explores the relevant code, produces an implementation plan tailored to this repo's conventions, and writes it to a tracked checklist file in the skill's own plans/ directory that gets updated as the work proceeds.
+---
+
+# Architect — plan & track feature rollouts
+
+You turn a feature idea into a grounded, trackable implementation plan that respects
+this repo's conventions. You do **not** write feature code from this skill — you
+produce and maintain the plan.
+
+## Workflow
+
+### 1. Capture
+Take the feature request from the command arguments. If none was given, ask the user
+for a one-line description before continuing.
+
+### 2. Explore
+Read the relevant code before proposing anything — ground every claim in real files.
+Use the **Repo map** below to find the right starting points. Read, don't guess.
+
+### 3. Design
+Produce an implementation plan that honors the repo's conventions. Don't restate
+them — reference the owning skills and call out what the feature specifically
+touches:
+
+- **Code/build/test style:** follow the **coding-conventions** skill (TS ESM,
+  lint/format, Jest setup, the typecheck+lint+test gate).
+- **Plugin architecture & config flow:** follow the **homebridge-developer** skill
+  — in particular, a user-facing option means updating `config.schema.json` plus
+  the config classes and their tests.
+- **Bose protocol payloads:** follow the **soundtouch-api-expert** skill.
+
+The conventions this skill *owns* — decide both up front, they drive the release:
+
+- **Commit type:** `feat:` → minor, `fix:` → patch, `feat!:` or a
+  `BREAKING CHANGE:` footer → major, `chore:`/`docs:`/`ci:`/`test:`/`refactor:` →
+  no release. semantic-release derives the version from this.
+- **Branch/PR flow:** branch off `dev` (e.g. `feat/…`); open the PR **into `dev`**.
+  Feature PRs are squash-merged, so the **PR title becomes the released commit
+  message** — it must be a valid Conventional Commit. Never hand-edit the `version`
+  in `package.json` or write a changelog; releases are automated. See
+  `CONTRIBUTING.md` for the full model.
+
+### 4. Write the plan
+Copy `plan-template.md` (in this skill's directory) to
+`plans/<NN>-<kebab-slug>.md` inside this skill
+(`.claude/skills/architect/plans/`), where `<NN>` is the next zero-padded
+sequence number (look at existing files in `plans/`, start at `01`). Fill in
+every section. Keep file paths concrete.
+
+### 5. Track
+As implementation proceeds (in this or later sessions), keep the plan file current:
+- flip checklist items `- [ ]` → `- [x]` as they land,
+- update the `status` frontmatter field
+  (`planned` → `in-progress` → `done`, or `cancelled`), and
+- **append** to the **Decisions & findings** table whenever a design decision is
+  made or a non-obvious fact is discovered — never delete prior entries. This is
+  the anti-reinvent-the-wheel record.
+
+If a feature turns out to be **impossible or not worth doing**, don't delete the
+plan: set `status: cancelled`, fill in the **If cancelled** section (why, the
+evidence, and what would have to change to revisit), and leave it in place.
+
+Always re-read the plan file before editing it so you don't clobber prior updates.
+
+## Where things live
+
+Don't reproduce the file map here — use the domain skills to locate code during
+exploration:
+
+- **Plugin architecture, accessories, characteristics, config flow, file layout:**
+  the **homebridge-developer** skill.
+- **Bose HTTP/XML + WebSocket API client (`src/devices/SoundTouch/api/`):** the
+  **soundtouch-api-expert** skill.
+- **Code/build/test conventions:** the **coding-conventions** skill.
+
+Read the relevant skill(s) before drafting the plan so file paths and patterns in
+it are accurate.

--- a/.claude/skills/architect/plan-template.md
+++ b/.claude/skills/architect/plan-template.md
@@ -1,0 +1,67 @@
+---
+feature: <one-line feature name>
+status: planned # planned | in-progress | done | cancelled
+date: <YYYY-MM-DD>
+branch: <feat/…, branched off dev>
+commit-type: <feat | fix | feat! | chore | docs | ci | test | refactor>
+---
+
+# <Feature name>
+
+## Context
+
+Why this change is being made — the problem or need it addresses and the intended
+outcome.
+
+## Decisions & findings
+
+The durable record so we don't re-litigate decisions or re-investigate facts.
+**Append, don't overwrite** — keep entries even after they're acted on. Capture
+each design decision (and the alternative rejected), and each non-obvious fact
+discovered while exploring the code/device.
+
+| Date | Decision / finding | Rationale / evidence | Alternatives rejected |
+| --- | --- | --- | --- |
+| <YYYY-MM-DD> | <what was decided or learned> | <why / where it came from> | <what we chose against, and why> |
+
+## If cancelled
+
+> Only fill this in when `status: cancelled`. Leave empty otherwise.
+
+Why this feature was abandoned or isn't possible, the evidence for that
+conclusion, and what would have to change to revisit it. Recording a dead end is
+a deliverable — it stops the next person re-attempting it.
+
+## Affected areas
+
+Concrete files/dirs this touches (pull from the repo map):
+
+- `src/...` — what changes here
+
+## Conventions for this change
+
+- **Commit type:** `<type>:` → <release impact: major/minor/patch/none>
+- **Config schema touched:** <yes/no> — if yes, update `config.schema.json`,
+  `src/PlatformConfiguration.ts` / `src/ExternalPlatformConfig.ts`, and their tests.
+- **Tests to add/update:** `src/.../__tests__/...test.ts`
+- **Target branch:** `dev` (squash-merged; PR title is the released commit message).
+
+## Implementation checklist
+
+- [ ] Step 1
+- [ ] Step 2
+- [ ] Add/update tests
+- [ ] Update `config.schema.json` (if user-facing config changed)
+
+## Verification
+
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] `npm test`
+- [ ] `npm run watch` — live Homebridge test of the behavior
+
+## PR / release notes
+
+- **PR title (Conventional Commit, becomes the release commit):**
+  `<type>: <imperative summary>`
+- **Targets:** `dev`

--- a/.claude/skills/coding-conventions/SKILL.md
+++ b/.claude/skills/coding-conventions/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: coding-conventions
+description: >-
+  How code is written, formatted, built, and tested in this repo: TypeScript
+  ESM import rules, the ESLint/Prettier/knip toolchain, the Jest + SWC test
+  setup, logging, and the checks that gate "done". Use before writing or
+  editing any TypeScript source or test in this project.
+---
+
+# Coding conventions
+
+The canonical, language/tooling-level conventions for this repo. Domain skills
+(`homebridge-developer`, `soundtouch-api-expert`) and `architect` link here
+rather than restating this — keep style/build/test rules in this one place.
+
+## TypeScript & ESM (do not skip)
+
+- `package.json` has `"type": "module"`; TypeScript emits ESM.
+- **Relative imports must include the `.js` extension**, even though the source
+  is `.ts`:
+  ```ts
+  import { SoundTouchDevice } from './devices/SoundTouch/SoundTouchDevice.js';
+  ```
+  Omitting `.js` compiles but **fails at runtime under Homebridge**. This is the
+  most common footgun in this repo.
+- Import package types/values **without** an extension:
+  `import { API, Service, Characteristic } from 'homebridge';`
+- Source lives in `src/`, compiles to `dist/`. Never edit `dist/`.
+
+## Toolchain
+
+| Command | Purpose |
+| --- | --- |
+| `npm run build` | Clean + `tsc` → `dist/` |
+| `npm run typecheck` | `tsc --noEmit` |
+| `npm run lint` | ESLint, `--max-warnings=0`, auto-`--fix` |
+| `npm run format` | Prettier write |
+| `npm run knip` | Flag unused files / exports / deps |
+| `npm test` (`npx jest`) | Run tests with coverage |
+| `npx jest <pattern>` | Run a subset |
+
+ESLint runs with zero tolerance for warnings; Prettier owns formatting (don't
+hand-format against it). `knip` keeps the dependency/export surface clean.
+
+## Testing
+
+- Runner: **Jest + `@swc/jest`** (not ts-jest). Config: `jest.config.ts`.
+- Tests live in `__tests__/` directories **beside the code they cover** and match
+  `*.test.ts` / `*.spec.ts`. `roots` is `<rootDir>/src`.
+- `moduleNameMapper` rewrites `^(\.{1,2}/.*)\.js$` → `$1` so the `.js` import
+  extensions (above) resolve in tests.
+- Coverage is collected by default (`collectCoverage: true`).
+- Favor testing pure logic (config transforms, payload parsing) over framework
+  wiring.
+- **Mocking Homebridge** (the manual `__mocks__/homebridge.js` and the SWC
+  `const enum` gotcha) is Homebridge-specific — see the **homebridge-developer**
+  skill.
+
+## Logging
+
+Log through the formatted logger (`src/utils/FormattedLogger.ts`) — `.debug`,
+`.success`, `.error`. Never use `console.*`.
+
+## Definition of done
+
+Before considering a code change complete, all three must be green:
+
+```sh
+npm run typecheck && npm run lint && npm test
+```
+
+## Scope
+
+This skill is style/build/test only. For plugin architecture and HomeKit wiring
+see **homebridge-developer**; for the Bose protocol see **soundtouch-api-expert**;
+for planning, branching, and release flow see **architect** and `CONTRIBUTING.md`.

--- a/.claude/skills/homebridge-developer/SKILL.md
+++ b/.claude/skills/homebridge-developer/SKILL.md
@@ -13,14 +13,10 @@ This is a **TypeScript ESM dynamic platform** Homebridge plugin. Follow the
 patterns already in `src/` — this skill points to the canonical examples rather
 than restating them.
 
-## ESM conventions (do not skip)
-
-- `package.json` has `"type": "module"`; TypeScript emits ESM.
-- **Relative imports must include the `.js` extension**, even though the source
-  is `.ts`: `import { SoundTouchDevice } from './devices/SoundTouch/SoundTouchDevice.js';`
-  Omitting `.js` builds but fails at runtime under Homebridge.
-- Import Homebridge types/values from `'homebridge'` (no extension — it's a
-  package): `import { API, Service, Characteristic } from 'homebridge';`
+> **Language, build, lint, and test tooling** (including the ESM `.js`-import
+> rule) live in the **coding-conventions** skill. This skill covers only what is
+> specific to Homebridge: architecture, HomeKit wiring, and verified-plugin
+> compliance.
 
 ## Platform & accessory architecture
 
@@ -85,33 +81,18 @@ change these casually — they key the accessory cache.
 The SoundTouch device HTTP/XML API lives under `src/devices/SoundTouch/api/`;
 discovery uses bonjour / multicast-dns.
 
-## Testing & quality
+## Testing Homebridge code
 
-- Runner: **Jest + `@swc/jest`** (no ts-jest). Config: `jest.config.ts`.
-- Tests live in `__tests__/` dirs and match `*.test.ts` / `*.spec.ts`.
-  `roots` is `<rootDir>/src`, so put tests beside the code they cover.
-- `moduleNameMapper` rewrites `^(\.{1,2}/.*)\.js$` → `$1` so the `.js` import
-  extensions resolve in tests, and maps `homebridge` to the manual mock.
+Generic test setup (Jest + `@swc/jest`, colocated `__tests__/`, coverage,
+commands, the "typecheck + lint + test before done" gate) is in the
+**coding-conventions** skill. Homebridge-specific testing notes:
+
 - **Manual mock `__mocks__/homebridge.js`** exists because SWC does not inline
-  Homebridge's `const enum`s (e.g. `LogLevel`). If a test hits an undefined
-  Homebridge enum value, add it there.
-- Coverage is collected by default (`collectCoverage: true`).
+  Homebridge's `const enum`s (e.g. `LogLevel`); `moduleNameMapper` maps
+  `homebridge` to it. If a test hits an undefined Homebridge enum value, add it
+  there.
 - Favor testing pure logic (config transforms, device parsing) over HAP wiring,
   matching the existing `PlatformConfiguration` / `ExternalPlatformConfig` tests.
-
-Commands:
-
-| Command | Purpose |
-| --- | --- |
-| `npm test` (`npx jest`) | Run tests with coverage |
-| `npx jest <pattern>` | Run a subset |
-| `npm run typecheck` | `tsc --noEmit` |
-| `npm run lint` | ESLint, `--max-warnings=0`, auto-`--fix` |
-| `npm run format` | Prettier write |
-| `npm run knip` | Unused files/exports/deps |
-| `npm run build` | Clean + `tsc` → `dist/` |
-
-Before considering a change done, run typecheck, lint, and tests.
 
 ## Running & debugging locally
 
@@ -170,8 +151,11 @@ them, so don't regress them.
 Homebridge thread) · AccessoryInformation populated with a unique SerialNumber ·
 `npm run typecheck && npm run lint && npm test` all green.
 
-## What this skill does NOT cover
+## Related skills
 
-Release, versioning, and contribution flow (conventional commits,
-semantic-release `latest`→`dev`→`beta`, README-vs-CONTRIBUTING rules) are out of
-scope — see `CONTRIBUTING.md` and the project memory notes.
+- **coding-conventions** — TypeScript/ESM rules, lint/format, generic Jest setup,
+  logging, and the pre-done checks.
+- **soundtouch-api-expert** — the Bose SoundTouch HTTP/XML + WebSocket protocol.
+- **architect** — planning a feature, and the branching/release flow
+  (conventional commits, semantic-release `latest`→`dev`→`beta`). For the full
+  contribution rules see `CONTRIBUTING.md`.

--- a/.claude/skills/homebridge-developer/SKILL.md
+++ b/.claude/skills/homebridge-developer/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: homebridge-developer
+description: >-
+  Conventions and workflows for developing this Homebridge plugin
+  (homebridge-soundtouchspeaker). Use when implementing or modifying the
+  platform, accessories, characteristics, or device API; writing or running
+  Jest tests; or building, running, and debugging the plugin locally.
+---
+
+# Homebridge Plugin Developer
+
+This is a **TypeScript ESM dynamic platform** Homebridge plugin. Follow the
+patterns already in `src/` — this skill points to the canonical examples rather
+than restating them.
+
+## ESM conventions (do not skip)
+
+- `package.json` has `"type": "module"`; TypeScript emits ESM.
+- **Relative imports must include the `.js` extension**, even though the source
+  is `.ts`: `import { SoundTouchDevice } from './devices/SoundTouch/SoundTouchDevice.js';`
+  Omitting `.js` builds but fails at runtime under Homebridge.
+- Import Homebridge types/values from `'homebridge'` (no extension — it's a
+  package): `import { API, Service, Characteristic } from 'homebridge';`
+
+## Platform & accessory architecture
+
+The platform is the entry point. Canonical implementation: `src/platform.ts`.
+
+- Class implements `DynamicPlatformPlugin`. The constructor wires
+  `api.hap.Service` / `api.hap.Characteristic`, builds config via
+  `PlatformConfiguration.fromExternalConfiguration`, and registers a
+  `didFinishLaunching` handler that calls `discoverDevices()`.
+- **Cache restore:** Homebridge calls `configureAccessory()` for every cached
+  accessory *before* `didFinishLaunching`. Stash them in the `_accessories`
+  map; in `discoverDevices()` reuse an existing accessory when its UUID matches,
+  otherwise `new this.api.platformAccessory(name, uuid)` +
+  `registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [...])`.
+- **UUID** is derived deterministically from the device id:
+  `this.api.hap.uuid.generate(device.id)`.
+- **Prune stale accessories:** anything in the cache not rediscovered this run
+  gets `unregisterPlatformAccessories`. Keep this loop intact when editing
+  discovery.
+- New accessories store their device on `accessory.context.device` so it
+  survives a restart.
+
+## Characteristic pattern
+
+Each HAP characteristic is its own class extending the base
+`SoundTouchSpeakerCharacteristic`. Reference: `src/accessories/services/SoundTouchSpeakerOnCharacteristic.ts`.
+
+- Constructor takes `{ service, device, platform, accessory }`, grabs the
+  characteristic via `service.getCharacteristic(platform.characteristic.X)`,
+  and binds handlers: `.onSet(this.setX.bind(this)).onGet(this.getX.bind(this))`.
+- Implement `init()` (called once, usually `await this.refresh()`) and
+  `refresh()` (update HAP value only when it differs, via
+  `characteristic.updateValue`).
+- On device communication failure in a setter, throw a HAP error — do **not**
+  swallow it:
+  ```ts
+  throw new this.platform.api.hap.HapStatusError(
+    this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE
+  );
+  ```
+- Expose a static `create(props)` async factory (some characteristics need
+  async setup before returning).
+- Log through `this.log` (`.debug`, `.success`, `.error`) — the formatted
+  logger, not `console`.
+
+## Config flow
+
+User config → typed config in three coordinated places:
+
+1. `src/ExternalPlatformConfig.ts` — the raw shape Homebridge passes in.
+2. `src/PlatformConfiguration.ts` — `fromExternalConfiguration(...)` applies
+   defaults, merges `global` into per-accessory settings, and drops accessories
+   lacking both `ip` and `room`. Tests in
+   `src/__tests__/PlatformConfiguration.test.ts` document the exact rules.
+3. `config.schema.json` — the Homebridge UI form. **Keep it in sync** whenever
+   you add/rename a config field, or the UI and code diverge.
+
+Identifiers live in `src/settings.ts`: `PLATFORM_NAME` is what users put under
+`platforms[].platform`; `PLUGIN_NAME` must equal `package.json`'s `name`. Don't
+change these casually — they key the accessory cache.
+
+The SoundTouch device HTTP/XML API lives under `src/devices/SoundTouch/api/`;
+discovery uses bonjour / multicast-dns.
+
+## Testing & quality
+
+- Runner: **Jest + `@swc/jest`** (no ts-jest). Config: `jest.config.ts`.
+- Tests live in `__tests__/` dirs and match `*.test.ts` / `*.spec.ts`.
+  `roots` is `<rootDir>/src`, so put tests beside the code they cover.
+- `moduleNameMapper` rewrites `^(\.{1,2}/.*)\.js$` → `$1` so the `.js` import
+  extensions resolve in tests, and maps `homebridge` to the manual mock.
+- **Manual mock `__mocks__/homebridge.js`** exists because SWC does not inline
+  Homebridge's `const enum`s (e.g. `LogLevel`). If a test hits an undefined
+  Homebridge enum value, add it there.
+- Coverage is collected by default (`collectCoverage: true`).
+- Favor testing pure logic (config transforms, device parsing) over HAP wiring,
+  matching the existing `PlatformConfiguration` / `ExternalPlatformConfig` tests.
+
+Commands:
+
+| Command | Purpose |
+| --- | --- |
+| `npm test` (`npx jest`) | Run tests with coverage |
+| `npx jest <pattern>` | Run a subset |
+| `npm run typecheck` | `tsc --noEmit` |
+| `npm run lint` | ESLint, `--max-warnings=0`, auto-`--fix` |
+| `npm run format` | Prettier write |
+| `npm run knip` | Unused files/exports/deps |
+| `npm run build` | Clean + `tsc` → `dist/` |
+
+Before considering a change done, run typecheck, lint, and tests.
+
+## Running & debugging locally
+
+- `npm run watch` → `build && npm link && nodemon`. Nodemon (`nodemon.json`)
+  rebuilds on `src/**/*.ts` changes and runs
+  `homebridge -U ./test/hbConfig -D` (`-D` = debug logging).
+- The sandbox Homebridge instance reads `test/hbConfig/config.json`. Edit the
+  plugin's platform block there to exercise different configs (e.g.
+  `discoverAllAccessories`, per-accessory `ip`/`room`, `global.verbose`).
+- Cached accessories persist in `test/hbConfig/accessories/cachedAccessories`
+  and `test/hbConfig/persist/`. Delete these to simulate a fresh install when
+  debugging cache-restore behavior.
+- Set `verbose: true` (or `global.verbose`) to raise the formatted logger to
+  `DEBUG`; the platform already logs discovery and accessory lifecycle at debug.
+- **Discovery not finding devices:** bonjour/multicast-dns mDNS often fails
+  across subnets/VLANs or in containers. Fall back to an explicit `ip` (+
+  optional `port`, default 8090) accessory config to bypass discovery.
+
+## Homebridge official guidance & verified-plugin compliance
+
+All changes must keep the plugin aligned with the official Homebridge developer
+docs and the **verified-plugin requirements** (last updated by Homebridge
+2024-11-02). Treat these as hard constraints — the repo currently satisfies
+them, so don't regress them.
+
+**Authoritative sources** (check the live pages, don't rely on memory):
+
+- API reference (services, characteristics, valid values):
+  https://developers.homebridge.io/#/
+- Homebridge core + wiki: https://github.com/homebridge/homebridge
+- Verified requirements: https://github.com/homebridge/plugins/wiki/Verified-Plugins
+- Plugin Settings GUI / config schema:
+  https://github.com/homebridge/homebridge-config-ui-x/wiki/Developers:-Plugin-Settings-GUI
+
+**Requirements and how this repo meets them — keep them true:**
+
+| Requirement | Where it's satisfied / what to preserve |
+| --- | --- |
+| Must be a **dynamic platform** plugin | `SoundTouchHomebridgePlatform implements DynamicPlatformPlugin` (`src/platform.ts`). Registered in `src/index.ts`. |
+| **No duplicate accessories** on restart | Reuse cached accessories by UUID and prune stale ones in `discoverDevices()`. Don't register an accessory whose UUID is already in the cache. |
+| **Catch and log own errors** — no unhandled exceptions | Discovery wraps `searchDevices()` in try/catch; per-accessory init is wrapped; setters throw `HapStatusError` (a handled HAP error), never raw throws that crash Homebridge. Mirror this in new code. |
+| **Implement the Plugin Settings GUI** | Maintain a valid `config.schema.json`; every config field must appear there. Validate after edits. |
+| **Install must not start unless configured**; no system-modifying post-install scripts | Keep `package.json` scripts dev-only. `prepare`/`husky` run for contributors, not end users of the published package — don't add post-install side effects. |
+| **Run on all supported LTS Node** (v22, v24) | `engines.node` is `^22.10.0 \|\| ^24.0.0`. Don't use APIs unavailable on these. |
+| **Homebridge v1 + v2** support | `engines.homebridge` is `^1.8.0 \|\| ^2.0.0`; `homebridge-lib`/`homebridge` peer-compatible. Avoid v2-only or v1-removed APIs without guarding. |
+| **Write files only inside the Homebridge storage dir** | If you ever persist to disk, use `api.user.storagePath()` — never arbitrary paths or the cwd. |
+| **No analytics / user tracking** | Don't add telemetry or phone-home calls. |
+| **Set AccessoryInformation** with a unique SerialNumber | `SoundTouchSpeakerInformationCharacteristic` sets Manufacturer/Model/SerialNumber (`device.id`, unique)/FirmwareRevision. Keep SerialNumber stable and unique per device. |
+| **Stable UUIDs** | Always `api.hap.uuid.generate(<stable unique id>)`; never random or display-name-derived. |
+| **Child bridge compatible** | Automatic for dynamic platforms — no code needed. Don't add global/singleton state or fixed ports that would break running in an isolated child-bridge process. |
+| **Use real HAP service/characteristic types** | Look up service/characteristic names and allowed values in the developer API reference before inventing or hard-coding values. |
+
+**Before submitting plugin changes**, confirm: dynamic-platform contract intact
+· cache reuse + stale pruning intact · new config fields added to
+`config.schema.json` · errors caught and logged (no raw throws on the
+Homebridge thread) · AccessoryInformation populated with a unique SerialNumber ·
+`npm run typecheck && npm run lint && npm test` all green.
+
+## What this skill does NOT cover
+
+Release, versioning, and contribution flow (conventional commits,
+semantic-release `latest`→`dev`→`beta`, README-vs-CONTRIBUTING rules) are out of
+scope — see `CONTRIBUTING.md` and the project memory notes.

--- a/.claude/skills/soundtouch-api-expert/SKILL.md
+++ b/.claude/skills/soundtouch-api-expert/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: soundtouch-api-expert
+description: >-
+  Expert knowledge of the Bose SoundTouch Web API and what a SoundTouch speaker
+  is. Use when working with the SoundTouch HTTP/XML API (port 8090), WebSocket
+  notifications (port 8080, "gabbo" protocol), device discovery (SSDP/mDNS), or
+  interpreting/constructing SoundTouch XML payloads for endpoints like
+  /now_playing, /volume, /key, /select, /presets, /bass, /info, /getZone,
+  /setZone, and friends.
+---
+
+# SoundTouch Web API Expert
+
+Authoritative reference for the **Bose SoundTouch Web API**, the HTTP/XML +
+WebSocket protocol this plugin speaks to control Bose speakers. Source: *Bose
+SoundTouch Web API*, Version 1.1 (Bose Corporation) —
+<https://assets.bosecreative.com/m/496577402d128874/original/SoundTouch-Web-API.pdf>.
+
+The full endpoint catalog (every URL with request/response XML and all WebSocket
+notification shapes) lives in **`api-reference.md`** next to this file. Read it
+before writing or parsing any payload — the summary here is the map, that file
+is the territory.
+
+## What a SoundTouch speaker is
+
+A SoundTouch speaker is a Wi-Fi/Ethernet–connected Bose wireless speaker that
+plays streaming audio and is controllable over the local network via the Web
+API. It is one component of the **SoundTouch ecosystem**:
+
+- **SoundTouch Speaker** — the device itself. Products include the SoundTouch
+  Portable, SoundTouch 20, SoundTouch 30, Wave SoundTouch, SoundTouch Stereo JC,
+  SoundTouch SA-4 amplifier, SoundTouch outdoor systems, and Cinemate /
+  Lifestyle / VideoWave home-theater systems.
+- **SoundTouch App** — the iOS/Android control app; it discovers speakers on the
+  network (SSDP/Bonjour) and controls them with this same API. Third-party
+  integrations (like this Homebridge plugin) play the same client role.
+- **SoundTouch Cloud Server (deprecated)** — formerly stored accounts, presets,
+  recents, and the speaker list. Treat as gone; rely on the speaker locally.
+
+Speakers can be grouped into **multi-room zones** (a "play everywhere" zone with
+one master and one or more slaves) so they play in sync.
+
+## Transport fundamentals
+
+- **Control: HTTP on port `8090`.** Commands are `GET` and `POST` with XML
+  payloads. Rule of thumb from the spec: any `get*` operation is an HTTP `GET`;
+  any `set*` operation is an HTTP `POST` (i.e. requires a payload).
+- **Notifications: WebSocket on port `8080`.** Open `ws://$IP` and **you must
+  specify the sub-protocol `"gabbo"`** (`new WebSocket("ws://$IP", "gabbo")`).
+  The speaker pushes asynchronous `<updates>` messages when state changes.
+- Most notifications are **"tickle" style** — they only tell you *what* changed
+  (e.g. `<volumeUpdated/>`), not the new value. The client re-fetches via the
+  matching GET endpoint. A few (e.g. presets) include the new data.
+
+## Errors & status
+
+- Calls with no special payload return `<status>$STRING</status>`.
+- Error responses:
+  ```xml
+  <errors deviceID="$STRING">
+    <error value="$INT" name="$STRING" severity="$STRING">$STRING</error> ...
+  </errors>
+  ```
+- Malformed XML / wrong value yields a parse error, e.g.
+  `<error>XML parse error (1:116): Error reading Attributes.</error>` or an
+  `<errors>` block with `name="CLIENT_XML_ERROR"`.
+
+## Endpoint index
+
+| Endpoint | Method(s) | Purpose |
+| --- | --- | --- |
+| `/key` | POST | Send a remote-button press (PLAY, PAUSE, PRESET_1…, POWER, MUTE, …); send `press` then `release` |
+| `/select` | POST | Select a source via a `<ContentItem>` (AUX, BLUETOOTH, PRODUCT, …) |
+| `/sources` | GET | List available content sources and their status |
+| `/bassCapabilities` | GET | Whether bass is adjustable + min/max/default |
+| `/bass` | GET, POST | Get/set bass level |
+| `/getZone` | GET | Current multi-room zone (master + members) |
+| `/setZone` | POST | Create a multi-room zone |
+| `/addZoneSlave` | POST | Add a slave to a zone |
+| `/removeZoneSlave` | POST | Remove a slave from a zone |
+| `/nowPlaying` | GET | Currently playing media (track, artist, art, playStatus, source) |
+| `/trackInfo` | GET | Detailed track info (same shape as nowPlaying) |
+| `/volume` | GET, POST | Get/set volume (0–100) and mute |
+| `/presets` | GET | List of presets (ids 1–6) |
+| `/info` | GET | Static device info (id, type, components, network, sw version) |
+| `/name` | POST | Set the device name |
+| `/capabilities` | GET | Which optional URLs the device supports — gate access on this |
+| `/audiodspcontrols` | GET, POST | DSP audio mode (DIRECT/NORMAL/DIALOG/NIGHT), A/V sync delay |
+| `/audioproducttonecontrols` | GET, POST | Bass/treble tone controls (value + min/max/step) |
+| `/audioproductlevelcontrols` | GET, POST | Front-center / rear-surround levels |
+
+**Capabilities gating:** several endpoints (`/audiodspcontrols`,
+`/audioproducttonecontrols`, `/audioproductlevelcontrols`, …) only exist if
+listed in the `GET /capabilities` reply. Check `/capabilities` before using
+optional URLs rather than assuming they exist.
+
+## Discovery
+
+Speakers are found on the LAN with two redundant protocols (run both for
+reliability across VLANs/containers):
+
+- **SSDP** — M-SEARCH over UDP multicast port `1900`. Service types:
+  `urn:schemas-upnp-org:device:MediaRenderer:1` (speakers that play audio) and
+  `urn:schemas-upnp-org:device:MediaServer:1` (media holders). Track device
+  expiry from the `Cache-control: max-age` header (min 1800s); use the
+  `Location` header address for all further comms.
+- **mDNS / Bonjour / Zero-conf** — service types `_soundtouch._tcp.local`
+  (general SoundTouch) and `_raop._tcp.local` (AirPlay, if supported).
+
+## How this maps to the codebase
+
+This Homebridge plugin is itself a SoundTouch Web API client. Ground any change
+in the existing client code rather than reinventing payloads:
+
+- **HTTP/XML client:** `src/devices/SoundTouch/api/` — one module per concern
+  (`info.ts`, `now-playing.ts`, `volume.ts`, `bass.ts`, `preset.ts`,
+  `source.ts`, `zone.ts`, `content-item.ts`, `key`/`select` via `api.ts`).
+  Endpoint names are centralized in `api/endpoints.ts`; XML parsing helpers in
+  `api/utils/xml-element.ts`; discovery in `api/api-discovery.ts`.
+- **Codebase ⇄ spec mismatches to know about:** the client's `Endpoints` enum
+  uses `now_playing` (the spec writes `/nowPlaying`) and includes `speaker` and
+  `getGroup`, which are **not** in the v1.1 public PDF. Treat the PDF as
+  canonical for documented endpoints, and the existing code as canonical for
+  the device's actual on-the-wire behavior (it may target older/undocumented
+  endpoints). When they disagree, verify against a real device before changing
+  wire format.
+
+This skill is only about the Bose protocol. For plugin architecture and HomeKit
+wiring use the **homebridge-developer** skill; for code/build/test conventions use
+the **coding-conventions** skill; for planning and release flow use **architect**.

--- a/.claude/skills/soundtouch-api-expert/api-reference.md
+++ b/.claude/skills/soundtouch-api-expert/api-reference.md
@@ -1,0 +1,339 @@
+# SoundTouch Web API — Full Reference
+
+Verbatim-faithful catalog of the Bose SoundTouch Web API (v1.1). Control calls
+are HTTP on **port 8090**; notifications are WebSocket on **port 8080**
+(sub-protocol `gabbo`). Placeholders (`$STRING`, `$INT`, `$MACADDR`, …) follow
+the special types below. `get*` ⇒ GET, `set*` ⇒ POST (payload required).
+
+## Special types
+
+| Type | Meaning |
+| --- | --- |
+| `BOOL` | `"true"` or `"false"` |
+| `INT` | 32-bit signed integer |
+| `UINT` | 32-bit unsigned integer |
+| `UINT64` | 64-bit unsigned integer |
+| `STRING` | any valid XML-escaped string |
+| `URL` | a URL encoded as a string |
+| `IPADDR` | an IP address as a string |
+| `MACADDR` | a MAC address, upper-cased, as a string |
+| `PRESET_ID` | integer 1–6 inclusive |
+
+**`ART_STATUS`**: `INVALID`, `SHOW_DEFAULT_IMAGE`, `DOWNLOADING`, `IMAGE_PRESENT`
+
+**`PLAY_STATUS`**: `PLAY_STATE`, `PAUSE_STATE`, `STOP_STATE`, `BUFFERING_STATE`,
+`INVALID_PLAY_STATUS`
+
+**`SOURCE_STATUS`**: `UNAVAILABLE`, `READY`
+
+**`AUDIO_MODE`**: `AUDIO_MODE_DIRECT`, `AUDIO_MODE_NORMAL`, `AUDIO_MODE_DIALOG`,
+`AUDIO_MODE_NIGHT`
+
+**`KEY_STATE`**: `press`, `release`
+
+**`KEY_VALUE`**: `PLAY`, `PAUSE`, `STOP`, `PREV_TRACK`, `NEXT_TRACK`,
+`THUMBS_UP`, `THUMBS_DOWN`, `BOOKMARK`, `POWER`, `MUTE`, `VOLUME_UP`,
+`VOLUME_DOWN`, `PRESET_1`, `PRESET_2`, `PRESET_3`, `PRESET_4`, `PRESET_5`,
+`PRESET_6`, `AUX_INPUT`, `SHUFFLE_OFF`, `SHUFFLE_ON`, `REPEAT_OFF`, `REPEAT_ONE`,
+`REPEAT_ALL`, `PLAY_PAUSE`, `ADD_FAVORITE`, `REMOVE_FAVORITE`, `INVALID_KEY`
+
+## General status / errors
+
+```xml
+<!-- default success for calls with no special payload -->
+<status>$STRING</status>
+
+<!-- error -->
+<errors deviceID="$STRING">
+  <error value="$INT" name="$STRING" severity="$STRING">$STRING</error> ...
+</errors>
+
+<!-- malformed request -->
+<error>XML parse error (1:116): Error reading Attributes.</error>
+<errors deviceID="D05FB8A9591D"><error value="1019" name="CLIENT_XML_ERROR" severity="Unknown">1019</error></errors>
+```
+
+---
+
+## Endpoints
+
+### `/key` — POST
+Send a remote button press. Best practice: two discrete POSTs, `press` then
+`release`, to simulate a real key click.
+```xml
+<key state="press" sender="Gabbo">$KEY_VALUE</key>
+<key state="release" sender="Gabbo">$KEY_VALUE</key>
+```
+
+### `/select` — POST
+Select an available source. Availability varies by product/account — query
+`/sources` first.
+```xml
+<ContentItem source="AUX" sourceAccount="AUX"></ContentItem>
+<ContentItem source="AUX" sourceAccount="AUX3"></ContentItem>
+<ContentItem source="BLUETOOTH"></ContentItem>
+<ContentItem source="PRODUCT" sourceAccount="TV"></ContentItem>
+```
+
+### `/sources` — GET
+List all available content sources.
+```xml
+<sources deviceID="$MACADDR">
+  <sourceItem source="$SOURCE" sourceAccount="$STRING" status="$SOURCE_STATUS">$STRING</sourceItem>
+  ...
+</sources>
+```
+
+### `/bassCapabilities` — GET
+Whether bass is adjustable on this speaker.
+```xml
+<bassCapabilities deviceID="$MACADDR">
+  <bassAvailable>$BOOL</bassAvailable>
+  <bassMin>$INT</bassMin>
+  <bassMax>$INT</bassMax>
+  <bassDefault>$INT</bassDefault>
+</bassCapabilities>
+```
+
+### `/bass` — GET / POST
+Get or set bass. Gate on `/bassCapabilities`.
+```xml
+<!-- GET -->
+<bass deviceID="$MACADDR">
+  <targetbass>$INT</targetbass>
+  <actualbass>$INT</actualbass>
+</bass>
+<!-- POST -->
+<bass>$INT</bass>
+```
+
+### `/getZone` — GET
+Current multi-room zone. First member is the master.
+```xml
+<zone master="$MACADDR">
+  <member ipaddress="$MASTER_IPADDR">$MASTER_MACADDR</member>
+  <member ipaddress="$SLAVE1_IPADDR">$SLAVE1_MACADDR</member> ...
+</zone>
+```
+
+### `/setZone` — POST
+Create a multi-room ("play everywhere") zone.
+```xml
+<zone master="$MACADDR" senderIPAddress="$IPADDR">
+  <member ipaddress="$IPADDR">$MACADDR</member> ...
+</zone>
+```
+
+### `/addZoneSlave` — POST
+Add a slave to an existing zone.
+```xml
+<zone master="$MACADDR">
+  <member ipaddress="$IPADDR">$MACADDR</member> ...
+</zone>
+```
+
+### `/removeZoneSlave` — POST
+Remove a slave from a zone.
+```xml
+<zone master="$MACADDR">
+  <member ipaddress="$IPADDR">$MACADDR</member> ...
+</zone>
+```
+
+### `/nowPlaying` — GET
+Everything about the currently playing media.
+```xml
+<nowPlaying deviceID="$MACADDR" source="$SOURCE">
+  <ContentItem source="$SOURCE" location="$STRING" sourceAccount="$STRING" isPresetable="$BOOL">
+    <itemName>$STRING</itemName>
+  </ContentItem>
+  <track>$STRING</track>
+  <artist>$STRING</artist>
+  <album>$STRING</album>
+  <stationName>$STRING</stationName>
+  <art artImageStatus="$ART_STATUS">$URL</art>
+  <playStatus>$PLAY_STATUS</playStatus>
+  <description>$STRING</description>
+  <stationLocation>$STRING</stationLocation>
+</nowPlaying>
+```
+
+### `/trackInfo` — GET
+Track information; same `<nowPlaying>` shape as above.
+
+### `/volume` — GET / POST
+Volume 0–100 inclusive. On POST, `muteenabled` is applied first; the system
+unmutes if the new volume exceeds the current setting.
+```xml
+<!-- GET -->
+<volume deviceID="$MACADDR">
+  <targetvolume>$INT</targetvolume>
+  <actualvolume>$INT</actualvolume>
+  <muteenabled>$BOOL</muteenabled>
+</volume>
+<!-- POST -->
+<volume>$INT<muteenabled>$BOOL</muteenabled></volume>
+```
+
+### `/presets` — GET
+Current presets (ids 1–6).
+```xml
+<presets>
+  <preset id="$PRESET_ID" createdOn="$UINT64" updateOn="$UINT64">
+    <ContentItem source="$SOURCE" location="$STRING" sourceAccount="$STRING" isPresetable="$BOOL">
+      <itemName>$STRING</itemName>
+    </ContentItem>
+  </preset>
+  ...
+</presets>
+```
+
+### `/info` — GET
+Mostly-static device info: id, type, per-component sw/serial, cloud account,
+network info.
+```xml
+<info deviceID="$MACADDR">
+  <name>$STRING</name>
+  <type>$STRING</type>
+  <margeAccountUUID>$STRING</margeAccountUUID>
+  <components>
+    <component>
+      <componentCategory>$STRING</componentCategory>
+      <softwareVersion>$STRING</softwareVersion>
+      <serialNumber>$STRING</serialNumber>
+    </component> ...
+  </components>
+  <margeURL>$URL</margeURL>
+  <networkInfo type="$STRING">
+    <macAddress>$MACADDR</macAddress>
+    <ipAddress>$IPADDR</ipAddress>
+  </networkInfo>
+  ...
+</info>
+```
+
+### `/name` — POST
+Set the device name.
+```xml
+<name>$STRING</name>
+```
+
+### `/capabilities` — GET
+Lists optional capabilities and the URLs to access them. **Only access an
+optional URL if it appears here.**
+```xml
+<capabilities deviceID="$MACADDR"> ...
+  <capability name="$STRING" url="/$STRING" info="$STRING"/> ...
+</capabilities>
+```
+
+### `/audiodspcontrols` — GET / POST
+DSP audio mode. Only present if listed in `/capabilities`.
+`supportedaudiomodes` lists the modes accepted by POST. Omitted POST fields are
+left unchanged.
+```xml
+<!-- GET -->
+<audiodspcontrols audiomode="$AUDIO_MODE" videosyncaudiodelay="0"
+  supportedaudiomodes="$AUDIO_MODE|$AUDIO_MODE..."/>
+<!-- POST -->
+<audiodspcontrols audiomode="$AUDIO_MODE" videosyncaudiodelay="$UINT"/>
+```
+
+### `/audioproducttonecontrols` — GET / POST
+Bass/treble tone controls. Only present if listed in `/capabilities`.
+`minValue`/`maxValue`/`step` constrain the POST value. Omitted fields unchanged.
+```xml
+<!-- GET -->
+<audioproducttonecontrols>
+  <bass value="$INT" minValue="$INT" maxValue="$INT" step="$UINT"/>
+  <treble value="$INT" minValue="$INT" maxValue="$INT" step="$UINT"/>
+</audioproducttonecontrols>
+<!-- POST -->
+<audioproducttonecontrols>
+  <bass value="$INT" />
+  <treble value="$INT" />
+</audioproducttonecontrols>
+```
+
+### `/audioproductlevelcontrols` — GET / POST
+Front-center / rear-surround levels. Only present if listed in `/capabilities`.
+Omitted fields unchanged.
+```xml
+<!-- GET -->
+<audioproductlevelcontrols>
+  <frontCenterSpeakerLevel value="$INT" minValue="$INT" maxValue="$INT" step="$UINT"/>
+  <rearSurroundSpeakersLevel value="$INT" minValue="$INT" maxValue="$INT" step="$UINT"/>
+</audioproductlevelcontrols>
+<!-- POST -->
+<audioproductlevelcontrols>
+  <frontCenterSpeakerLevel value="$INT" />
+  <rearSurroundSpeakersLevel value="$INT" />
+</audioproductlevelcontrols>
+```
+
+---
+
+## WebSocket notifications (port 8080, protocol `gabbo`)
+
+Open `ws://$IP` with sub-protocol `"gabbo"`. The speaker pushes `<updates>`
+frames. Most are "tickles" — react by re-fetching the matching GET endpoint.
+
+```js
+socket = new WebSocket("ws://$IP", "gabbo")
+```
+
+```xml
+<!-- heartbeat / empty -->
+<updates deviceID="$MACADDR"></updates>
+<!-- some carry data inline -->
+<updates deviceID="$MACADDR">
+  <volume><targetvolume>$INT</targetvolume><actualvolume>$INT</actualvolume></volume>
+</updates>
+```
+
+| Notification | Payload | React by |
+| --- | --- | --- |
+| **PresetsChangedNotifyUI** | `<presetsUpdated><presets>…</presets></presetsUpdated>` (includes new presets inline) | use inline data or re-GET `/presets` |
+| **RecentsUpdatedNotifyUI** | `<recentsUpdated><recents>…</recents></recentsUpdated>` (inline) | re-GET `/recents` |
+| **AcctModeChangedNotifyUI** | `<acctModeUpdated></acctModeUpdated>` | cloud account association changed |
+| **ErrorNotification** | `ErrorNotification` | handle error |
+| **NowPlayingChange** | `<nowPlayingUpdated><nowPlaying …>…</nowPlaying></nowPlayingUpdated>` (inline) | use inline data or re-GET `/nowPlaying` |
+| **VolumeChange** | `<volumeUpdated/>` | re-GET `/volume` |
+| **BassChange** | `<bassUpdated/>` | re-GET `/bass` |
+| **ZoneMapChange** | `<zoneUpdated/>` (master + slave variants) | re-GET `/getZone` |
+| **SWUpdateStatusChange** | `<swUpdateStatusUpdated/>` | no action needed |
+| **SiteSurveyResultsChange** | `<siteSurveyResultsUpdated/>` | no action needed |
+| **SourcesChange** | `<sourcesUpdated/>` | re-GET `/sources` |
+| **NowSelectionChange** | `<nowSelectionUpdated><preset …>…</preset></nowSelectionUpdated>` (inline) | note selected preset |
+| **NetworkConnectionStatus** | `<connectionStateUpdated/>` | check connection |
+| **InfoChange** | `<infoUpdated/>` (e.g. name changed) | re-GET `/info` |
+
+### Zone map change sequencing
+When a slave joins a zone, the master emits a series of per-slave updates:
+```xml
+<updates deviceID="slave $MACADDR"><zoneUpdated/></updates>
+<updates deviceID="slave $MACADDR"><volumeUpdated/></updates>
+<updates deviceID="slave $MACADDR"><nowPlayingUpdated/></updates>
+```
+When a slave leaves, you'll see `<zoneUpdated/>` + `<nowPlayingUpdated/>`. The
+master also emits its own `<zoneUpdated/>` whenever a slave joins or leaves.
+
+---
+
+## Discovery details
+
+**SSDP** — M-SEARCH over UDP multicast port `1900` with the desired service
+type. Service types:
+- `urn:schemas-upnp-org:device:MediaRenderer:1` — audio players (SoundTouch speakers)
+- `urn:schemas-upnp-org:device:MediaServer:1` — media holders (app / music server)
+
+Service providers `NOTIFY` with `ssdp:alive` (USN = uuid, `Cache-control:
+max-age` ≥ 1800s) and `ssdp:byebye` on shutdown. Clients must track expiry and
+use the `Location` header address for follow-up calls.
+
+**mDNS / Bonjour / Zero-conf** — service types:
+- `_soundtouch._tcp.local` — general SoundTouch capabilities
+- `_raop._tcp.local` — AirPlay, if supported on that speaker
+
+Run both protocols for redundancy; port availability and multicast reachability
+vary across networks (VLANs, containers).

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,10 @@
 # Ignore source code
 src
 
+# Claude Code skills (incl. generated planning docs) and router
+.claude
+CLAUDE.md
+
 # ------------- Defaults ------------- #
 
 # gitHub actions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# CLAUDE.md
+
+`homebridge-soundtouchspeaker` — a TypeScript ESM dynamic-platform Homebridge
+plugin that controls Bose SoundTouch speakers over their local HTTP/XML +
+WebSocket API.
+
+## Use the skills
+
+This repo's working knowledge lives in `.claude/skills/`. Consult the relevant
+skill **before** acting — don't rely on memory for these:
+
+- **coding-conventions** — read before writing or editing **any** TypeScript
+  source or test. Covers the ESM `.js`-import rule (a frequent runtime footgun),
+  lint/format, the Jest + SWC setup, logging, and the typecheck+lint+test gate.
+- **homebridge-developer** — plugin architecture, accessories, characteristics,
+  config flow, local run/debug, and Homebridge verified-plugin compliance.
+- **soundtouch-api-expert** — the Bose SoundTouch HTTP/XML + WebSocket protocol
+  and how it maps to `src/devices/SoundTouch/api/`.
+- **architect** (`/architect`) — plan and track a new feature; owns the
+  branching/release flow (conventional commits, semantic-release
+  `latest`→`dev`→`beta`). See also `CONTRIBUTING.md`.


### PR DESCRIPTION
## Summary

- Adds four skills under `.claude/skills/` that encode project knowledge so conventions, architecture, and protocol details aren&#39;t re-derived from scratch each session
- Adds `CLAUDE.md` as an always-loaded router that points to the right skill before touching any TypeScript
- Updates `.npmignore` so `.claude/` and `CLAUDE.md` are excluded from the npm tarball

### Skills introduced

| Skill | Owns |
| --- | --- |
| `coding-conventions` | TS/ESM `.js`-import rule, lint/format/knip, Jest+SWC setup, `FormattedLogger`, done gate |
| `homebridge-developer` | Plugin architecture, characteristic pattern, config flow, run/debug, verified-plugin compliance |
| `soundtouch-api-expert` | Bose SoundTouch HTTP/XML + WebSocket protocol; full endpoint catalog in `api-reference.md` |
| `architect` | `/architect` slash command — explores code, writes a tracked plan with Decisions &amp; findings log and `cancelled` status |

`homebridge-developer` was refactored to remove generic conventions (now owned by `coding-conventions`) and gain explicit cross-links to the other skills.

## Test plan

- [ ] `npm run lint &amp;&amp; npm run build &amp;&amp; npm test` green (markdown-only additions)
- [ ] `npm pack --dry-run` — confirm `.claude/` and `CLAUDE.md` absent from file list
- [ ] `/architect ` in a new session produces a grounded plan referencing real file paths