### PR TITLE
chore: fix stale knip.json config blocking commits

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -4,14 +4,30 @@
   "project": "src/**",
   "ignore": ["src/devices/SoundTouch/api/**"],
   "ignoreDependencies": [
-    "homebridge",
-    "homebridge-base-platform",
     "homebridge-lib",
-    "bonjour",
-    "xml2js",
-    "axios",
     "lint-staged",
     "ts-node",
-    "multicast-dns"
+    "multicast-dns",
+    "@commitlint/cli",
+    "@swc/core",
+    "eslint",
+    "husky",
+    "nodemon",
+    "prettier",
+    "rimraf",
+    "semantic-release"
+  ],
+  "ignoreBinaries": [
+    "semantic-release",
+    "commitlint",
+    "lint-staged",
+    "knip",
+    "rimraf",
+    "tsc",
+    "eslint",
+    "prettier",
+    "nodemon",
+    "jest",
+    "husky"
   ]
 }


### PR DESCRIPTION
## Summary

- Removes `ignoreDependencies` entries that knip now auto-detects (`homebridge`, `homebridge-base-platform`, `bonjour`, `xml2js`, `axios`)
- Adds missing `ignoreDependencies` for devDeps used in scripts/hooks that knip can&#39;t trace (`@commitlint/cli`, `@swc/core`, `eslint`, `husky`, `nodemon`, `prettier`, `rimraf`, `semantic-release`)
- Adds `ignoreBinaries` for binaries invoked from `package.json` scripts and husky hooks

## Test plan

- [ ] `npx knip` exits clean
- [ ] `git commit` no longer fails on the pre-commit hook