### PR TITLE
feat: add volume control via Speaker service on the Switch accessory

### DIFF
--- a/.claude/skills/architect/plans/2026-06-19-volume-control.md
+++ b/.claude/skills/architect/plans/2026-06-19-volume-control.md
@@ -1,6 +1,6 @@
 ---
 feature: Volume control — Speaker service (Switch mode) and Lightbulb Brightness (Lightbulb mode)
-status: planned # planned | in-progress | done | cancelled
+status: in-progress # planned | in-progress | done | cancelled
 date: 2026-06-19
 updated: 2026-06-20
 branch: feat/volume-control
@@ -41,6 +41,8 @@ activates only once plan 01 enables the Lightbulb accessory type.
 | 2026-06-20 | Two characteristic classes: `SoundTouchSpeakerVolumeCharacteristic` (Speaker/Volume) and the Lightbulb Brightness wiring | Different services, different power-off semantics; cleaner to keep them separate than to parameterise one class | One class parameterised by service/characteristic type — more complex with marginal reuse |
 | 2026-06-20 | WebSocket push used for external volume changes — no new WS infrastructure needed | The speaker sends a `volumeUpdated` tickle on port 8080 (existing per-device WebSocket connection) whenever volume changes externally. The characteristic's `refresh()` listens for this event and re-fetches via `api.getVolume()`, then pushes the new value to HomeKit via `characteristic.updateValue`. The WS connection is already open; volume just needs to subscribe to the existing event emitter. | Polling on a timer — less responsive and wastes requests; opening a second WebSocket — redundant |
 | 2026-06-20 | Promote the `On` setter's 5 s `finally` sleep fix into plan 02 scope (in-scope, not just a finding) | The race has been a passive finding since 2026-06-19. Plan 02 introduces the volume set that races it, and plan 02 already touches the power/volume interaction — so the fix belongs here. The brief must hand this off as a concrete task, not an open hazard. (Polling-loop lifecycle is a *separate* concern — see plan 06.) | Leaving it a passive finding (risk it never gets fixed); a separate fix PR touching `SoundTouchSpeakerOnCharacteristic.ts` (merge-conflict churn with plan 02, which also edits it) |
+| 2026-06-20 | **Implemented** the race fix as a non-blocking settle window, not a blocking sleep | Replaced the `finally { await setTimeout(5000) }` with a `settleUntil` timestamp (`POWER_SETTLE_MS = 5000`): a power press records `settleUntil`; the setter returns immediately, so a concurrent volume set is never stalled. A repeated same-state press within the window is skipped (preserves the original anti-hammer intent). Covered by a fake-timer test that hangs against the old blocking sleep. | Keeping the blocking sleep (stalls HomeKit setters); a debounce timer that defers the press (adds latency to a deliberate toggle) |
+| 2026-06-20 | **Deferred** the WebSocket `volumeUpdated` push; Switch-path volume uses the existing polling `refresh()` | There is no WebSocket infrastructure in the codebase yet (`grep` for `ws://`/`gabbo`/`8080` finds only the HTTP `sender: 'Gabbo'` string). The plan's WS decision assumed an existing per-device WS connection that does not exist. `SoundTouchSpeakerVolumeCharacteristic.refresh()` follows the same polling-loop pattern as `SoundTouchSpeakerOnCharacteristic`. A WS push layer is its own piece of work (touches every characteristic) and is out of scope for the Switch volume slice. | Building new WS infrastructure inside this PR (scope creep; a cross-cutting concern that belongs in its own plan) |
 
 ## If cancelled
 
@@ -92,20 +94,26 @@ activates only once plan 01 enables the Lightbulb accessory type.
 
 ## Implementation checklist
 
-- [ ] Add `SoundTouchSpeakerVolumeCharacteristic` (Speaker service, Volume 0–100)
-- [ ] Wire Speaker service + volume characteristic into `createAccessory` for the
+### Switch path (this PR)
+
+- [x] Add `SoundTouchSpeakerVolumeCharacteristic` (Speaker service, Volume 0–100)
+- [x] Wire Speaker service + volume characteristic into `createAccessory` for the
       Switch path
+- [x] **Fix the power/volume race:** replaced the `On` setter's blocking 5 s
+      `finally` sleep with a non-blocking `settleUntil` window, so a
+      near-simultaneous volume set isn't blocked or fought by the power set
+- [x] Add the Volume characteristic tests (get/set, HAP error, refresh) and a
+      power+volume interaction test that hangs against the old 5 s sleep
+- [x] Extend the integration harness (Speaker/Volume stub types) + assert the
+      Speaker Volume initialises from the device
+
+### Lightbulb path (deferred — gated on plan 01)
+
 - [ ] Add `SoundTouchSpeakerBrightnessCharacteristic` (Lightbulb Brightness ↔
       volume, 0 = power off)
 - [ ] Wire Brightness characteristic into `createAccessory` for the Lightbulb path
       (behind the plan 01 `accessoryType` gate)
 - [ ] Reconcile On/Brightness ordering with `SoundTouchSpeakerOnCharacteristic`
-- [ ] **Fix the power/volume race:** replace the `On` setter's blocking 5 s
-      `finally` sleep (`SoundTouchSpeakerOnCharacteristic.ts:66`) with a
-      non-blocking settle/debounce, so a near-simultaneous volume set isn't
-      blocked or fought by the power set
-- [ ] Add tests for both characteristic classes (incl. a power+volume
-      interaction test that would fail against the old 5 s sleep)
 
 ## Verification
 

--- a/src/__integration__/helpers/fake-soundtouch-server.ts
+++ b/src/__integration__/helpers/fake-soundtouch-server.ts
@@ -31,7 +31,7 @@ export function nowPlayingXml(source: string, deviceId = 'DEV-INT-1'): string {
   );
 }
 
-function volumeXml(
+export function volumeXml(
   options: { target?: number; actual?: number; muted?: boolean } = {}
 ): string {
   const { target = 20, actual = 20, muted = false } = options;

--- a/src/__integration__/helpers/homebridge-stub.ts
+++ b/src/__integration__/helpers/homebridge-stub.ts
@@ -18,11 +18,13 @@ interface Identifier {
 
 const ServiceTypes = {
   Switch: { name: 'Switch' },
+  Speaker: { name: 'Speaker' },
   AccessoryInformation: { name: 'AccessoryInformation' },
 } satisfies Record<string, Identifier>;
 
 const CharacteristicTypes = {
   On: { name: 'On' },
+  Volume: { name: 'Volume' },
   Name: { name: 'Name' },
   Manufacturer: { name: 'Manufacturer' },
   Model: { name: 'Model' },

--- a/src/__integration__/platform-lifecycle.integration.test.ts
+++ b/src/__integration__/platform-lifecycle.integration.test.ts
@@ -14,6 +14,7 @@ import {
   FakeSoundTouchServer,
   infoXml,
   nowPlayingXml,
+  volumeXml,
 } from './helpers/fake-soundtouch-server.js';
 import { HomebridgeApiStub } from './helpers/homebridge-stub.js';
 
@@ -85,6 +86,15 @@ describe('SoundTouchHomebridgePlatform', () => {
       await api.emitDidFinishLaunching();
 
       expect(api.getCharacteristicValue('Switch', 'On')).toBe(true);
+    });
+
+    it('initialises the Speaker volume characteristic from the device', async () => {
+      server.setResponse('/volume', volumeXml({ actual: 35 }));
+      createPlatform();
+
+      await api.emitDidFinishLaunching();
+
+      expect(api.getCharacteristicValue('Speaker', 'Volume')).toBe(35);
     });
 
     it('unregisters a stale cached accessory not seen in discovery', async () => {

--- a/src/accessories/SoundTouchSpeakerPlatformAccessory.ts
+++ b/src/accessories/SoundTouchSpeakerPlatformAccessory.ts
@@ -8,6 +8,7 @@ import {
 } from './services/SoundTouchSpeakerCharacteristic.js';
 import { SoundTouchSpeakerInformationCharacteristic } from './services/SoundTouchSpeakerInformationCharacteristic.js';
 import { SoundTouchSpeakerOnCharacteristic } from './services/SoundTouchSpeakerOnCharacteristic.js';
+import { SoundTouchSpeakerVolumeCharacteristic } from './services/SoundTouchSpeakerVolumeCharacteristic.js';
 
 export class SoundTouchSpeakerPlatformAccessory extends SoundTouchSpeakerCharacteristic {
   private readonly speakerCharacteristics: SoundTouchSpeakerCharacteristic[];
@@ -80,9 +81,20 @@ export class SoundTouchSpeakerPlatformAccessory extends SoundTouchSpeakerCharact
       ...props,
     });
 
+    const speakerService =
+      SoundTouchSpeakerPlatformAccessory.ensureAccessoryService({
+        serviceType: ServiceType.SPEAKER,
+        service: props.platform.service.Speaker,
+        ...props,
+      });
+
     const characteristics = [
       await SoundTouchSpeakerOnCharacteristic.create({
         service,
+        ...props,
+      }),
+      await SoundTouchSpeakerVolumeCharacteristic.create({
+        service: speakerService,
         ...props,
       }),
       ...props.defaultCharacteristics,

--- a/src/accessories/services/SoundTouchSpeakerCharacteristic.ts
+++ b/src/accessories/services/SoundTouchSpeakerCharacteristic.ts
@@ -5,6 +5,7 @@ import { DeviceLogger, Logger } from '../../utils/FormattedLogger.js';
 
 export enum ServiceType {
   'ON_OFF' = 'ON',
+  'SPEAKER' = 'SPEAKER',
 }
 
 export abstract class SoundTouchSpeakerCharacteristic {

--- a/src/accessories/services/SoundTouchSpeakerOnCharacteristic.ts
+++ b/src/accessories/services/SoundTouchSpeakerOnCharacteristic.ts
@@ -9,10 +9,18 @@ import { SoundTouchHomebridgePlatform } from '../../platform.js';
 import { KeyValue } from '../../devices/SoundTouch/api/index.js';
 import { SoundTouchSpeakerCharacteristic } from './SoundTouchSpeakerCharacteristic.js';
 
+// After toggling power the speaker takes a moment to settle. Within this
+// window a repeated press of the same desired state is ignored, so rapid
+// HomeKit toggles don't hammer the device. This is a non-blocking cooldown —
+// the setter returns immediately rather than stalling a concurrent volume set.
+const POWER_SETTLE_MS = 5000;
+
 export class SoundTouchSpeakerOnCharacteristic extends SoundTouchSpeakerCharacteristic {
   private readonly service: Service;
 
   private characteristic: Characteristic;
+
+  private settleUntil = 0;
 
   constructor({
     service,
@@ -52,18 +60,23 @@ export class SoundTouchSpeakerOnCharacteristic extends SoundTouchSpeakerCharacte
     const desiredPowerStatus = value as boolean;
 
     try {
-      if (this.characteristic.value !== desiredPowerStatus) {
-        await this.device.api.pressKey(KeyValue.power);
+      if (this.characteristic.value === desiredPowerStatus) {
+        return;
       }
+
+      if (Date.now() < this.settleUntil) {
+        this.log.debug('power press ignored while settling');
+        return;
+      }
+
+      await this.device.api.pressKey(KeyValue.power);
+      this.settleUntil = Date.now() + POWER_SETTLE_MS;
       this.log.success('set status - %s', desiredPowerStatus ? 'on' : 'off');
     } catch (e: unknown) {
       this.log.error('error setting on status', e);
       throw new this.platform.api.hap.HapStatusError(
         this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE
       );
-    } finally {
-      //give it time before trying to change.
-      await new Promise((resolve) => setTimeout(resolve, 5000));
     }
   }
 

--- a/src/accessories/services/SoundTouchSpeakerVolumeCharacteristic.ts
+++ b/src/accessories/services/SoundTouchSpeakerVolumeCharacteristic.ts
@@ -1,0 +1,82 @@
+import {
+  Characteristic,
+  CharacteristicValue,
+  PlatformAccessory,
+  Service,
+} from 'homebridge';
+import { SoundTouchDevice } from '../../devices/SoundTouch/SoundTouchDevice.js';
+import { SoundTouchHomebridgePlatform } from '../../platform.js';
+import { SoundTouchSpeakerCharacteristic } from './SoundTouchSpeakerCharacteristic.js';
+
+export class SoundTouchSpeakerVolumeCharacteristic extends SoundTouchSpeakerCharacteristic {
+  private readonly service: Service;
+
+  private characteristic: Characteristic;
+
+  constructor({
+    service,
+    ...props
+  }: {
+    device: SoundTouchDevice;
+    service: Service;
+    platform: SoundTouchHomebridgePlatform;
+    accessory: PlatformAccessory;
+  }) {
+    super(props);
+
+    this.service = service;
+    this.characteristic = this.service.getCharacteristic(
+      this.platform.characteristic.Volume
+    );
+
+    this.characteristic
+      .onSet(this.setVolume.bind(this))
+      .onGet(this.getVolume.bind(this));
+  }
+
+  async init(): Promise<void> {
+    this.log.debug('initialising volume characteristic');
+    await this.refresh();
+  }
+
+  async refresh(): Promise<void> {
+    const volume = await this.device.api.getVolume();
+    if (volume === undefined) {
+      return;
+    }
+    this.log.debug('get volume', volume.actual);
+    if (volume.actual !== this.characteristic.value) {
+      this.characteristic.updateValue(volume.actual);
+    }
+  }
+
+  async setVolume(value: CharacteristicValue): Promise<void> {
+    const desiredVolume = value as number;
+
+    try {
+      await this.device.api.setVolume(desiredVolume);
+      this.log.success('set volume - %d', desiredVolume);
+    } catch (e: unknown) {
+      this.log.error('error setting volume', e);
+      throw new this.platform.api.hap.HapStatusError(
+        this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE
+      );
+    }
+  }
+
+  async getVolume(): Promise<CharacteristicValue> {
+    const volume = await this.device.api.getVolume();
+    const actual = volume?.actual ?? 0;
+    this.log.debug('get volume', actual);
+    return actual;
+  }
+
+  static async create(props: {
+    accessory: PlatformAccessory;
+    device: SoundTouchDevice;
+    platform: SoundTouchHomebridgePlatform;
+    service: Service;
+  }): Promise<SoundTouchSpeakerVolumeCharacteristic> {
+    return new SoundTouchSpeakerVolumeCharacteristic(props);
+  }
+}

--- a/src/accessories/services/__tests__/SoundTouchSpeakerOnCharacteristic.test.ts
+++ b/src/accessories/services/__tests__/SoundTouchSpeakerOnCharacteristic.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { SoundTouchSpeakerOnCharacteristic } from '../SoundTouchSpeakerOnCharacteristic.js';
+import { KeyValue } from '../../../devices/SoundTouch/api/index.js';
+
+class FakeCharacteristic {
+  value: unknown = null;
+  readonly updateValue = jest.fn((value: unknown) => {
+    this.value = value;
+    return this;
+  });
+  readonly onSet = jest.fn(() => this);
+  readonly onGet = jest.fn(() => this);
+}
+
+class HapStatusError extends Error {
+  constructor(readonly hapStatus: number) {
+    super(`HapStatusError ${hapStatus}`);
+  }
+}
+
+function build() {
+  const characteristic = new FakeCharacteristic();
+  const OnIdentifier = { name: 'On' };
+  const service = {
+    getCharacteristic: jest.fn(() => characteristic),
+  };
+  const api = {
+    pressKey: jest.fn<(key: KeyValue) => Promise<boolean>>(),
+    getSource: jest.fn<() => Promise<string | undefined>>(),
+  };
+  const device = { name: 'Kitchen', api };
+  const platform = {
+    characteristic: { On: OnIdentifier },
+    logger: { homebridgeLogger: { log: jest.fn() }, requiredLogLevel: 'debug' },
+    api: {
+      hap: {
+        HapStatusError,
+        HAPStatus: { SERVICE_COMMUNICATION_FAILURE: -70402 },
+      },
+    },
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const props: any = { service, device, platform, accessory: {} };
+  const subject = new SoundTouchSpeakerOnCharacteristic(props);
+
+  return { subject, characteristic, api };
+}
+
+describe('SoundTouchSpeakerOnCharacteristic', () => {
+  let harness: ReturnType<typeof build>;
+
+  beforeEach(() => {
+    harness = build();
+  });
+
+  describe('#setOn', () => {
+    it('presses the power key when the desired state differs from the current value', async () => {
+      harness.characteristic.value = false;
+      harness.api.pressKey.mockResolvedValue(true);
+
+      await harness.subject.setOn(true);
+
+      expect(harness.api.pressKey).toHaveBeenCalledWith(KeyValue.power);
+    });
+
+    it('does not press the power key when the desired state already matches', async () => {
+      harness.characteristic.value = true;
+      harness.api.pressKey.mockResolvedValue(true);
+
+      await harness.subject.setOn(true);
+
+      expect(harness.api.pressKey).not.toHaveBeenCalled();
+    });
+
+    it('throws a HAP communication error when the key press fails', async () => {
+      harness.characteristic.value = false;
+      harness.api.pressKey.mockRejectedValue(new Error('unreachable'));
+
+      await expect(harness.subject.setOn(true)).rejects.toBeInstanceOf(
+        HapStatusError
+      );
+    });
+
+    // Guards the power/volume race: the setter used to block for 5s in a
+    // `finally`, which stalled a near-simultaneous volume set. Under fake
+    // timers a blocking `setTimeout(5000)` would never resolve, so awaiting
+    // the setter would hang and this test would time out.
+    it('resolves without blocking on a settle delay', async () => {
+      jest.useFakeTimers();
+      try {
+        harness.characteristic.value = false;
+        harness.api.pressKey.mockResolvedValue(true);
+
+        await harness.subject.setOn(true);
+
+        expect(harness.api.pressKey).toHaveBeenCalledWith(KeyValue.power);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('skips a repeated power press while the device is still settling', async () => {
+      jest.useFakeTimers();
+      try {
+        harness.characteristic.value = false;
+        harness.api.pressKey.mockResolvedValue(true);
+
+        await harness.subject.setOn(true);
+        // HomeKit reflects the new state; a rapid re-trigger of the same
+        // desired state must not hammer the power key mid-settle.
+        harness.characteristic.value = false;
+        await harness.subject.setOn(true);
+
+        expect(harness.api.pressKey).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+
+  describe('#getOn', () => {
+    it('reports on when the device is not in standby', async () => {
+      harness.api.getSource.mockResolvedValue('SPOTIFY');
+
+      await expect(harness.subject.getOn()).resolves.toBe(true);
+    });
+
+    it('reports off when the device is in standby', async () => {
+      harness.api.getSource.mockResolvedValue('STANDBY');
+
+      await expect(harness.subject.getOn()).resolves.toBe(false);
+    });
+  });
+});

--- a/src/accessories/services/__tests__/SoundTouchSpeakerVolumeCharacteristic.test.ts
+++ b/src/accessories/services/__tests__/SoundTouchSpeakerVolumeCharacteristic.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { SoundTouchSpeakerVolumeCharacteristic } from '../SoundTouchSpeakerVolumeCharacteristic.js';
+import type { Volume } from '../../../devices/SoundTouch/api/volume.js';
+
+class FakeCharacteristic {
+  value: unknown = null;
+  readonly updateValue = jest.fn((value: unknown) => {
+    this.value = value;
+    return this;
+  });
+  readonly onSet = jest.fn(() => this);
+  readonly onGet = jest.fn(() => this);
+}
+
+class HapStatusError extends Error {
+  constructor(readonly hapStatus: number) {
+    super(`HapStatusError ${hapStatus}`);
+  }
+}
+
+function volume(actual: number): Volume {
+  return { deviceId: 'DEV1', target: actual, actual, isMuted: false };
+}
+
+function build() {
+  const characteristic = new FakeCharacteristic();
+  const VolumeIdentifier = { name: 'Volume' };
+  const service = {
+    getCharacteristic: jest.fn(() => characteristic),
+  };
+  const api = {
+    getVolume: jest.fn<() => Promise<Volume | undefined>>(),
+    setVolume: jest.fn<(value: number) => Promise<boolean>>(),
+  };
+  const device = { name: 'Kitchen', api };
+  const platform = {
+    characteristic: { Volume: VolumeIdentifier },
+    logger: { homebridgeLogger: { log: jest.fn() }, requiredLogLevel: 'debug' },
+    api: {
+      hap: {
+        HapStatusError,
+        HAPStatus: { SERVICE_COMMUNICATION_FAILURE: -70402 },
+      },
+    },
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const props: any = { service, device, platform, accessory: {} };
+  const subject = new SoundTouchSpeakerVolumeCharacteristic(props);
+
+  return { subject, characteristic, api, service, device, platform };
+}
+
+describe('SoundTouchSpeakerVolumeCharacteristic', () => {
+  let harness: ReturnType<typeof build>;
+
+  beforeEach(() => {
+    harness = build();
+  });
+
+  describe('#getVolume', () => {
+    it('returns the actual volume reported by the device', async () => {
+      harness.api.getVolume.mockResolvedValue(volume(42));
+
+      await expect(harness.subject.getVolume()).resolves.toBe(42);
+    });
+
+    it('returns 0 when the device reports no volume', async () => {
+      harness.api.getVolume.mockResolvedValue(undefined);
+
+      await expect(harness.subject.getVolume()).resolves.toBe(0);
+    });
+  });
+
+  describe('#setVolume', () => {
+    it('sends the desired volume to the device', async () => {
+      harness.api.setVolume.mockResolvedValue(true);
+
+      await harness.subject.setVolume(55);
+
+      expect(harness.api.setVolume).toHaveBeenCalledWith(55);
+    });
+
+    it('throws a HAP communication error when the device call fails', async () => {
+      harness.api.setVolume.mockRejectedValue(new Error('unreachable'));
+
+      await expect(harness.subject.setVolume(30)).rejects.toBeInstanceOf(
+        HapStatusError
+      );
+    });
+  });
+
+  describe('#init', () => {
+    it('refreshes the characteristic from the device on startup', async () => {
+      harness.api.getVolume.mockResolvedValue(volume(15));
+
+      await harness.subject.init();
+
+      expect(harness.characteristic.updateValue).toHaveBeenCalledWith(15);
+    });
+  });
+
+  describe('.create', () => {
+    it('resolves to a volume characteristic instance', async () => {
+      const { service, device, platform } = build();
+
+      const created = await SoundTouchSpeakerVolumeCharacteristic.create({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        service: service as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        device: device as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        platform: platform as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        accessory: {} as any,
+      });
+
+      expect(created).toBeInstanceOf(SoundTouchSpeakerVolumeCharacteristic);
+    });
+  });
+
+  describe('#refresh', () => {
+    it('pushes the actual volume to HomeKit when it has changed', async () => {
+      harness.api.getVolume.mockResolvedValue(volume(70));
+
+      await harness.subject.refresh();
+
+      expect(harness.characteristic.updateValue).toHaveBeenCalledWith(70);
+    });
+
+    it('does not update HomeKit when the volume is unchanged', async () => {
+      harness.characteristic.value = 70;
+      harness.api.getVolume.mockResolvedValue(volume(70));
+
+      await harness.subject.refresh();
+
+      expect(harness.characteristic.updateValue).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the device reports no volume', async () => {
+      harness.api.getVolume.mockResolvedValue(undefined);
+
+      await harness.subject.refresh();
+
+      expect(harness.characteristic.updateValue).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## What

Implements **Plan 02 — Volume control (Switch path)** from the roadmap. Exposes speaker volume in HomeKit on the default **Switch** accessory type by adding a linked HAP **Speaker** service with a `Volume` characteristic (0–100).

The SoundTouch API layer already implemented `getVolume()` / `setVolume()`, so this is pure HomeKit wiring on top of the existing polling refresh loop — no protocol work.

### Also: power/volume race fix

The `On` setter previously blocked for 5 s in a `finally`, which stalled a near-simultaneous volume set. It now records a non-blocking `settleUntil` window and returns immediately, while still **skipping a repeated same-state press mid-settle** to preserve the original anti-hammer intent. A fake-timer test captures the regression (it hangs against the old blocking sleep).

## Scope / deferrals

- **Lightbulb `Brightness` path** — deferred behind Plan 01&#39;s `accessoryType` gate (unchecked in the plan).
- **WebSocket `volumeUpdated` push** — deferred. No WS infrastructure exists in the codebase yet; the plan&#39;s WS decision assumed a per-device connection that isn&#39;t there. Volume uses the existing polling `refresh()`, consistent with the `On` characteristic. A WS push layer is a cross-cutting concern for its own plan.

Both deferrals are recorded in the plan&#39;s Decisions &amp; findings table.

## Changes

- **New** `SoundTouchSpeakerVolumeCharacteristic` — Speaker/Volume get/set/refresh, HAP error on device failure.
- Wire the Speaker service + Volume characteristic into `createAccessory` (Switch path); add `ServiceType.SPEAKER`.
- Non-blocking settle-window fix in `SoundTouchSpeakerOnCharacteristic`.
- Unit tests for both characteristic classes.
- Integration harness: add `Speaker`/`Volume` stub types + assert the Speaker Volume initialises from the device.

## Verification

- ✅ `npm run typecheck`
- ✅ `npm run lint`
- ✅ `npm test` — 204 passing (unit + integration), coverage gate green
- ✅ `npm run build`
- ⬜ Manual `npm run watch` against a real Switch speaker (per plan): confirm the Speaker tile appears, dragging volume tracks the speaker, and external volume changes reflect back. **Not yet done — needs hardware.**