### PR TITLE
chore: add feature plans and refine skill trigger descriptions

### DIFF
--- a/.claude/skills/architect/SKILL.md
+++ b/.claude/skills/architect/SKILL.md
@@ -1,6 +1,16 @@
 ---
 name: architect
-description: Plan and track a new feature rollout for this Homebridge SoundTouch plugin. Use when the user runs /architect with a feature idea — explores the relevant code, produces an implementation plan tailored to this repo's conventions, and writes it to a tracked checklist file in the skill's own plans/ directory that gets updated as the work proceeds.
+description: >-
+  Plan and track feature implementation for this Homebridge SoundTouch plugin.
+  Use when the user runs /architect, asks how to implement a feature, wants an
+  approach for adding new functionality ("how should I add X", "what's the best
+  way to implement Y", "I want to build Z", "where do I start with X"). Also
+  use when continuing work on an existing plan or when any architectural
+  question comes up about this repo. Explores the relevant code first, produces
+  an implementation plan tailored to this repo's conventions, and writes it to a
+  tracked checklist file that stays up to date as work proceeds. Don't rely on
+  memory for file locations or conventions — always read the plan and relevant
+  skills fresh.
 ---
 
 # Architect — plan & track feature rollouts

--- a/.claude/skills/architect/plans/01-accessory-type-switch-or-lightbulb.md
+++ b/.claude/skills/architect/plans/01-accessory-type-switch-or-lightbulb.md
@@ -1,0 +1,103 @@
+---
+feature: Configurable accessory type — Switch or Lightbulb
+status: planned # planned | in-progress | done | cancelled
+date: 2026-06-19
+branch: feat/accessory-type
+commit-type: feat
+---
+
+# Configurable accessory type — Switch or Lightbulb
+
+## Context
+
+Today every speaker is exposed as a HomeKit **Switch** with a single `On`
+characteristic (power), hardcoded in
+`SoundTouchSpeakerPlatformAccessory.createAccessory` (`:71`). We want the user to
+choose, per speaker (with a global default), whether a speaker appears as a
+**Switch** (on/off only — current behavior) or a **Lightbulb** (on/off **and**
+volume via Brightness — see plan 02).
+
+This plan delivers only the **accessory-type plumbing + the Lightbulb service
+shell**. The Brightness/volume characteristic itself is plan 02, which depends on
+this. Default must stay `switch` so existing installs are unchanged.
+
+## Decisions & findings
+
+| Date | Decision / finding | Rationale / evidence | Alternatives rejected |
+| --- | --- | --- | --- |
+| 2026-06-19 | `accessoryType` is per-accessory with a global default; default `switch` | No surprise for existing installs on upgrade | Defaulting to `lightbulb` — silently changes every current user's accessory |
+| 2026-06-19 | Keep the `On` characteristic on both Switch and Lightbulb | Lightbulb also exposes `On`; reuses `SoundTouchSpeakerOnCharacteristic` unchanged | A separate power class per type |
+| 2026-06-19 | Finding: service type is hardcoded to Switch in `createAccessory` (`SoundTouchSpeakerPlatformAccessory.ts:71`) | Single switch-point to branch on | — |
+| 2026-06-19 | Finding: `flattenAccessoryConfiguration` copies all keys, but `DeviceConfiguration.create`/`fromAccessoryConfiguration` copy named fields only | New config fields must be threaded through `DeviceConfiguration` explicitly | — |
+| 2026-06-19 | Finding: changing an accessory's type leaves an orphan service (different `getServiceName`) | Requires explicit pruning — see checklist | — |
+
+## If cancelled
+
+> Only fill this in when `status: cancelled`. Leave empty otherwise.
+
+## Affected areas
+
+- `src/ExternalPlatformConfig.ts` — add `accessoryType?: 'switch' | 'lightbulb'`
+  to `AccessoryConfig` and to `GlobalConfig` (so a global default flows through
+  `flattenAccessoryConfiguration`, which already copies all non-undefined keys).
+- `src/devices/SoundTouch/SoundTouchDeviceConfiguration.ts` — add a readonly
+  `accessoryType` (default `'switch'`); thread it through the constructor,
+  `fromAccessoryConfiguration`, and `create` (these copy named fields explicitly,
+  so it won't propagate automatically).
+- `src/devices/SoundTouch/SoundTouchDevice.ts` — `getOrCreateDeviceConfiguration`
+  builds `DeviceConfiguration` for discovered devices; pass `accessoryType`
+  through its `create`/`fromAccessoryConfiguration` calls.
+- `src/PlatformConfiguration.ts` — `fromExternalConfiguration` builds configs;
+  ensure `accessoryType` (global → per-accessory) reaches `DeviceConfiguration`.
+- `src/accessories/services/SoundTouchSpeakerCharacteristic.ts` — extend the
+  `ServiceType` enum (e.g. add a `LIGHTBULB` member) used for the service name/subtype.
+- `src/accessories/SoundTouchSpeakerPlatformAccessory.ts` — in `createAccessory`,
+  pick `platform.service.Lightbulb` vs `platform.service.Switch` from
+  `device.configuration.accessoryType`. The `On` characteristic stays on both
+  (Lightbulb also has `On`).
+- `config.schema.json` — add an `accessoryType` enum/select under both
+  `accessories.items.properties` and `global.properties`.
+
+## Conventions for this change
+
+- **Commit type:** `feat:` → minor release.
+- **Config schema touched:** yes — `config.schema.json` + `ExternalPlatformConfig`
+  + `DeviceConfiguration`, with matching tests (per **homebridge-developer** config-flow).
+- **Tests to add/update:** `src/__tests__/PlatformConfiguration.test.ts`,
+  `src/devices/SoundTouch/__tests__/SoundTouchDeviceConfiguration.test.ts`,
+  `src/__tests__/ExternalPlatformConfig.test.ts` — assert default `switch`, global
+  default, and per-accessory override.
+- Follow the **coding-conventions** skill (ESM `.js` imports, lint/format, the
+  typecheck+lint+test gate).
+- **Target branch:** `dev` (squash-merged; PR title is the released commit message).
+
+## Implementation checklist
+
+- [ ] Add `accessoryType` to `AccessoryConfig` + `GlobalConfig`
+- [ ] Add `accessoryType` (default `switch`) to `DeviceConfiguration` and thread
+      through `create` / `fromAccessoryConfiguration` / constructor
+- [ ] Pass `accessoryType` through `PlatformConfiguration.fromExternalConfiguration`
+      and `SoundTouchDevice.getOrCreateDeviceConfiguration`
+- [ ] Extend `ServiceType`; branch service creation in `createAccessory`
+- [ ] **Prune stale service on type change:** when a cached accessory switches
+      Switch↔Lightbulb the old service lingers (different `getServiceName`); remove
+      the now-unused service in `ensureAccessoryService`/`createAccessory` so HomeKit
+      doesn't show a dead tile
+- [ ] Add `accessoryType` to `config.schema.json` (accessory + global)
+- [ ] Add/update tests
+
+## Verification
+
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] `npm test`
+- [ ] `npm run watch` — in `test/hbConfig/config.json` set one accessory to
+      `lightbulb`, one to default; confirm a Lightbulb vs Switch tile appears and
+      both toggle power. Flip an accessory's type and restart; confirm no orphan
+      service remains (delete `test/hbConfig/accessories/cachedAccessories` to also
+      test a clean install).
+
+## PR / release notes
+
+- **PR title:** `feat: let each speaker be a Switch or a Lightbulb accessory`
+- **Targets:** `dev`

--- a/.claude/skills/architect/plans/02-volume-control.md
+++ b/.claude/skills/architect/plans/02-volume-control.md
@@ -1,0 +1,117 @@
+---
+feature: Volume control — Speaker service (Switch mode) and Lightbulb Brightness (Lightbulb mode)
+status: planned # planned | in-progress | done | cancelled
+date: 2026-06-19
+updated: 2026-06-20
+branch: feat/volume-control
+commit-type: feat
+---
+
+# Volume control — Speaker service (Switch) and Lightbulb Brightness (Lightbulb)
+
+## Context
+
+Expose speaker volume in HomeKit for both accessory types:
+
+- **Switch mode (default, ships first):** add a linked **Speaker** service with a
+  `Volume` characteristic (0–100). This is a separate tile in the Home app,
+  independent of the On/Off switch. No dependency on plan 01.
+- **Lightbulb mode (plan 01 prerequisite):** expose volume via the Lightbulb's
+  `Brightness` characteristic (0–100). `Brightness 0` powers the speaker off;
+  raising from 0 powers it back on.
+
+The API layer is already complete: `api.getVolume()` returns
+`{ target, actual, isMuted }` (`src/devices/SoundTouch/api/volume.ts`) and
+`api.setVolume(value)` POSTs `/volume` (`src/devices/SoundTouch/api/api.ts:69`).
+This is purely HomeKit wiring — no protocol work.
+
+**Implementation order:** plan 02 ships before plan 01. The Switch/Speaker path
+works independently. The Lightbulb/Brightness path is wired in plan 02 but
+activates only once plan 01 enables the Lightbulb accessory type.
+
+## Decisions & findings
+
+| Date | Decision / finding | Rationale / evidence | Alternatives rejected |
+| --- | --- | --- | --- |
+| 2026-06-19 | Lightbulb: Volume = `Brightness` 0–100; `Brightness 0` ⇒ power off | Explicit product decision | Brightness 0 = mute but stay powered on |
+| 2026-06-19 | Finding: the API already implements `getVolume`/`setVolume` | No protocol work; pure HomeKit wiring | — |
+| 2026-06-19 | Finding: the `On` setter sleeps 5s in `finally` (`SoundTouchSpeakerOnCharacteristic.ts:66`) | A near-simultaneous volume set can race; needs reconciling/debounce | — |
+| 2026-06-20 | Switch mode: HAP `Speaker` service + `Volume` characteristic as a separate linked service | Semantically correct; appears as its own tile; no dependency on plan 01's Lightbulb plumbing | Fan/RotationSpeed — semantically wrong; Lightbulb-only volume — leaves Switch users without volume control |
+| 2026-06-20 | Plan 02 ships before plan 01; dependency on plan 01 removed | Volume should be available immediately on default Switch accessories | Waiting for plan 01 before shipping volume |
+| 2026-06-20 | Two characteristic classes: `SoundTouchSpeakerVolumeCharacteristic` (Speaker/Volume) and the Lightbulb Brightness wiring | Different services, different power-off semantics; cleaner to keep them separate than to parameterise one class | One class parameterised by service/characteristic type — more complex with marginal reuse |
+
+## If cancelled
+
+> Only fill this in when `status: cancelled`. Leave empty otherwise.
+
+## Affected areas
+
+- **New** `src/accessories/services/SoundTouchSpeakerVolumeCharacteristic.ts` —
+  characteristic class for the **Speaker** service path. Takes
+  `{ service, device, platform, accessory }`, grabs
+  `platform.characteristic.Volume`, binds `onSet`/`onGet`, implements
+  `init()`/`refresh()` (update only when changed via `characteristic.updateValue`),
+  exposes static async `create`. Logs via `this.log`.
+- **New** `src/accessories/services/SoundTouchSpeakerBrightnessCharacteristic.ts` —
+  characteristic class for the **Lightbulb** path. Same pattern but uses
+  `platform.characteristic.Brightness`; additionally maps `0 → power off` and
+  `>0 from off → power on` (coordinates with `SoundTouchSpeakerOnCharacteristic`).
+- `src/accessories/SoundTouchSpeakerPlatformAccessory.ts`:
+  - **Switch path:** add a linked Speaker service and wire
+    `SoundTouchSpeakerVolumeCharacteristic` to it.
+  - **Lightbulb path (plan 01 gate):** add `SoundTouchSpeakerBrightnessCharacteristic`
+    to the Lightbulb service alongside `On`.
+
+## Conventions for this change
+
+- **Commit type:** `feat:` → minor release.
+- **Config schema touched:** no new fields; volume is always-on per accessory type.
+- **Tests to add/update:**
+  - `src/accessories/services/__tests__/SoundTouchSpeakerVolumeCharacteristic.test.ts`
+    — volume get/set, HAP error on device failure.
+  - `src/accessories/services/__tests__/SoundTouchSpeakerBrightnessCharacteristic.test.ts`
+    — volume↔brightness mapping, `0 ⇒ off`, `>0-from-off ⇒ on`, race condition
+    with the `On` setter.
+- Follow **coding-conventions** (ESM `.js` imports, lint/format, the
+  typecheck+lint+test gate) and the characteristic pattern in **homebridge-developer**.
+- **Target branch:** `dev`.
+
+## Design notes / risks
+
+- **On + Brightness interplay (Lightbulb only):** HomeKit often sends `On` and
+  `Brightness` together (e.g. turning on sends `On=true` then `Brightness=last`).
+  Treat `setBrightness(0)` as power-off; `setBrightness(>0)` as set-volume
+  (powering on first if currently off). Guard against fighting the `On` setter's
+  5s settle sleep (`SoundTouchSpeakerOnCharacteristic.ts:66`).
+- **Speaker service on Switch:** the Speaker service appears as a linked tile in
+  HomeKit, not embedded in the Switch tile. Confirm the UX is acceptable on a real
+  device before finalising.
+- `getVolume().actual` is the live value for both `refresh()` paths.
+
+## Implementation checklist
+
+- [ ] Add `SoundTouchSpeakerVolumeCharacteristic` (Speaker service, Volume 0–100)
+- [ ] Wire Speaker service + volume characteristic into `createAccessory` for the
+      Switch path
+- [ ] Add `SoundTouchSpeakerBrightnessCharacteristic` (Lightbulb Brightness ↔
+      volume, 0 = power off)
+- [ ] Wire Brightness characteristic into `createAccessory` for the Lightbulb path
+      (behind the plan 01 `accessoryType` gate)
+- [ ] Reconcile On/Brightness ordering with `SoundTouchSpeakerOnCharacteristic`
+- [ ] Add tests for both characteristic classes
+
+## Verification
+
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] `npm test`
+- [ ] `npm run watch` — with a **Switch** speaker: confirm the Speaker tile appears,
+      dragging volume tracks the speaker, and external volume changes reflect back.
+- [ ] `npm run watch` — with a **Lightbulb** speaker (after plan 01): drag brightness,
+      confirm volume tracks; set to 0, confirm power off; raise from 0, confirm power
+      on.
+
+## PR / release notes
+
+- **PR title:** `feat: add volume control via Speaker service and Lightbulb brightness`
+- **Targets:** `dev`

--- a/.claude/skills/architect/plans/02-volume-control.md
+++ b/.claude/skills/architect/plans/02-volume-control.md
@@ -39,6 +39,7 @@ activates only once plan 01 enables the Lightbulb accessory type.
 | 2026-06-20 | Switch mode: HAP `Speaker` service + `Volume` characteristic as a separate linked service | Semantically correct; appears as its own tile; no dependency on plan 01's Lightbulb plumbing | Fan/RotationSpeed — semantically wrong; Lightbulb-only volume — leaves Switch users without volume control |
 | 2026-06-20 | Plan 02 ships before plan 01; dependency on plan 01 removed | Volume should be available immediately on default Switch accessories | Waiting for plan 01 before shipping volume |
 | 2026-06-20 | Two characteristic classes: `SoundTouchSpeakerVolumeCharacteristic` (Speaker/Volume) and the Lightbulb Brightness wiring | Different services, different power-off semantics; cleaner to keep them separate than to parameterise one class | One class parameterised by service/characteristic type — more complex with marginal reuse |
+| 2026-06-20 | WebSocket push used for external volume changes — no new WS infrastructure needed | The speaker sends a `volumeUpdated` tickle on port 8080 (existing per-device WebSocket connection) whenever volume changes externally. The characteristic's `refresh()` listens for this event and re-fetches via `api.getVolume()`, then pushes the new value to HomeKit via `characteristic.updateValue`. The WS connection is already open; volume just needs to subscribe to the existing event emitter. | Polling on a timer — less responsive and wastes requests; opening a second WebSocket — redundant |
 
 ## If cancelled
 

--- a/.claude/skills/architect/plans/03-source-selection.md
+++ b/.claude/skills/architect/plans/03-source-selection.md
@@ -1,0 +1,111 @@
+---
+feature: Source selection
+status: planned # planned | in-progress | done | cancelled
+date: 2026-06-19
+branch: feat/source-selection
+commit-type: feat
+---
+
+# Source selection
+
+## Context
+
+Expose the speaker's available **sources** in HomeKit and let the user switch
+between them. The API layer is already complete: `api.getSources()` returns the
+list (`src/devices/SoundTouch/api/source.ts` — each `Source` has `source`,
+`sourceAccount`, `status`), `api.selectSource(contentItem)` POSTs `/select`
+(`api.ts:131`), and `api.getSource()` returns the current source name from
+`/now_playing`. No protocol work — this is HomeKit wiring.
+
+Chosen representation: **Television service + one InputSource per source**, with
+`selectSource()` driven by `ActiveIdentifier`. ⚠️ This is the riskiest item — see
+the HomeKit reality check before committing to it.
+
+## Decisions & findings
+
+| Date | Decision / finding | Rationale / evidence | Alternatives rejected |
+| --- | --- | --- | --- |
+| 2026-06-19 | Provisional: Television + InputSource for source selection, **pending a spike** | The "correct" HomeKit input picker | Per-source Switches (kept as documented Plan B); read-only current-source |
+| 2026-06-19 | Finding: the API already implements `getSources`/`selectSource`/`getSource` | No protocol work; pure HomeKit wiring | — |
+| 2026-06-19 | Risk/finding: Televisions generally need external publishing, `Active` clashes with our `On` power model, and the picker UX is buried | Could force the Plan-B fallback — resolve in the spike before building out | — |
+
+## If cancelled
+
+> Only fill this in when `status: cancelled`. Leave empty otherwise.
+
+## HomeKit reality check (resolve via a spike FIRST)
+
+The Television/InputSource pattern is the *correct* HomeKit input picker, but has
+real caveats that need verifying on a real device + the Home app before building
+out:
+
+1. **Televisions usually must be published as external accessories**
+   (`api.publishExternalAccessories(...)`), not as part of the bridged platform —
+   multiple TVs on one bridge are known to misbehave. This plugin currently only
+   bridges accessories, so this is new wiring in `discoverDevices`.
+2. **Power model clash:** a Television has its own `Active` characteristic for
+   power, which overlaps the Switch/Lightbulb `On` we already use. Decide whether
+   the Television is a *separate* accessory (input only) or replaces the power
+   surface — don't drive power from two services inconsistently.
+3. **UX:** the input picker lives in the Home app's accessory settings / the
+   Control-Center Remote, not as front-and-center tiles. Confirm it's acceptable.
+
+**Fallback if the spike shows the TV path is too rough:** expose each source as a
+its own Switch (radio-button style — turning one on calls `selectSource`, and the
+others turn off). Simpler, fits the existing Switch model, reliably works; cost is
+multiple tiles per speaker. Keep this as the documented Plan B.
+
+## Affected areas
+
+- **New** `src/accessories/services/SoundTouchSpeakerSourceCharacteristic.ts` (or a
+  small service wrapper) — build the Television + linked InputSource services from
+  `api.getSources()` (filter `status === READY`), map each to an identifier, set
+  `ConfiguredName`/`InputSourceType`, and on `ActiveIdentifier` `onSet` call
+  `api.selectSource({ source, sourceAccount })`. `refresh()`/`onGet` reflects the
+  current source from `api.getSource()`.
+- `src/accessories/SoundTouchSpeakerPlatformAccessory.ts` — create/link the
+  Television + InputSource services; if published externally, coordinate with the
+  platform (below).
+- `src/platform.ts` — if external publishing is required, add
+  `publishExternalAccessories` wiring in `discoverDevices` and keep cache
+  reuse/pruning correct for it.
+- Possibly `config.schema.json` — only if source selection becomes opt-in
+  (e.g. `enableSourceSelection`); decide during the spike.
+
+## Conventions for this change
+
+- **Commit type:** `feat:` → minor release.
+- **Config schema touched:** maybe (decide in spike); if so, mirror in
+  `config.schema.json` + config classes + tests.
+- **Tests to add/update:** unit-test source→identifier mapping and the
+  `selectSource` `ContentItem` construction (pure logic); HAP/Television wiring is
+  hard to unit-test, so verify on device.
+- Use **soundtouch-api-expert** for the `/sources` + `/select` payload shapes and
+  **homebridge-developer** for the verified-plugin / real-HAP-types rules; follow
+  **coding-conventions** for style/tests.
+- **Target branch:** `dev`.
+
+## Implementation checklist
+
+- [ ] **Spike:** prototype a Television+InputSource on a real speaker; confirm the
+      caveats above are acceptable. Decide TV-path vs per-source-Switch fallback
+- [ ] Build InputSources from `getSources()` (filter `READY`); map identifiers
+- [ ] `ActiveIdentifier` onSet → `selectSource({ source, sourceAccount })`
+- [ ] Reflect current source on refresh/onGet via `getSource()`
+- [ ] External-accessory publishing wiring (if TV path) + cache correctness
+- [ ] Decide/add any opt-in config + schema
+- [ ] Add tests for mapping + ContentItem construction
+
+## Verification
+
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] `npm test`
+- [ ] `npm run watch` — on a real speaker: confirm sources appear, selecting one
+      changes the playing source, and the current source reflects back. Exercise
+      both a fresh install and a cached accessory.
+
+## PR / release notes
+
+- **PR title:** `feat: add source selection`
+- **Targets:** `dev`

--- a/.claude/skills/architect/plans/04-progressive-web-app.md
+++ b/.claude/skills/architect/plans/04-progressive-web-app.md
@@ -1,0 +1,178 @@
+---
+feature: Progressive Web App — WiFi provisioning, group management, Homebridge config sync
+status: planned # planned | in-progress | done | cancelled
+date: 2026-06-19
+updated: 2026-06-20
+branch: feat/pwa
+commit-type: feat
+---
+
+# Progressive Web App — WiFi provisioning (phase 1), with group management and Homebridge config sync planned
+
+## Context
+
+A mobile-first Progressive Web App that can be pinned to a phone's home screen.
+Phase 1: walk the user through joining a SoundTouch speaker to a WiFi network
+(the initial out-of-box setup flow). Later phases: dynamically manage multi-room
+speaker zones and push new Homebridge plugin config (e.g. groups, device IPs)
+without editing JSON by hand.
+
+This is architecturally distinct from the Homebridge plugin — it's a setup/
+management tool, not a HomeKit control path. It likely lives as a new `web/`
+workspace in this repo (or a separate repo), served either from GitHub Pages or
+from a lightweight HTTP server embedded in the plugin.
+
+## Decisions & findings
+
+| Date | Decision / finding | Rationale / evidence | Alternatives rejected |
+| --- | --- | --- | --- |
+| 2026-06-19 | **Critical finding: the SoundTouch v1.1 public API has NO documented WiFi provisioning endpoints** | Full scan of `api-reference.md` — only control/status endpoints are documented; `/info` exposes read-only `<networkInfo>` but offers no write path | Assuming undocumented endpoints exist without verification |
+| 2026-06-20 | Finding: speaker creates a "Bose SoundTouch Wi-Fi Network" hotspot during setup mode | Bose support docs confirm this SSID | BLE provisioning (not used by SoundTouch) |
+| 2026-06-20 | Finding: setup mode is triggered by a hardware button combo — **PRESET 2 + VOLUME DOWN**, hold until Wi-Fi indicator turns solid amber/yellow | Bose support (CA) for SoundTouch 10/20/30/Portable; some models differ | Software-triggered setup mode — not possible; user must press buttons |
+| 2026-06-20 | **Correction: setup web UI IP is `192.0.2.1`, not `192.168.1.1`** | Community report (Reddit) for SoundTouch 20 manual recovery explicitly uses `http://192.0.2.1`; earlier research citing `192.168.1.1` was from a different Bose product (LS135 III soundbar) and should not be relied upon for SoundTouch | `192.168.1.1` — likely wrong for SoundTouch speakers |
+| 2026-06-20 | Finding: standard SoundTouch HTTP API (port 8090) is also available at the setup IP during setup mode | Bose support (DE) instructs visiting `http://192.168.1.1:8090/info` during setup — same pattern expected at `192.0.2.1:8090` | — |
+| 2026-06-20 | Finding: browser-based setup UI at `http://192.0.2.1` (port 80) allows WiFi network selection and credential entry | Community-confirmed; this is the manual recovery path when the SoundTouch app fails | — |
+| 2026-06-20 | **Key unknown: the provisioning API behind `http://192.0.2.1` is not documented** | The web UI exists and submits WiFi credentials, but the specific HTTP endpoints, methods, and payloads it uses are unconfirmed — must be reverse-engineered via browser devtools during spike | Treating the web UI URL alone as sufficient to implement the PWA |
+| 2026-06-20 | WiFi provisioning spike scoped to HTTP only — BLE ruled out for SoundTouch | Research confirms HTTP; no BLE evidence found for SoundTouch provisioning | BLE / Web Bluetooth approach |
+| 2026-06-20 | Finding: older SoundTouch speakers only support 2.4 GHz and WPA2-Personal | Bose troubleshooting docs; affects UI copy — the PWA must warn users to confirm network compatibility before provisioning | — |
+| 2026-06-20 | Finding: Bose SoundTouch cloud platform discontinued (2026); local WiFi operation continues | The Verge (2026); local HTTP API and this plugin are unaffected | — |
+| 2026-06-19 | Phase 2 (group management) IS possible with documented API: `/getZone`, `/setZone`, `/addZoneSlave`, `/removeZoneSlave` | All four endpoints are in the v1.1 spec and implemented in `src/devices/SoundTouch/api/zone.ts` | — |
+| 2026-06-19 | Phase 3 (Homebridge config sync) requires an HTTP API endpoint exposed by the plugin | The Homebridge Config UI handles plugin settings via `config.schema.json` in-process; direct config edits need `api.user.storagePath()` and must not race Homebridge's own write | Writing config outside Homebridge storage dir — violates verified-plugin rules |
+| 2026-06-19 | PWA must work offline during the provisioning flow | During setup the phone is on the speaker's hotspot, not the home network — the PWA cannot reach the internet or the Homebridge host | Server-side-rendered app that requires constant connectivity |
+| 2026-06-20 | **Hosting resolved: embedded HTTP server in the plugin** | Research confirms Homebridge plugins can run their own HTTP server inside the Homebridge process (same pattern as `homebridge-http-webhooks`, `homebridge-mqttthing`). Plugin starts Express on a configurable port in `didFinishLaunching`; serves `web/dist/` statically. Phone installs the PWA from the plugin URL while on the home network, service worker caches it, then it operates offline during the provisioning hotspot step. | GitHub Pages — requires internet during install, no control over hosting; assumes user has internet access during provisioning UX |
+| 2026-06-19 | Phase 2 (group management) IS possible with documented API: `/getZone`, `/setZone`, `/addZoneSlave`, `/removeZoneSlave` | All four endpoints are in the v1.1 spec and implemented in `src/devices/SoundTouch/api/zone.ts` | — |
+| 2026-06-19 | Phase 3 (Homebridge config sync) requires an HTTP API endpoint exposed by the plugin | The Homebridge Config UI handles plugin settings via `config.schema.json` in-process; direct config edits need `api.user.storagePath()` and must not race Homebridge's own write | Writing config outside Homebridge storage dir — violates verified-plugin rules |
+| 2026-06-19 | PWA must work offline during the provisioning flow | During setup the phone is on the speaker's hotspot, not the home network — the PWA cannot reach the internet or the Homebridge host | Server-side-rendered app that requires constant connectivity |
+| 2026-06-20 | **Hosting resolved: embedded HTTP server in the plugin** | Research confirms Homebridge plugins can run their own HTTP server inside the Homebridge process (same pattern as `homebridge-http-webhooks`, `homebridge-mqttthing`). Plugin starts Express on a configurable port in `didFinishLaunching`; serves `web/dist/` statically. Phone installs the PWA from the plugin URL while on the home network, service worker caches it, then it operates offline during the provisioning hotspot step. | GitHub Pages — requires internet during install, no control over hosting; assumes user has internet access during provisioning UX |
+
+## If cancelled
+
+> Only fill this in when `status: cancelled`. Leave empty otherwise.
+
+## HomeKit / provisioning reality check (resolve via spikes FIRST)
+
+### Spike A — WiFi provisioning (block on phase 1)
+
+**Known (from research, 2026-06-20):**
+- Setup mode: hold **PRESET 2 + VOLUME DOWN** until Wi-Fi indicator turns solid
+  amber/yellow. (Some models differ — SoundTouch 20 alternate: hold AUX 15s.)
+- Speaker broadcasts a "Bose SoundTouch Wi-Fi Network" hotspot.
+- Setup web UI is at **`http://192.0.2.1`** (port 80). Note: `192.168.1.1` from
+  earlier research was a different Bose product — do not use.
+- Standard SoundTouch HTTP API (port 8090) is also available at `192.0.2.1:8090`
+  during setup mode.
+- Mechanism is HTTP, not BLE.
+- Speakers are 2.4 GHz only and require WPA2-Personal.
+- WiFi-only reset (without full factory reset): hold **BLUETOOTH + VOLUME DOWN**.
+- Full factory reset: hold **PRESET 1 + VOLUME DOWN** until restart.
+
+**Still unknown — must resolve on a real speaker:**
+1. **What HTTP calls does `http://192.0.2.1` actually make?** Connect a laptop
+   to the hotspot, open browser devtools (Network tab), walk through WiFi setup.
+   Capture: endpoints, methods, request/response bodies, any tokens or cookies.
+2. **Does the UI scan for available networks** (i.e. is there a network-list
+   endpoint), or does the user type the SSID manually?
+3. **What happens after credentials are submitted?** Does the speaker drop the
+   hotspot immediately? How long does it take to join the home network?
+4. **Transition UX:** Does the user need to manually reconnect their phone, or
+   does the phone drop back to the home network automatically?
+
+### Spike B — Homebridge config write path (block on phase 3)
+
+1. Confirm `api.user.storagePath()` gives the writable path and that atomically
+   updating `config.json` there (write-then-rename) doesn't corrupt Homebridge
+   state.
+2. Check whether Homebridge Config UI X watches for external config changes and
+   reloads — or whether a restart is always required after a config push.
+
+## Affected areas
+
+### Phase 1 — WiFi provisioning
+
+- **New `web/` directory** (monorepo workspace or standalone) — the PWA source.
+  Suggest Vite + vanilla TS or React; `manifest.json` + service worker for
+  installability and offline caching. Build output goes to `web/dist/`.
+- `package.json` — add `web` workspace if monorepo; add a `build:web` script.
+- Possibly **a new `src/server/`** — a minimal Express/Fastify server (if hosted
+  in-plugin rather than GitHub Pages) to serve `web/dist/` on a configurable
+  port; started in `platform.ts` `didFinishLaunching`; reads port from config.
+- `config.schema.json` + config classes — `webPort` (opt-in, default off) if the
+  embedded server path is chosen.
+
+### Phase 2 — Group management (zone API)
+
+- The PWA adds a "Groups" screen calling the Homebridge plugin's REST API (or
+  talking directly to speakers if the phone is on the same LAN).
+- `src/devices/SoundTouch/api/zone.ts` already implements `getZone`, `setZone`,
+  `addZoneSlave`, `removeZoneSlave` — these are the backend calls.
+- If surfaced via the plugin's REST API: new routes in `src/server/`.
+
+### Phase 3 — Homebridge config sync
+
+- New REST endpoint(s) in `src/server/` to GET/PATCH the plugin's platform block
+  in `config.json` (under `api.user.storagePath()`). Write atomically.
+- The PWA gains a "Settings" screen to edit speaker IPs, names, groups.
+
+## Conventions for this change
+
+- **Commit type:** `feat:` → minor release (for each phase PR).
+- **Config schema touched:** yes if embedded server is chosen — add `webPort`
+  (optional integer) to `GlobalConfig` / `config.schema.json` / `PlatformConfiguration`.
+- **Tests to add/update:** unit-test any server-side route logic; pure PWA UI is
+  not Jest-tested (use Playwright or manual verification). Config class tests in
+  `src/__tests__/PlatformConfiguration.test.ts` if `webPort` is added.
+- Follow **coding-conventions** for any TypeScript in `src/`; the `web/` workspace
+  may have its own toolchain (Vite, ESLint config) — document it in `web/README.md`
+  (contributor-facing, not published to npm users).
+- **Target branch:** `dev` (each phase as its own PR).
+
+## Implementation checklist
+
+### Spike (prerequisite — block all phases on this)
+- [ ] **Spike A:** On a real SoundTouch speaker, document the setup-mode hotspot
+      SSID, IP, and any HTTP provisioning endpoints (port, method, payload). If BLE
+      is the actual mechanism, document that and evaluate Web Bluetooth feasibility
+      on iOS Safari before committing to phase 1.
+
+### Phase 1 — WiFi provisioning PWA
+- [ ] Spike A resolved — provisioning mechanism confirmed
+- [ ] Scaffold `web/` PWA (Vite + TS, `manifest.json`, service worker, app icon)
+- [ ] Implement WiFi scan UI → calls speaker hotspot endpoint
+- [ ] Implement credential submission → speaker connects to home network
+- [ ] Handle the hotspot→home-network transition gracefully in the UI
+- [ ] Decide and implement hosting: GitHub Pages static or embedded plugin server
+- [ ] If embedded server: add `webPort` config + `src/server/` Express routes
+- [ ] Add `build:web` script and CI step
+
+### Phase 2 — Group management
+- [ ] PWA "Groups" screen: discover speakers (via Homebridge REST API or direct
+      mDNS on same LAN), show current zones
+- [ ] Create/update/delete zones → `setZone` / `addZoneSlave` / `removeZoneSlave`
+- [ ] REST routes in `src/server/` proxying the zone API calls
+
+### Phase 3 — Homebridge config sync
+- [ ] Spike B: confirm config write path safety
+- [ ] REST GET/PATCH routes for plugin config (`src/server/`)
+- [ ] Atomic config write (write-then-rename in `api.user.storagePath()`)
+- [ ] PWA "Settings" screen
+- [ ] Trigger Homebridge reload or surface restart prompt after config push
+
+## Verification
+
+- [ ] `npm run lint`
+- [ ] `npm run build` (plugin + web)
+- [ ] `npm test`
+- [ ] **Phase 1:** On a real speaker in setup mode, run through the full
+      provisioning flow on an iOS + Android device; confirm PWA installs from home
+      screen and works offline on the speaker's hotspot.
+- [ ] **Phase 2:** Create, modify, and destroy a zone from the PWA; confirm
+      Homebridge reflects the change.
+- [ ] **Phase 3:** Push a config change from the PWA; restart Homebridge; confirm
+      the new config takes effect.
+
+## PR / release notes
+
+- **Phase 1 PR title:** `feat: add PWA for SoundTouch WiFi provisioning`
+- **Phase 2 PR title:** `feat: add group management to provisioning PWA`
+- **Phase 3 PR title:** `feat: add Homebridge config sync to provisioning PWA`
+- **Targets:** `dev`

--- a/.claude/skills/coding-conventions/SKILL.md
+++ b/.claude/skills/coding-conventions/SKILL.md
@@ -3,8 +3,12 @@ name: coding-conventions
 description: >-
   How code is written, formatted, built, and tested in this repo: TypeScript
   ESM import rules, the ESLint/Prettier/knip toolchain, the Jest + SWC test
-  setup, logging, and the checks that gate "done". Use before writing or
-  editing any TypeScript source or test in this project.
+  setup, logging, and the checks that gate "done". Read this skill before
+  writing or editing ANY TypeScript source or test file — including bug fixes,
+  new features, refactors, and test changes. The single most common footgun:
+  missing .js extensions on relative imports compiles fine but silently breaks
+  at runtime under Homebridge. If you're about to touch a .ts file and haven't
+  read this skill yet, read it first.
 ---
 
 # Coding conventions
@@ -39,8 +43,10 @@ rather than restating this — keep style/build/test rules in this one place.
 | `npm test` (`npx jest`) | Run tests with coverage |
 | `npx jest <pattern>` | Run a subset |
 
-ESLint runs with zero tolerance for warnings; Prettier owns formatting (don't
-hand-format against it). `knip` keeps the dependency/export surface clean.
+ESLint runs with zero tolerance for warnings (`--max-warnings=0`). Prettier
+owns formatting — run `npm run format` to auto-write; don't hand-format against
+it. Run `npm run knip` after deleting or moving code to catch newly unused
+exports, files, or dependencies.
 
 ## Testing
 

--- a/.claude/skills/homebridge-developer/SKILL.md
+++ b/.claude/skills/homebridge-developer/SKILL.md
@@ -4,7 +4,13 @@ description: >-
   Conventions and workflows for developing this Homebridge plugin
   (homebridge-soundtouchspeaker). Use when implementing or modifying the
   platform, accessories, characteristics, or device API; writing or running
-  Jest tests; or building, running, and debugging the plugin locally.
+  Jest tests; building, running, or debugging the plugin locally; or
+  troubleshooting issues like accessories not appearing in the Home app,
+  cached accessories not updating, config not taking effect, HAP errors in
+  setters, or verified-plugin compliance. Also use when adding a new HomeKit
+  service or characteristic, handling discovery failures, or any question
+  about the platform/accessory lifecycle. Don't rely on memory for architecture
+  patterns — consult this skill any time you touch Homebridge-specific code.
 ---
 
 # Homebridge Plugin Developer
@@ -150,6 +156,24 @@ them, so don't regress them.
 `config.schema.json` · errors caught and logged (no raw throws on the
 Homebridge thread) · AccessoryInformation populated with a unique SerialNumber ·
 `npm run typecheck && npm run lint && npm test` all green.
+
+## Common issues & quick fixes
+
+**Accessory not appearing in the Home app after changes:**
+- Did you restart Homebridge? (`npm run watch` does this automatically on save.)
+- Is the UUID stable? If the UUID computation changed, Home sees a new accessory and the old one orphans. Fix UUID derivation first, then delete cached accessories.
+- Delete `test/hbConfig/accessories/cachedAccessories` and restart to force re-registration.
+
+**"Accessory disappeared" or stale accessories after config change:**
+- The stale-pruning loop in `discoverDevices()` removes accessories whose UUID isn't rediscovered. Check that the device's `id` (used for UUID generation) hasn't changed.
+- If you renamed a config field, the `PlatformConfiguration` transform may be dropping the accessor silently — check the `fromExternalConfiguration` logic.
+
+**HAP `SERVICE_COMMUNICATION_FAILURE` in the Home app:**
+- A setter threw a `HapStatusError` — expected behavior when the speaker is unreachable. Verify the device IP is reachable and the SoundTouch API is responding on port 8090.
+- If it's a new characteristic, check the `onSet`/`onGet` handlers are correctly bound and the error propagation follows the pattern in `SoundTouchSpeakerOnCharacteristic.ts`.
+
+**Discovery not finding a device:**
+- mDNS/Bonjour often fails across subnets, VLANs, or inside Docker. Bypass discovery entirely with an explicit `ip` (+ optional `port`, default `8090`) in the accessory config.
 
 ## Related skills
 

--- a/.claude/skills/soundtouch-api-expert/SKILL.md
+++ b/.claude/skills/soundtouch-api-expert/SKILL.md
@@ -6,7 +6,11 @@ description: >-
   notifications (port 8080, "gabbo" protocol), device discovery (SSDP/mDNS), or
   interpreting/constructing SoundTouch XML payloads for endpoints like
   /now_playing, /volume, /key, /select, /presets, /bass, /info, /getZone,
-  /setZone, and friends.
+  /setZone. Also use when writing or modifying any code under
+  src/devices/SoundTouch/api/, adding a new endpoint, debugging API responses,
+  or understanding device state changes via WebSocket. Always read the bundled
+  api-reference.md before writing or parsing any XML payload — don't guess at
+  field names, attribute shapes, or response structure.
 ---
 
 # SoundTouch Web API Expert


### PR DESCRIPTION
## Summary

- Adds four tracked feature plans under \`.claude/skills/architect/plans/\`:
  - \`01\` — Configurable accessory type (Switch or Lightbulb)
  - \`02\` — Volume control (Speaker service / Lightbulb Brightness)
  - \`03\` — Source selection (Television + InputSource, spike-gated)
  - \`04\` — Progressive Web App for WiFi provisioning and Homebridge config sync
- Refines skill \`description:\` frontmatter for more accurate auto-triggering
- Adds a common-issues troubleshooting section to the homebridge-developer skill

## Test plan

- [ ] No production code changed — no tests required
- [ ] Verify \`.npmignore\` excludes \`.claude/\` from the published package