### PR TITLE
docs: distinguish planning branches from implementation branches

### DIFF
--- a/.claude/skills/architect/SKILL.md
+++ b/.claude/skills/architect/SKILL.md
@@ -46,11 +46,25 @@ The conventions this skill *owns* — decide both up front, they drive the relea
 - **Commit type:** `feat:` → minor, `fix:` → patch, `feat!:` or a
   `BREAKING CHANGE:` footer → major, `chore:`/`docs:`/`ci:`/`test:`/`refactor:` →
   no release. semantic-release derives the version from this.
-- **Branch/PR flow:** branch off `dev` (e.g. `feat/…`); open the PR **into `dev`**.
-  Feature PRs are squash-merged, so the **PR title becomes the released commit
-  message** — it must be a valid Conventional Commit. Never hand-edit the `version`
-  in `package.json` or write a changelog; releases are automated. See
-  `CONTRIBUTING.md` for the full model.
+- **Branch/PR flow:** branch off `dev`; open the PR **into `dev`**. Distinguish
+  the two kinds of branch — keep them separate so a feature PR stays a clean,
+  single-purpose release unit:
+  - **Implementation branches** (`feat/…`, `fix/…`, `test/…`, `refactor/…`) carry
+    the production code + tests that deliver **one** plan. They *may* also carry
+    that plan's own bookkeeping — checklist ticks, `status` frontmatter, and
+    Decisions & findings rows — because those document the work landing in the
+    same PR. Squash-merged, so the **PR title becomes the released commit
+    message** and must be a valid Conventional Commit.
+  - **Planning branches** (`docs/…` or `plan/…`, commit type `docs:` → no
+    release) carry planning artifacts **only**: new or revised plan files,
+    `ROADMAP.md` sequencing/status, and skill changes. Do **not** commit these
+    onto an implementation branch — cross-cutting planning churn must not ride
+    along on a feature PR.
+  - **Rule of thumb:** does the change deliver or document the code in *this*
+    PR's plan? → implementation branch. Does it re-sequence work, create/revise
+    plans, or edit skills/roadmap across features? → planning branch.
+  - Never hand-edit the `version` in `package.json` or write a changelog;
+    releases are automated. See `CONTRIBUTING.md` for the full model.
 
 ### 4. Note delivery sequencing separately
 The architect owns *what* to build and *why* — feature design, trade-offs, API

--- a/.claude/skills/technical-lead/SKILL.md
+++ b/.claude/skills/technical-lead/SKILL.md
@@ -32,6 +32,16 @@ You do **not** write feature code. You write research, decisions, and briefs.
 The architect writes plans independently of delivery order. You slot them into
 the roadmap and own driving them to shipped.
 
+**Planning vs. implementation branches.** Your artefacts — `ROADMAP.md`,
+sequencing/status edits, and new or revised plan files — are *planning* changes.
+Commit them on a **planning branch** (`docs/…` or `plan/…`, commit type
+`docs:` → no release), never onto a feature's implementation branch. An
+implementation branch (`feat/…`, `test/…`, etc.) carries only the code for its
+plan plus that plan's own bookkeeping (checklist ticks, `status`, findings). A
+roadmap re-sequence or a cross-feature status refresh must not ride along on a
+feature PR — it couples planning churn to that feature's review and release. The
+architect skill owns the full branch/PR model; follow it.
+
 ## Workflow
 
 ### 1. Survey the landscape
@@ -174,8 +184,10 @@ fed back.
 For each unit of work, produce a brief:
 
 **Plan:** `<filename>` — `<feature name>`
-**Branch:** `<branch name>` (off `dev`; if parallel work, use distinct branch
-names e.g. `feat/volume-switch-path`, `feat/volume-lightbulb-path`)
+**Branch:** `<implementation branch>` (`feat/…`/`fix/…`/`test/…` off `dev`; if
+parallel work, use distinct names e.g. `feat/volume-switch-path`,
+`feat/volume-lightbulb-path`). Plan/roadmap edits belong on a separate planning
+branch, not here.
 **Commit type:** `<type>` → `<release impact>`
 **Session cost estimate:** `<Small | Medium | Heavy>` — `<the one or two drivers
 that set the band>` (see step 5)


### PR DESCRIPTION
## What

Captures the distinction between **planning branches** and **implementation branches** in the skills that own the workflow, so planning churn (roadmap/sequencing/plan edits) stops riding along on feature PRs.

## Why

This was a real mistake in the current session: a cross-cutting roadmap status refresh got committed onto an implementation branch (`test/integration-harness`, PR #58). Coupling planning churn to a feature PR muddies its review and its squash-merged release commit. The rule needed to live in the skills, not just in one person&#39;s head.

## The rule

- **Implementation branches** (`feat/…`, `fix/…`, `test/…`, `refactor/…`): production code + tests delivering **one** plan, plus *that plan&#39;s own* bookkeeping (checklist ticks, `status`, Decisions &amp; findings). Squash-merged; PR title is the released Conventional Commit.
- **Planning branches** (`docs/…` or `plan/…`, `docs:` → no release): plan files, `ROADMAP.md` sequencing/status, and skill changes — **only**.
- **Rule of thumb:** delivers/documents the code in *this* PR&#39;s plan → implementation branch. Re-sequences work, creates/revises plans, or edits skills/roadmap across features → planning branch.

## Changes

- **`architect/SKILL.md`** (owns the branch/PR flow) — expands the Branch/PR flow bullet with the two branch types and the rule of thumb.
- **`technical-lead/SKILL.md`** — reinforces that roadmap/sequencing/plan edits go on a planning branch; the brief&#39;s Branch field is explicitly the implementation branch.

Docs-only; no code touched. This PR itself is on a planning branch, per the rule it documents.