### PR TITLE
docs(technical-lead): add session-cost estimation step and capture estimates

### DIFF
--- a/.claude/skills/technical-lead/ROADMAP.md
+++ b/.claude/skills/technical-lead/ROADMAP.md
@@ -45,6 +45,37 @@ flowchart TD
 | 7 | **[04] PWA — Phase 2** | `feat/pwa` | Group management via the zone API (`/getZone`, `/setZone`, etc. — already implemented in `src/devices/SoundTouch/api/zone.ts`). Needs the phase 1 PWA scaffold and embedded server to be in place. |
 | 8 | **[04] PWA — Phase 3** | `feat/pwa` | Homebridge config sync. Blocked on **spike B** (confirm atomic config write path safety under Homebridge). Requires phase 1 scaffold. |
 
+## Session cost estimates
+
+Per-plan estimate of how much of a single coding session each unit consumes, by
+the methodology in `SKILL.md` step 5. Cost is driven by iteration loops
+(read → edit → test → lint → fix), not line count. Bands: **Small** (room to
+spare), **Medium** (one fits comfortably), **Heavy** (plan on one per session).
+Update the band after each unit ships and note the variance — see "Calibration"
+below.
+
+| Plan | Band | Drivers that set the band | Session guidance |
+| ---- | ---- | ------------------------- | ---------------- |
+| **[05] Integration test harness** | Medium | New test infra (fake HTTP server + Homebridge stub) and a Jest `projects` split; lots of additive code but low iteration risk and no release | Best first pick — de-risks every later feature PR. ~10 checklist items. |
+| **[02] Volume — Switch path** | Medium | Pure HomeKit wiring (API already done), but the `On` setter's 5s `finally` sleep introduces a race that needs debounce/reconcile + tests | One known hazard drives the iteration. Highest user value. ~11 items. |
+| **[01] Accessory type** | Heavy | Config threading through `DeviceConfiguration`, branching the hardcoded Switch in `createAccessory` (`:71`), and orphan-service pruning on type change | Plan a full session. Gates the Lightbulb volume follow-up. ~11 items. |
+| **[02] Volume — Lightbulb path** | Small | Brightness characteristic wiring once plan 01's `accessoryType` gate exists | Bundle into plan 01's PR or a quick follow-up. |
+| **[03] Source selection** | TBD (blocked) | Estimate after the TV-vs-Switch spike resolves the architecture | Re-estimate once unblocked. |
+| **[04] PWA — Phase 1–3** | TBD (blocked) | New `web/` workspace + embedded `src/server/`; estimate after spike A | Each phase is its own session at minimum. |
+
+**Realistic capacity per session:** one Medium/Heavy plan to a shippable,
+verified, pushed state; a second only if the first goes smoothly with budget to
+spare. Three in one session is unlikely without compromising the test bar that
+plan 05 exists to raise.
+
+### Calibration
+
+When a unit ships, record actual-vs-estimate here so future estimates sharpen.
+
+| Date | Plan | Estimate | Actual | Variance / note |
+| ---- | ---- | -------- | ------ | --------------- |
+| _(none yet)_ | | | | |
+
 ## Spikes (blockers)
 
 Two features are gated on spikes that must happen on a real device before code

--- a/.claude/skills/technical-lead/SKILL.md
+++ b/.claude/skills/technical-lead/SKILL.md
@@ -4,12 +4,12 @@ description: >-
   Use for delivery leadership on this Homebridge SoundTouch plugin — NOT for
   writing code. Trigger when the user wants to: prioritize or sequence the
   plans backlog, figure out what's next after merging a PR, identify work that
-  can run in parallel, decide whether to cancel/defer/pivot a stalled feature,
-  work through a pre-implementation decision or spike before coding starts, or
-  produce a detailed handoff brief for an engineer. This is the "what do we
-  build next and in what order" skill — it owns sequencing, blockers,
-  cancel/defer decisions, and engineering briefs. It does not implement
-  features.
+  can run in parallel, estimate the session/token cost of a plan before starting,
+  decide whether to cancel/defer/pivot a stalled feature, work through a
+  pre-implementation decision or spike before coding starts, or produce a detailed
+  handoff brief for an engineer. This is the "what do we build next and in what
+  order" skill — it owns sequencing, blockers, capacity/cost estimates,
+  cancel/defer decisions, and engineering briefs. It does not implement features.
 ---
 
 # Technical Lead
@@ -119,7 +119,57 @@ If parallel work makes sense, say so explicitly and produce one brief per
 engineer. Each brief must be fully self-contained — an engineer reads only
 their brief and the cited domain skills, nothing else.
 
-### 5. Write the engineering brief(s)
+### 5. Estimate session cost (token budget)
+
+Before briefing, size each candidate unit of work against a **single session's
+budget** so scope fits what can actually be delivered to a green, pushed state.
+A coding session's cost is dominated by **iteration loops** (read → edit → run
+tests → lint → fix → re-run), not by raw output length. Estimate from the
+drivers below, not from line count alone.
+
+**Cost drivers** (each one present pushes the estimate up):
+
+| Driver | Cheap | Expensive |
+| --- | --- | --- |
+| New vs. modify | New, additive files | Modifying existing code (must read + understand first) |
+| Cross-file threading | Localised to 1–2 files | Propagated through several layers (e.g. config → `DeviceConfiguration` → accessory) |
+| Iteration risk | Deterministic, synchronous | Async timing, races (e.g. the 5s `finally` sleep), lifecycle/caching, service pruning, config migration |
+| Test surface | Few new cases | New test infra, or many cases each needing run/fix cycles |
+| Open decisions | All resolved in the plan | Decisions likely to surface mid-implementation |
+| Unfamiliar paths | Well-trodden code | Code no plan has touched yet |
+
+**Cost bands** (per brief):
+
+- **Small** — mostly additive, no cross-file threading, low iteration risk,
+  small test surface. Comfortable; leaves budget for a second item.
+- **Medium** — mixes new + modified files, some test iteration expected, ~one
+  known hazard to reconcile. One fits comfortably; a second only if the first
+  reached green + pushed with budget clearly remaining.
+- **Heavy** — threads through multiple modules/config layers, has
+  lifecycle/pruning/migration concerns or a broad test surface, or carries an
+  unresolved decision likely to surface mid-build. Plan on **one per session**.
+
+**Budgeting rules:**
+
+- Default to **one Medium/Heavy unit per session**, fully verified. Chain a
+  second only when the first is green and pushed with budget to spare.
+- Checklist item count is a rough proxy only (~10–12 ≈ one feature PR); the
+  drivers above dominate. Splitting a Heavy plan into Small/Medium briefs (see
+  step 4) is the main lever for fitting work into a session.
+- State the estimate in the brief (band + the one or two drivers that set it),
+  and record the current estimates in `ROADMAP.md`'s "Session cost estimates"
+  table.
+- **If the budget tightens mid-session, stop at a clean committed + pushed
+  checkpoint** rather than leaving a feature half-done. A partial, green,
+  pushed slice beats an unfinished one.
+
+**Calibrate.** After a unit ships, compare the estimate to what it actually
+took (smooth vs. many fix-loops, finished in one pass vs. split) and add a row
+to the plan's Decisions & findings noting the variance. Update the band in
+`ROADMAP.md` if the estimate was off. Estimates only get sharper if actuals are
+fed back.
+
+### 6. Write the engineering brief(s)
 
 For each unit of work, produce a brief:
 
@@ -127,6 +177,8 @@ For each unit of work, produce a brief:
 **Branch:** `<branch name>` (off `dev`; if parallel work, use distinct branch
 names e.g. `feat/volume-switch-path`, `feat/volume-lightbulb-path`)
 **Commit type:** `<type>` → `<release impact>`
+**Session cost estimate:** `<Small | Medium | Heavy>` — `<the one or two drivers
+that set the band>` (see step 5)
 
 **What to build (this session):**
 A focused scope — not necessarily the entire plan. If the plan is large, scope
@@ -151,7 +203,7 @@ the engineer doesn't have to re-read the entire history.
 `npm run typecheck && npm run lint && npm test` — all green before the PR is
 opened. If the plan lists additional manual verification steps, list them.
 
-### 6. Update plan status and roadmap
+### 7. Update plan status and roadmap
 
 When handing off to the engineer, set `status: in-progress` in the plan file
 frontmatter. When all checklist items are done and the PR is merged, set
@@ -178,6 +230,12 @@ Always re-read a file before editing it.
   cancel/defer/pivot decision rather than leaving work in limbo indefinitely.
   A recorded cancellation is a better outcome than an open plan that never
   moves.
+- **Scope each session to its budget.** A coding session's cost is driven by
+  iteration loops, not output length. Estimate before briefing (step 5), default
+  to one Medium/Heavy unit per session, and stop at a clean pushed checkpoint
+  rather than overrunning into a half-done feature.
+- **Feed actuals back.** Every shipped unit is a data point — compare it to the
+  estimate and record the variance so the next estimate is sharper.
 - **The roadmap is a living document.** If delivery order changes because of
   new findings, update it.
 


### PR DESCRIPTION
## What

Adds a **session/token-cost estimation** step to the `technical-lead` skill so each plan is sized against a single coding session *before* an engineer brief is written, and captures the current estimates in the roadmap so planning is data-driven going forward.

## Why

Session capacity is the real constraint on how much planned work we can take on in a day, and it&#39;s driven by iteration loops (read → edit → test → lint → fix), not line count. Making the estimate an explicit, recorded step — with a calibration loop — lets us scope each session realistically instead of guessing.

## Changes

**`SKILL.md`**
- New **step 5 — Estimate session cost (token budget)**: cost-driver rubric (new vs. modify, cross-file threading, iteration risk, test surface, open decisions, unfamiliar paths) and three bands — **Small / Medium / Heavy**.
- Budgeting rules (default one Medium/Heavy unit per session; stop at a clean pushed checkpoint when budget tightens) and a **calibration** loop that feeds actuals back into estimates.
- Brief template gains a **Session cost estimate** field; two supporting principles added; subsequent steps renumbered (6 = briefs, 7 = status).

**`ROADMAP.md`**
- New **Session cost estimates** table for plans 01–05 with the driver that sets each band, plus realistic per-session capacity.
- Empty **Calibration** table for recording actual-vs-estimate after each unit ships.

## Captured estimates

| Plan | Band |
| ---- | ---- |
| 05 Integration test harness | Medium |
| 02 Volume — Switch path | Medium |
| 01 Accessory type | Heavy |
| 02 Volume — Lightbulb path | Small |
| 03 Source selection / 04 PWA | TBD (blocked on spikes) |

Docs-only; no source or test changes.