### PR TITLE
fix: correct SoundTouch API spec mismatches

### DIFF
--- a/.claude/skills/coding-conventions/SKILL.md
+++ b/.claude/skills/coding-conventions/SKILL.md
@@ -62,6 +62,63 @@ exports, files, or dependencies.
   `const enum` gotcha) is Homebridge-specific — see the **homebridge-developer**
   skill.
 
+## TDD workflow (red → green → refactor)
+
+Write tests **before** the implementation for any new behaviour or bug fix:
+
+1. **Red** — write a failing test that captures the intended behaviour. Run it;
+   confirm it fails for the right reason (wrong output, not a compile error).
+2. **Green** — write the minimum code that makes the test pass. Resist the urge
+   to over-engineer here.
+3. **Refactor** — clean up the implementation (and test) while keeping the suite
+   green.
+
+For bug fixes, start by writing a test that reproduces the bug before touching
+production code.
+
+## BDD test structure
+
+Structure tests so they read as a living specification. Use Jest's
+`describe`/`it` to express **what** the unit does, not how it does it.
+
+```
+describe('ClassName or function name')
+  describe('method or scenario')
+    it('returns X when Y')
+    it('throws when Z')
+```
+
+Rules:
+- `describe` labels name the **subject** (`'NowPlayingParser'`, `'#parsePreset'`).
+- `it` labels name **observable behaviour** in plain English: `'returns null when
+  the content item is missing'`, not `'handles missing content item'` or
+  `'test 3'`.
+- Nest a second `describe` for distinct scenarios or preconditions
+  (`'when the device is in standby'`).
+- Structure each test as **Arrange → Act → Assert** with a blank line between
+  phases. Skip the "Arrange" block when setup is trivial (one-liner).
+
+```ts
+describe('VolumeParser', () => {
+  describe('#parse', () => {
+    it('returns the numeric value from the XML', () => {
+      const xml = '<volume><actualvolume>42</actualvolume></volume>';
+
+      const result = VolumeParser.parse(xml);
+
+      expect(result).toBe(42);
+    });
+
+    it('returns null when the actualvolume element is absent', () => {
+      expect(VolumeParser.parse('<volume/>')).toBeNull();
+    });
+  });
+});
+```
+
+Avoid `test('...')` — prefer `it('...')` so descriptions complete the sentence
+"it should …" naturally.
+
 ## Logging
 
 Log through the formatted logger (`src/utils/FormattedLogger.ts`) — `.debug`,

--- a/src/devices/SoundTouch/api/__tests__/api.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/api.test.ts
@@ -66,10 +66,10 @@ describe('API', () => {
       await expect(api.getInfo()).rejects.toBeInstanceOf(APIErrors);
     });
 
-    test('throws APIErrors when the response contains a single <Error>', async () => {
+    test('throws APIErrors when the response contains a single <error>', async () => {
       mock
         .onGet(`${BASE}/info`)
-        .reply(200, '<Error value="1" name="X" severity="Low">bad</Error>');
+        .reply(200, '<error value="1" name="X" severity="Low">bad</error>');
       await expect(api.getInfo()).rejects.toBeInstanceOf(APIErrors);
     });
 
@@ -146,7 +146,7 @@ describe('API', () => {
       '<time total="200">5</time></nowPlaying>';
 
     test('getNowPlaying parses a playing document', async () => {
-      mock.onGet(`${BASE}/now_playing`).reply(200, nowPlayingXml);
+      mock.onGet(`${BASE}/nowPlaying`).reply(200, nowPlayingXml);
       const np = await api.getNowPlaying();
       expect(np).toMatchObject({
         deviceId: 'DEV1',
@@ -157,7 +157,7 @@ describe('API', () => {
 
     test('getSource returns the source attribute', async () => {
       mock
-        .onGet(`${BASE}/now_playing`)
+        .onGet(`${BASE}/nowPlaying`)
         .reply(
           200,
           '<nowPlaying deviceID="DEV1" source="STANDBY"><ContentItem source="STANDBY"/></nowPlaying>'
@@ -165,17 +165,18 @@ describe('API', () => {
       await expect(api.getSource()).resolves.toBe('STANDBY');
     });
 
-    test('getNowPlaying returns undefined in STANDBY because art/time are absent', async () => {
-      // FLAG: nowPlayingFromElement treats <art> and <time> as required even
-      // though the NowPlaying interface marks them optional. A standby (or AUX)
-      // response with no art/time parses to undefined rather than a NowPlaying.
+    test('getNowPlaying parses a STANDBY response with no art or time', async () => {
       mock
-        .onGet(`${BASE}/now_playing`)
+        .onGet(`${BASE}/nowPlaying`)
         .reply(
           200,
           '<nowPlaying deviceID="DEV1" source="STANDBY"><ContentItem source="STANDBY"/></nowPlaying>'
         );
-      await expect(api.getNowPlaying()).resolves.toBeUndefined();
+      const np = await api.getNowPlaying();
+      expect(np).toBeDefined();
+      expect(np?.source).toBe('STANDBY');
+      expect(np?.art).toBeUndefined();
+      expect(np?.time).toBeUndefined();
     });
   });
 
@@ -227,6 +228,17 @@ describe('API', () => {
       await expect(api.setZone(zone)).resolves.toBe(true);
       expect(mock.history.post[0].data).toContain('master="M1"');
     });
+
+    test('setZone includes senderIPAddress when provided', async () => {
+      mock.onPost(`${BASE}/setZone`).reply(200, '<status>/setZone</status>');
+      const zone = {
+        master: 'M1',
+        members: [{ deviceId: 'DEV1', ipAddress: '10.0.0.1' }],
+        senderIpAddress: '10.0.0.1',
+      };
+      await expect(api.setZone(zone)).resolves.toBe(true);
+      expect(mock.history.post[0].data).toContain('senderIPAddress="10.0.0.1"');
+    });
   });
 
   describe('bass', () => {
@@ -274,7 +286,7 @@ describe('API', () => {
         .onGet(`${BASE}/presets`)
         .reply(
           200,
-          '<presets><preset id="1" createdOn="1600000000" updatedOn="1600000000">' +
+          '<presets><preset id="1" createdOn="1600000000" updateOn="1600000000">' +
             '<ContentItem source="SPOTIFY" sourceAccount="a"><itemName>Mix</itemName></ContentItem></preset></presets>'
         );
       const presets = await api.getPresets();

--- a/src/devices/SoundTouch/api/__tests__/component.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/component.test.ts
@@ -9,6 +9,20 @@ describe('componentFromElement', () => {
       serialNumber: ['SN-001'],
     });
     expect(componentFromElement(el)).toEqual({
+      category: undefined,
+      softwareVersion: '1.2.3',
+      serialNumber: 'SN-001',
+    });
+  });
+
+  test('parses componentCategory when present', () => {
+    const el = new XMLElement({
+      componentCategory: ['DEVICE'],
+      softwareVersion: ['1.2.3'],
+      serialNumber: ['SN-001'],
+    });
+    expect(componentFromElement(el)).toEqual({
+      category: 'DEVICE',
       softwareVersion: '1.2.3',
       serialNumber: 'SN-001',
     });

--- a/src/devices/SoundTouch/api/__tests__/now-playing.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/now-playing.test.ts
@@ -105,10 +105,15 @@ describe('nowPlayingFromElement', () => {
     expect(nowPlayingFromElement(new XMLElement(data))).toBeUndefined();
   });
 
-  test('returns undefined when the art or time children are missing', () => {
+  test('parses successfully when art or time children are absent', () => {
     const data = makeFullData();
     delete (data as Record<string, unknown>).art;
-    expect(nowPlayingFromElement(new XMLElement(data))).toBeUndefined();
+    delete (data as Record<string, unknown>).time;
+    const result = nowPlayingFromElement(new XMLElement(data));
+    expect(result).toBeDefined();
+    expect(result?.art).toBeUndefined();
+    expect(result?.time).toBeUndefined();
+    expect(result?.source).toBe('SPOTIFY');
   });
 
   test('returns undefined when the content item is malformed', () => {

--- a/src/devices/SoundTouch/api/__tests__/preset.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/preset.test.ts
@@ -5,7 +5,7 @@ import { XMLElement } from '../utils/xml-element.js';
 describe('presetFromElement', () => {
   test('parses id, dates and content item', () => {
     const el = new XMLElement({
-      $: { id: '3', createdOn: '1600000000', updatedOn: '1600000500' },
+      $: { id: '3', createdOn: '1600000000', updateOn: '1600000500' },
       ContentItem: [
         { $: { source: 'SPOTIFY', sourceAccount: 'acct' }, itemName: ['Mix'] },
       ],

--- a/src/devices/SoundTouch/api/api.ts
+++ b/src/devices/SoundTouch/api/api.ts
@@ -250,8 +250,8 @@ export class API {
       if (errors) {
         throw APIErrors.fromElement(errors);
       }
-    } else if (root.hasChild('Error')) {
-      const errElement = root.getChild('Error');
+    } else if (root.hasChild('error')) {
+      const errElement = root.getChild('error');
       if (errElement) {
         const err = errorFromElement(errElement);
         if (err) {

--- a/src/devices/SoundTouch/api/component.ts
+++ b/src/devices/SoundTouch/api/component.ts
@@ -1,6 +1,7 @@
 import { XMLElement } from './utils/xml-element.js';
 
 export interface Component {
+  readonly category?: string;
   readonly softwareVersion: string;
   readonly serialNumber: string;
 }
@@ -17,6 +18,7 @@ export function componentFromElement(
     return undefined;
   }
   return {
+    category: element.getText('componentCategory') ?? undefined,
     softwareVersion,
     serialNumber,
   };

--- a/src/devices/SoundTouch/api/endpoints.ts
+++ b/src/devices/SoundTouch/api/endpoints.ts
@@ -3,7 +3,7 @@ export enum Endpoints {
   volume = 'volume',
   speaker = 'speaker',
   key = 'key',
-  nowPlaying = 'now_playing',
+  nowPlaying = 'nowPlaying',
   select = 'select',
   sources = 'sources',
   getZone = 'getZone',

--- a/src/devices/SoundTouch/api/error.ts
+++ b/src/devices/SoundTouch/api/error.ts
@@ -23,7 +23,7 @@ export class APIErrors extends Error {
   readonly errors: APIError[];
 
   constructor(errors: APIError[], deviceId?: string) {
-    super(`Occured on device ${deviceId}: ${JSON.stringify(errors)}`);
+    super(`Occurred on device ${deviceId}: ${JSON.stringify(errors)}`);
     this.deviceId = deviceId;
     this.errors = errors;
   }

--- a/src/devices/SoundTouch/api/now-playing.ts
+++ b/src/devices/SoundTouch/api/now-playing.ts
@@ -24,6 +24,7 @@ export interface NowPlaying {
   readonly album?: string;
   readonly genre?: string;
   readonly stationName?: string;
+  readonly description?: string;
   readonly art?: Art;
   readonly time?: Time;
   readonly canGoForward: boolean;
@@ -55,13 +56,7 @@ export function nowPlayingFromElement(
   const deviceId = element.getAttribute('deviceID');
   const source = element.getAttribute('source');
   const contentItemElement = element.getChild('ContentItem');
-  if (
-    !artElement ||
-    !timeElement ||
-    !deviceId ||
-    !source ||
-    !contentItemElement
-  ) {
+  if (!deviceId || !source || !contentItemElement) {
     return undefined;
   }
   const rating = element.getText('rating');
@@ -82,6 +77,7 @@ export function nowPlayingFromElement(
     artist: element.getText('artist'),
     album: element.getText('album'),
     genre: element.getText('genre'),
+    description: element.getText('description'),
     rating: rating ? (rating as Rate) : Rate.none,
     stationName: element.getText('stationName'),
     art: artElement ? artFromElement(artElement) : undefined,

--- a/src/devices/SoundTouch/api/preset.ts
+++ b/src/devices/SoundTouch/api/preset.ts
@@ -10,14 +10,14 @@ export interface Preset {
 
 export function presetFromElement(element: XMLElement): Preset | undefined {
   if (
-    !element.hasAttributes(['id', 'createdOn', 'updatedOn']) ||
+    !element.hasAttributes(['id', 'createdOn', 'updateOn']) ||
     !element.hasChild('ContentItem')
   ) {
     return undefined;
   }
   const id = element.getAttribute('id');
   const createdOn = element.getAttribute('createdOn');
-  const updatedOn = element.getAttribute('updatedOn');
+  const updatedOn = element.getAttribute('updateOn');
   const contentItemElement = element.getChild('ContentItem');
   if (!id || !createdOn || !updatedOn || !contentItemElement) {
     return undefined;

--- a/src/devices/SoundTouch/api/special-types.ts
+++ b/src/devices/SoundTouch/api/special-types.ts
@@ -12,6 +12,7 @@ export enum KeyValue {
   power = 'POWER',
   stop = 'STOP',
   mute = 'MUTE',
+  auxInput = 'AUX_INPUT',
   shuffleOn = 'SHUFFLE_ON',
   shuffleOff = 'SHUFFLE_OFF',
   repeatOne = 'REPEAT_ONE',
@@ -28,6 +29,7 @@ export enum KeyValue {
   preset4 = 'PRESET_4',
   preset5 = 'PRESET_5',
   preset6 = 'PRESET_6',
+  invalid = 'INVALID_KEY',
 }
 
 export enum PlayStatus {
@@ -35,6 +37,7 @@ export enum PlayStatus {
   pause = 'PAUSE_STATE',
   stop = 'STOP_STATE',
   buffering = 'BUFFERING_STATE',
+  invalid = 'INVALID_PLAY_STATUS',
 }
 
 export enum SourceStatus {

--- a/src/devices/SoundTouch/api/zone.ts
+++ b/src/devices/SoundTouch/api/zone.ts
@@ -4,6 +4,7 @@ import { Member, memberFromElement } from './member.js';
 export interface Zone {
   readonly master: string;
   readonly members: Member[];
+  readonly senderIpAddress?: string;
 }
 
 export function zoneFromElement(element: XMLElement): Zone | undefined {
@@ -21,10 +22,12 @@ export function zoneFromElement(element: XMLElement): Zone | undefined {
 }
 
 export function zoneToElement(zone: Zone): XMLElement {
+  const attrs: Record<string, string> = { master: zone.master };
+  if (zone.senderIpAddress) {
+    attrs.senderIPAddress = zone.senderIpAddress;
+  }
   const data = {
-    $: {
-      master: zone.master,
-    },
+    $: attrs,
     member: zone.members.map((member: Member) => {
       return {
         $: {


### PR DESCRIPTION
## Summary

- **`endpoints.ts`** — `nowPlaying` endpoint value was `&#39;now_playing&#39;`; spec says `&#39;nowPlaying&#39;` — every now-playing call was hitting the wrong URL
- **`preset.ts`** — attribute guard used `&#39;updatedOn&#39;`; spec says `&#39;updateOn&#39;` — all presets parsed as `undefined`
- **`now-playing.ts`** — `art` and `time` treated as required; spec marks them optional — `getNowPlaying()` returned `undefined` for AUX/Bluetooth/standby sources; also adds missing `description` field
- **`api.ts`** — standalone error element checked as `&#39;Error&#39;` (capital E); spec uses `&#39;error&#39;` — single-error responses were silently swallowed
- **`zone.ts`** — `setZone` payload omitted `senderIPAddress` required by spec; adds optional `senderIpAddress` to `Zone` interface so callers can supply it
- **`component.ts`** — adds missing `componentCategory` field
- **`special-types.ts`** — adds `INVALID_PLAY_STATUS`, `AUX_INPUT`, `INVALID_KEY` enum values
- **`error.ts`** — typo: `Occured` → `Occurred`

## Test plan

- [ ] 183/183 tests passing
- [ ] `npm run typecheck` clean
- [ ] `npm run lint` clean