### PR TITLE
docs: track polling-lifecycle tech debt and scope the volume power/volume race

### DIFF
--- a/.claude/skills/architect/plans/2026-06-19-volume-control.md
+++ b/.claude/skills/architect/plans/2026-06-19-volume-control.md
@@ -40,6 +40,7 @@ activates only once plan 01 enables the Lightbulb accessory type.
 | 2026-06-20 | Plan 02 ships before plan 01; dependency on plan 01 removed | Volume should be available immediately on default Switch accessories | Waiting for plan 01 before shipping volume |
 | 2026-06-20 | Two characteristic classes: `SoundTouchSpeakerVolumeCharacteristic` (Speaker/Volume) and the Lightbulb Brightness wiring | Different services, different power-off semantics; cleaner to keep them separate than to parameterise one class | One class parameterised by service/characteristic type — more complex with marginal reuse |
 | 2026-06-20 | WebSocket push used for external volume changes — no new WS infrastructure needed | The speaker sends a `volumeUpdated` tickle on port 8080 (existing per-device WebSocket connection) whenever volume changes externally. The characteristic's `refresh()` listens for this event and re-fetches via `api.getVolume()`, then pushes the new value to HomeKit via `characteristic.updateValue`. The WS connection is already open; volume just needs to subscribe to the existing event emitter. | Polling on a timer — less responsive and wastes requests; opening a second WebSocket — redundant |
+| 2026-06-20 | Promote the `On` setter's 5 s `finally` sleep fix into plan 02 scope (in-scope, not just a finding) | The race has been a passive finding since 2026-06-19. Plan 02 introduces the volume set that races it, and plan 02 already touches the power/volume interaction — so the fix belongs here. The brief must hand this off as a concrete task, not an open hazard. (Polling-loop lifecycle is a *separate* concern — see plan 06.) | Leaving it a passive finding (risk it never gets fixed); a separate fix PR touching `SoundTouchSpeakerOnCharacteristic.ts` (merge-conflict churn with plan 02, which also edits it) |
 
 ## If cancelled
 
@@ -99,7 +100,12 @@ activates only once plan 01 enables the Lightbulb accessory type.
 - [ ] Wire Brightness characteristic into `createAccessory` for the Lightbulb path
       (behind the plan 01 `accessoryType` gate)
 - [ ] Reconcile On/Brightness ordering with `SoundTouchSpeakerOnCharacteristic`
-- [ ] Add tests for both characteristic classes
+- [ ] **Fix the power/volume race:** replace the `On` setter's blocking 5 s
+      `finally` sleep (`SoundTouchSpeakerOnCharacteristic.ts:66`) with a
+      non-blocking settle/debounce, so a near-simultaneous volume set isn't
+      blocked or fought by the power set
+- [ ] Add tests for both characteristic classes (incl. a power+volume
+      interaction test that would fail against the old 5 s sleep)
 
 ## Verification
 

--- a/.claude/skills/architect/plans/2026-06-20-polling-lifecycle.md
+++ b/.claude/skills/architect/plans/2026-06-20-polling-lifecycle.md
@@ -1,0 +1,101 @@
+---
+feature: Polling lifecycle — stop polling on accessory removal/shutdown and make it configurable
+status: planned # planned | in-progress | done | cancelled
+date: 2026-06-20
+branch: fix/polling-lifecycle
+commit-type: fix
+---
+
+# Polling lifecycle — stoppable, configurable device polling
+
+## Context
+
+Surfaced while building the integration test harness (plan 05): the device
+polling loop can never be stopped, and it can't be turned off via config.
+
+- `SoundTouchSpeakerPlatformAccessory.init()` starts a 2 s polling loop
+  (`_refreshDeviceServices`) whenever `device.configuration.pollingInterval`
+  is defined — which it **always** is (`DeviceConfiguration` defaults it to
+  `2000`, and `PlatformConfiguration.fromExternalConfiguration` also hardcodes
+  the platform-level value).
+- `stopPolling()` exists on the accessory wrapper, but
+  `SoundTouchHomebridgePlatform.discoverDevices` **discards the wrapper** after
+  `create()` — it only retains the HAP `PlatformAccessory` in `_accessories`.
+  Nothing holds a reference that can call `stopPolling()`.
+
+Consequences in production:
+1. **Leak on removal:** when a cached accessory is no longer discovered, the
+   platform calls `unregisterPlatformAccessories` but the orphaned wrapper's
+   polling loop keeps firing `getSource()` against the gone device forever.
+2. **No clean shutdown:** Homebridge restart/shutdown leaves the loop running
+   until the process dies.
+3. **Not configurable:** there is no way to slow or disable polling; the
+   interval is effectively fixed at 2 s per accessory.
+
+The harness only *worked around* this with `jest.useFakeTimers()` to park the
+loop. This plan fixes the underlying lifecycle in production code.
+
+## Decisions & findings
+
+| Date | Decision / finding | Rationale / evidence | Alternatives rejected |
+| --- | --- | --- | --- |
+| 2026-06-20 | Finding: the platform discards the `SoundTouchSpeakerPlatformAccessory` wrapper returned by `create()` (`platform.ts:114-130`); only the HAP `PlatformAccessory` is kept in `_accessories` | `stopPolling()` is unreachable, so polling never stops | — |
+| 2026-06-20 | Finding: `pollingInterval` is always defined — `DeviceConfiguration` defaults it to `2000` and there is no config path that yields `undefined` | `init()`'s `pollingInterval !== undefined` guard is always true, so polling is unconditional | — |
+| 2026-06-20 | Finding: `PlatformConfiguration.fromExternalConfiguration` hardcodes `pollingInterval` **and** `verbose`, ignoring `props.global?.pollingInterval`/`verbose` (`PlatformConfiguration.ts:41-42`) | Global config for these two fields is silently dropped — a related config-threading bug worth fixing in the same pass | — |
+| 2026-06-20 | Decision: retain wrappers in a `Map<uuid, SoundTouchSpeakerPlatformAccessory>` on the platform and call `stopPolling()` on unregister and on Homebridge `shutdown` | Smallest change that makes the loop stoppable; mirrors the existing `_accessories` map | Passing an `AbortSignal` into the accessory (larger refactor); a global polling scheduler (over-engineered for the device count) |
+| 2026-06-20 | Decision: treat `pollingInterval <= 0` as "disable polling" | Gives users an off switch without a new boolean field | A separate `polling: boolean` field (more schema surface for the same effect) |
+
+## If cancelled
+
+> Only fill this in when `status: cancelled`. Leave empty otherwise.
+
+## Affected areas
+
+- `src/platform.ts` — keep the `SoundTouchSpeakerPlatformAccessory` wrappers in a
+  `Map<uuid, …>`; call `stopPolling()` in the stale-accessory unregister branch;
+  register an `api.on('shutdown', …)` handler that stops all wrappers.
+- `src/accessories/SoundTouchSpeakerPlatformAccessory.ts` — only start the polling
+  loop when `pollingInterval > 0`; ensure `stopPolling()` is idempotent.
+- `src/PlatformConfiguration.ts` — thread `global.pollingInterval` and
+  `global.verbose` through instead of hardcoding the defaults.
+- `src/devices/SoundTouch/SoundTouchDeviceConfiguration.ts` — allow a `0`/disabled
+  interval to pass through rather than being coerced to the 2 s default.
+
+## Conventions for this change
+
+- **Commit type:** `fix:` → patch release.
+- **Config schema touched:** `pollingInterval` already exists in config; document
+  that `0` disables polling in `config.schema.json` description (no new field).
+- **Tests to add/update:**
+  - `src/__tests__/PlatformConfiguration.test.ts` — global `pollingInterval`/
+    `verbose` now honoured; `0` preserved.
+  - `src/__integration__/platform-lifecycle.integration.test.ts` — extend: a
+    stale-accessory unregister stops its polling; `shutdown` stops all. (This can
+    drop the fake-timer workaround for the stop path.)
+- Follow **coding-conventions** and the platform/accessory patterns in
+  **homebridge-developer**.
+- **Target branch:** `dev`.
+
+## Implementation checklist
+
+- [ ] Platform: retain wrappers in a `Map<uuid, SoundTouchSpeakerPlatformAccessory>`
+- [ ] Platform: call `stopPolling()` when unregistering a stale cached accessory
+- [ ] Platform: add an `api.on('shutdown', …)` handler that stops all wrappers
+- [ ] Accessory: start polling only when `pollingInterval > 0`; make `stopPolling()` idempotent
+- [ ] Config: thread `global.pollingInterval` and `global.verbose` through `PlatformConfiguration`
+- [ ] Config: let `pollingInterval: 0` survive as "disabled" through `DeviceConfiguration`
+- [ ] Add/update tests (config + integration lifecycle)
+- [ ] Update `config.schema.json` description noting `0` disables polling
+
+## Verification
+
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] `npm test`
+- [ ] `npm run watch` — confirm a removed accessory stops polling (no further
+      requests in logs) and a restart shuts the loop down cleanly
+
+## PR / release notes
+
+- **PR title:** `fix: stop device polling on accessory removal/shutdown and honour polling config`
+- **Targets:** `dev`

--- a/.claude/skills/technical-lead/ROADMAP.md
+++ b/.claude/skills/technical-lead/ROADMAP.md
@@ -14,6 +14,7 @@ flowchart TD
     VolSwitchNode["[02] Volume – Switch path\nSpeaker service"]
     AccessoryTypeNode["[01] Accessory type\nSwitch / Lightbulb"]
     VolLightbulbNode["[02] Volume – Lightbulb path\nBrightness characteristic"]
+    PollingNode["[06] Polling lifecycle\nfix/polling-lifecycle"]
     SpikeTV{"Spike: TV vs\nper-Switch fallback"}
     SourceNode["[03] Source selection"]
     SpikeA{"Spike A: hotspot\nHTTP API"}
@@ -23,6 +24,7 @@ flowchart TD
     PWA3Node["[04] PWA – Phase 3\nConfig sync"]
 
     HarnessNode --> VolSwitchNode
+    VolSwitchNode -. "shares accessory file" .-> PollingNode
     VolSwitchNode --> AccessoryTypeNode
     AccessoryTypeNode --> VolLightbulbNode
     SpikeTV --> SourceNode
@@ -34,25 +36,31 @@ flowchart TD
 
 ## Current state (2026-06-20)
 
-- **Now:** [05] Integration test harness — **PR #58 open against `dev`** (draft), green
-  locally (typecheck/lint/knip/187 tests), awaiting CI + merge.
+- **Now:** [05] Integration test harness — **PR #58 open against `dev`**, with a
+  coverage-threshold guard added per review; awaiting merge.
 - **Next (ready):** [02] Volume — Switch path. Cut `feat/volume-control` off `dev`
-  once #58 merges (clean base) — or off `test/integration-harness` if starting before merge.
+  once #58 merges. The `On` setter's 5 s `finally` race fix is now **in scope**
+  for this plan (promoted from a finding).
+- **Tech debt (ready):** [06] Polling lifecycle — make polling stoppable on
+  removal/shutdown and configurable. Shares `SoundTouchSpeakerPlatformAccessory.ts`
+  with plan 02, so **serialise after 02** to avoid conflicts.
 - **Blocked:** [03] Source selection (spike), [04] PWA all phases (spikes A/B).
-- Skill change adding session-cost estimation landed in `dev` via PR #57.
+- Skill changes landed in `dev`: session-cost estimation (#57), planning vs.
+  implementation branches (#59), roadmap status + plan-05 calibration (#60).
 
 ## Anticipated delivery order
 
 | Order | Plan | Branch | Status | Why this position |
 | ----- | ---- | ------ | ------ | ----------------- |
 | 1 | **[05] Integration test harness** | `test/integration-harness` | 🔵 PR #58 open (review) | Pure test infrastructure, no release. Gives confidence before shipping any user-facing feature. No dependencies. |
-| 2 | **[02] Volume — Switch path** | `feat/volume-control` | 🟢 Ready (next) | Adds immediate value to all existing users on the default Switch accessory type. The Speaker-service path has no dependency on plan 01. Ships first so volume isn't blocked on the accessory-type rework. |
-| 3 | **[01] Accessory type** | `feat/accessory-type` | ⚪ Planned | Independent of plans 02 and 03, but it's the gate for the Lightbulb/Brightness volume path. Delivering it after the Switch volume path avoids holding volume hostage to the larger config-threading change. |
-| 4 | **[02] Volume — Lightbulb path** | (small follow-up PR or bundled with 01) | ⚪ Planned (gated on 01) | Brightness characteristic wiring is a small addition once plan 01's `accessoryType` gate exists. Can ship in the same PR as plan 01 or immediately after. |
-| 5 | **[03] Source selection** | `feat/source-selection` | 🔴 Blocked (spike) | Independent of 01/02. Blocked on a **spike** (verify Television+InputSource on a real device; choose TV path vs per-source Switch fallback). Cannot be committed until the spike resolves the architecture choice. |
-| 6 | **[04] PWA — Phase 1** | `feat/pwa` | 🔴 Blocked (spike A) | Architecturally separate (new `web/` workspace + embedded HTTP server). Blocked on **spike A** (reverse-engineer the hotspot provisioning HTTP API at `http://192.0.2.1`). Phase 1 must ship before phases 2 and 3 (it creates the web scaffold and embedded server). |
-| 7 | **[04] PWA — Phase 2** | `feat/pwa` | 🔴 Blocked (needs P1) | Group management via the zone API (`/getZone`, `/setZone`, etc. — already implemented in `src/devices/SoundTouch/api/zone.ts`). Needs the phase 1 PWA scaffold and embedded server to be in place. |
-| 8 | **[04] PWA — Phase 3** | `feat/pwa` | 🔴 Blocked (spike B) | Homebridge config sync. Blocked on **spike B** (confirm atomic config write path safety under Homebridge). Requires phase 1 scaffold. |
+| 2 | **[02] Volume — Switch path** | `feat/volume-control` | 🟢 Ready (next) | Adds immediate value to all existing users on the default Switch accessory type. The Speaker-service path has no dependency on plan 01. Ships first so volume isn't blocked on the accessory-type rework. Now also owns the `On` setter 5 s-sleep race fix. |
+| 3 | **[06] Polling lifecycle** | `fix/polling-lifecycle` | 🟢 Ready (tech debt) | Stop polling on accessory removal/shutdown; make the interval configurable (`0` disables). Surfaced by plan 05. Shares `SoundTouchSpeakerPlatformAccessory.ts` with plan 02 → serialise after 02. `fix:` → patch. |
+| 4 | **[01] Accessory type** | `feat/accessory-type` | ⚪ Planned | Independent of plans 02 and 03, but it's the gate for the Lightbulb/Brightness volume path. Delivering it after the Switch volume path avoids holding volume hostage to the larger config-threading change. |
+| 5 | **[02] Volume — Lightbulb path** | (small follow-up PR or bundled with 01) | ⚪ Planned (gated on 01) | Brightness characteristic wiring is a small addition once plan 01's `accessoryType` gate exists. Can ship in the same PR as plan 01 or immediately after. |
+| 6 | **[03] Source selection** | `feat/source-selection` | 🔴 Blocked (spike) | Independent of 01/02. Blocked on a **spike** (verify Television+InputSource on a real device; choose TV path vs per-source Switch fallback). Cannot be committed until the spike resolves the architecture choice. |
+| 7 | **[04] PWA — Phase 1** | `feat/pwa` | 🔴 Blocked (spike A) | Architecturally separate (new `web/` workspace + embedded HTTP server). Blocked on **spike A** (reverse-engineer the hotspot provisioning HTTP API at `http://192.0.2.1`). Phase 1 must ship before phases 2 and 3 (it creates the web scaffold and embedded server). |
+| 8 | **[04] PWA — Phase 2** | `feat/pwa` | 🔴 Blocked (needs P1) | Group management via the zone API (`/getZone`, `/setZone`, etc. — already implemented in `src/devices/SoundTouch/api/zone.ts`). Needs the phase 1 PWA scaffold and embedded server to be in place. |
+| 9 | **[04] PWA — Phase 3** | `feat/pwa` | 🔴 Blocked (spike B) | Homebridge config sync. Blocked on **spike B** (confirm atomic config write path safety under Homebridge). Requires phase 1 scaffold. |
 
 ## Session cost estimates
 
@@ -69,6 +77,7 @@ below.
 | **[02] Volume — Switch path** | Medium | Pure HomeKit wiring (API already done), but the `On` setter's 5s `finally` sleep introduces a race that needs debounce/reconcile + tests | One known hazard drives the iteration. Highest user value. ~11 items. |
 | **[01] Accessory type** | Heavy | Config threading through `DeviceConfiguration`, branching the hardcoded Switch in `createAccessory` (`:71`), and orphan-service pruning on type change | Plan a full session. Gates the Lightbulb volume follow-up. ~11 items. |
 | **[02] Volume — Lightbulb path** | Small | Brightness characteristic wiring once plan 01's `accessoryType` gate exists | Bundle into plan 01's PR or a quick follow-up. |
+| **[06] Polling lifecycle** | Small–Medium | Modifies existing platform + accessory lifecycle (retain wrappers, stop on unregister/shutdown) and threads two config fields; async lifecycle reasoning + a couple of tests | Contained; the integration harness already exercises the lifecycle path. |
 | **[03] Source selection** | TBD (blocked) | Estimate after the TV-vs-Switch spike resolves the architecture | Re-estimate once unblocked. |
 | **[04] PWA — Phase 1–3** | TBD (blocked) | New `web/` workspace + embedded `src/server/`; estimate after spike A | Each phase is its own session at minimum. |
 


### PR DESCRIPTION
## What

Planning-only. Turns the production issues the plan-05 harness *surfaced but only worked around* into tracked work, and makes the volume power/volume race an explicit scope item rather than a passive finding.

## Changes

**New plan 06 — `fix/polling-lifecycle`** (`.claude/skills/architect/plans/2026-06-20-polling-lifecycle.md`)
- The platform discards the `SoundTouchSpeakerPlatformAccessory` wrapper after `create()`, so `stopPolling()` is unreachable → polling can never stop (leaks on accessory removal, never shuts down cleanly), and the 2 s interval is effectively hardcoded.
- Fix: retain wrappers in a `Map`, call `stopPolling()` on unregister + on Homebridge `shutdown`, start polling only when `interval &gt; 0`, and thread `global.pollingInterval`/`global.verbose` through `PlatformConfiguration` (currently hardcoded). `fix:` → patch.

**Plan 02 (volume) — 5 s-sleep race promoted to scope**
- The `On` setter&#39;s blocking 5 s `finally` sleep race has been a passive finding since 2026-06-19. Added a decision row + explicit checklist item to **fix it within plan 02**, since plan 02 introduces the racing volume set and already edits `SoundTouchSpeakerOnCharacteristic.ts`.

**`ROADMAP.md`**
- Slotted plan 06 at delivery order 3 (after plan 02 — they share `SoundTouchSpeakerPlatformAccessory.ts`, so serialise), added its cost estimate (Small–Medium), refreshed the current-state snapshot and dependency graph.

## Separation of concerns

- **5 s-sleep race** (power/volume interaction, `SoundTouchSpeakerOnCharacteristic.ts`) → owned by **plan 02**.
- **Polling loop lifecycle** (platform retains refs, stop on removal/shutdown, configurable) → owned by **plan 06**.

No code changes — plan/roadmap docs only, on a planning branch per the branch-type rule.