### PR TITLE
docs: plan WebSocket push (gabbo) rollout and define Spike C

### DIFF
--- a/.claude/skills/architect/plans/2026-06-20-websocket-push.md
+++ b/.claude/skills/architect/plans/2026-06-20-websocket-push.md
@@ -1,0 +1,130 @@
+---
+feature: WebSocket push (gabbo) — event-driven characteristic refresh, augmenting HTTP polling
+status: planned # planned | in-progress | done | cancelled
+date: 2026-06-20
+branch: feat/websocket-push
+commit-type: feat
+---
+
+# WebSocket push (gabbo) — event-driven refresh
+
+## Context
+
+Today every characteristic is refreshed by a fixed HTTP **polling** loop
+(`SoundTouchSpeakerPlatformAccessory._refreshDeviceServices`, 2 s). That is
+laggy (up to one interval behind a real change) and wasteful (every device is
+re-GET'd on a timer whether or not anything changed).
+
+The SoundTouch speaker also exposes a **WebSocket notification channel** on
+port `8080`, sub-protocol `gabbo`. It pushes `<updates>` frames when state
+changes — `volumeUpdated`, `nowPlayingUpdated`, `bassUpdated`, `zoneUpdated`,
+`presetsUpdated`, `infoUpdated`, … . Most are "tickles" (they say *what*
+changed; the client re-GETs the matching endpoint); a few carry data inline.
+
+This plan adopts that channel to drive refresh **reactively**: when a tickle
+arrives, refresh the affected characteristic immediately. The target is an
+**augmentation**, not a replacement — polling stays on as a relaxed-interval
+fallback (see decisions). This depends on **plan 06 (polling lifecycle)** for
+the connection-lifecycle machinery and the configurable polling it makes the
+fallback, and is **blocked on Spike C** (see `ROADMAP.md`) until the gabbo
+channel's real-device behaviour is confirmed.
+
+## Decisions & findings
+
+| Date | Decision / finding | Rationale / evidence | Alternatives rejected |
+| --- | --- | --- | --- |
+| 2026-06-20 | **Finding (correction):** there is **no** existing WebSocket connection in the codebase | `grep` for `ws://`/`gabbo`/`8080`/`WebSocket` over `src/` finds only the literal `sender: 'Gabbo'` in the `/key` POST body (`api/api.ts`). The optimistic claim in the volume plan's findings (2026-06-20, "existing per-device WebSocket connection") is **wrong** — the WS channel must be built from scratch. This is exactly why volume's WS path was deferred. | — |
+| 2026-06-20 | **Finding:** the WS *client* needs no new runtime dependency | Node 22/24 ship a global `WebSocket` (undici) supporting sub-protocol negotiation; `engines.node` is `^22.10.0 \|\| ^24.0.0`. `new WebSocket("ws://<ip>:8080", "gabbo")` works out of the box. | Adding `ws` as a runtime dependency (unnecessary; larger supply-chain surface) |
+| 2026-06-20 | **Finding:** the local *test* fake-gabbo server **does** need `ws` (devDependency) | Node has no built-in WS *server*; the fake-gabbo harness (mirroring `FakeSoundTouchServer`) needs one to emit reference frames. Dev-only, so no end-user impact. | Hand-rolling an RFC6455 server (over-engineered for a test double) |
+| 2026-06-20 | **Decision:** augment polling, don't replace it | WS sockets drop (Wi-Fi, speaker standby, idle timeout) and a tickle can be missed. Polling at a relaxed interval (e.g. 30–60 s) is a cheap safety net that reconciles missed events; WS gives the instant updates. User-selected. | Replace polling entirely (no safety net if the socket drops or a tickle is missed) |
+| 2026-06-20 | **Decision:** sequence after plan 06 (polling lifecycle); serialise, don't parallelise | The WS connection has the same lifecycle as the polling loop — open on `init`, tear down on unregister/`shutdown`. Plan 06 builds exactly that (retain wrappers in a `Map`, stop on unregister/shutdown). WS reuses it. Both touch `SoundTouchSpeakerPlatformAccessory.ts` + `platform.ts`, so they **must** serialise. Plan 06 also makes polling configurable, which is what turns polling into the relaxed fallback. | Parallel with plan 06 (guaranteed merge conflicts on shared lifecycle files); before plan 06 (would build connection-lifecycle twice) |
+| 2026-06-20 | **Decision (this session):** research/docs only — no probe or harness code yet | User directive. Record the spike definition, findings, and rollout plan; defer building the probe script and fake-gabbo harness until the spike is scheduled (and ideally a real device is available). | Building the Part-1 harness now (premature given no real-device validation lined up) |
+| 2026-06-20 | **Open (Spike C):** real-device behaviour is unverified | Heartbeat/idle cadence, socket behaviour on standby/power-off, reconnect/backoff semantics, and whether real frames match the v1.1 reference are all undocumented. These shape the reconnect strategy and the fallback interval. Must be answered before implementation. | Building on documented assumptions alone (higher risk of a reconnect-storm or missed-event bug) |
+
+## If cancelled
+
+> Only fill this in when `status: cancelled`. Leave empty otherwise.
+
+## Affected areas
+
+> Indicative — to be finalised by the architect after Spike C resolves.
+
+- **New** `src/devices/SoundTouch/api/notifications/` (or similar) — a
+  `gabbo` WebSocket client: connect to `ws://<ip>:8080` with sub-protocol
+  `"gabbo"`, parse `<updates>` frames (reuse `XMLElement` /
+  `api/utils/xml-element.ts`), and emit typed events (`volumeUpdated`,
+  `nowPlayingUpdated`, …). Owns reconnect/backoff and teardown.
+- `src/devices/SoundTouch/SoundTouchDevice.ts` — own the notification client
+  alongside the HTTP `api`; expose subscribe/teardown.
+- `src/accessories/SoundTouchSpeakerPlatformAccessory.ts` — on a relevant
+  tickle, call the matching characteristic's `refresh()`. Polling becomes the
+  relaxed fallback (interval from plan 06's config).
+- `src/accessories/services/*Characteristic.ts` — no shape change; their
+  existing `refresh()` is the reuse point (updates HAP only when changed).
+- `src/platform.ts` — tear down notification clients on unregister/`shutdown`
+  (alongside plan 06's `stopPolling()`).
+- **New (test)** `src/__integration__/helpers/fake-gabbo-server.ts` — a
+  `ws`-backed fake emitting reference frames, mirroring `FakeSoundTouchServer`.
+- `package.json` — add `ws` (+ `@types/ws`) as **devDependencies** only.
+
+## Conventions for this change
+
+- **Commit type:** `feat:` → minor release. (Phased; each phase its own PR.)
+- **Config schema touched:** likely yes in a later phase (e.g. a toggle to
+  disable push, or to set the fallback interval) — defer the exact shape to the
+  architect post-spike. No schema change in phase 1 if push is always-on with
+  polling fallback.
+- **Tests to add/update:** fake-gabbo harness + a notification-client unit test
+  (connect, parse tickle, emit event, reconnect on close); an integration test
+  asserting a pushed `volumeUpdated` updates the HAP value without advancing the
+  poll timer.
+- Follow **coding-conventions**, the SoundTouch protocol in
+  **soundtouch-api-expert** (read `api-reference.md` → "WebSocket
+  notifications"), and the lifecycle patterns in **homebridge-developer**.
+- **Target branch:** `dev`.
+
+## Phased rollout (post-spike)
+
+Sequenced **after plan 06**. Each phase is its own PR.
+
+- **Phase 1 — connection + lifecycle.** `gabbo` client module: connect,
+  sub-protocol negotiate, parse `<updates>`, reconnect/backoff, teardown on
+  unregister/shutdown. Wire it to trigger the existing accessory `refresh()` on
+  any state-change tickle. Polling retained as fallback. *Heavy.*
+- **Phase 2 — per-event mapping.** Map specific tickles to specific
+  characteristic refreshes (`volumeUpdated`→volume, `nowPlayingUpdated`→on/
+  source, `bassUpdated`→bass, …) instead of refreshing everything; optionally
+  consume inline data to skip the re-GET. *Medium.*
+- **Phase 3 — tune polling + edges.** Relax/disable the polling fallback now
+  that push is primary (config-driven via plan 06); handle reconnect storms,
+  the zone-map update sequence, and standby/power-off socket behaviour per the
+  spike findings. *Medium.*
+
+## Implementation checklist
+
+> Do **not** start until Spike C is resolved and plan 06 has merged.
+
+- [ ] (Spike C) Resolve real-device behaviour — see `ROADMAP.md` → Spike C
+- [ ] Phase 1: `gabbo` WebSocket client (connect, parse, reconnect, teardown)
+- [ ] Phase 1: trigger accessory `refresh()` on state-change tickles
+- [ ] Phase 1: add `ws` + `@types/ws` devDependencies; fake-gabbo test harness
+- [ ] Phase 1: tear down clients on unregister/shutdown (reuse plan 06 lifecycle)
+- [ ] Phase 2: map individual tickles → individual characteristic refreshes
+- [ ] Phase 3: relax/disable polling fallback; handle reconnect + zone sequences
+- [ ] Add/update tests (client unit + integration push-updates-HAP)
+- [ ] Update `config.schema.json` if a push/fallback config field is added
+
+## Verification
+
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] `npm test`
+- [ ] `npm run watch` — with a real speaker: change volume/source from the Bose
+      app and confirm HomeKit reflects it near-instantly (faster than the poll
+      interval); pull the speaker's power and confirm the client reconnects
+      cleanly when it returns.
+
+## PR / release notes
+
+- **PR title (per phase):** e.g. `feat: add gabbo WebSocket client for push updates`
+- **Targets:** `dev`

--- a/.claude/skills/technical-lead/ROADMAP.md
+++ b/.claude/skills/technical-lead/ROADMAP.md
@@ -1,6 +1,6 @@
 # Technical Roadmap
 
-Last updated: 2026-06-20
+Last updated: 2026-06-20 (added plan 07 WebSocket push + Spike C)
 
 This file gives the delivery order and dependency chain across all planned
 features. The individual plan files contain the detail; this file answers
@@ -15,6 +15,8 @@ flowchart TD
     AccessoryTypeNode["[01] Accessory type\nSwitch / Lightbulb"]
     VolLightbulbNode["[02] Volume – Lightbulb path\nBrightness characteristic"]
     PollingNode["[06] Polling lifecycle\nfix/polling-lifecycle"]
+    SpikeC{"Spike C: gabbo\nWebSocket feasibility"}
+    WSNode["[07] WebSocket push\nfeat/websocket-push"]
     SpikeTV{"Spike: TV vs\nper-Switch fallback"}
     SourceNode["[03] Source selection"]
     SpikeA{"Spike A: hotspot\nHTTP API"}
@@ -27,6 +29,8 @@ flowchart TD
     VolSwitchNode -. "shares accessory file" .-> PollingNode
     VolSwitchNode --> AccessoryTypeNode
     AccessoryTypeNode --> VolLightbulbNode
+    PollingNode --> WSNode
+    SpikeC --> WSNode
     SpikeTV --> SourceNode
     SpikeA --> PWA1Node
     PWA1Node --> PWA2Node
@@ -36,15 +40,21 @@ flowchart TD
 
 ## Current state (2026-06-20)
 
-- **Now:** [05] Integration test harness — **PR #58 open against `dev`**, with a
-  coverage-threshold guard added per review; awaiting merge.
-- **Next (ready):** [02] Volume — Switch path. Cut `feat/volume-control` off `dev`
-  once #58 merges. The `On` setter's 5 s `finally` race fix is now **in scope**
-  for this plan (promoted from a finding).
-- **Tech debt (ready):** [06] Polling lifecycle — make polling stoppable on
+- **Done:** [05] Integration test harness — **#58 merged into `dev`**.
+- **In review:** [02] Volume — Switch path — **PR #62 open against `dev`**
+  (CI green). Includes the `On` setter's 5 s `finally` race fix (replaced with a
+  non-blocking settle window). Lightbulb/Brightness path deferred behind plan 01.
+- **Next (ready):** [06] Polling lifecycle — make polling stoppable on
   removal/shutdown and configurable. Shares `SoundTouchSpeakerPlatformAccessory.ts`
-  with plan 02, so **serialise after 02** to avoid conflicts.
-- **Blocked:** [03] Source selection (spike), [04] PWA all phases (spikes A/B).
+  with plan 02, so **serialise after #62 merges** to avoid conflicts.
+- **Blocked:** [03] Source selection (spike), [04] PWA all phases (spikes A/B),
+  **[07] WebSocket push (Spike C + needs plan 06)**.
+- **New:** [07] WebSocket push (`feat/websocket-push`) — adopt the gabbo
+  notification channel for event-driven refresh, **augmenting** polling.
+  Blocked on **Spike C** and sequenced **after plan 06** (shares the
+  connection-lifecycle machinery). Volume's deferred-WS finding now has its own
+  plan + spike. (This session: spike/rollout **docs only** — no probe/harness
+  code yet, per user directive.)
 - Skill changes landed in `dev`: session-cost estimation (#57), planning vs.
   implementation branches (#59), roadmap status + plan-05 calibration (#60).
 
@@ -57,6 +67,7 @@ flowchart TD
 | 3 | **[06] Polling lifecycle** | `fix/polling-lifecycle` | 🟢 Ready (tech debt) | Stop polling on accessory removal/shutdown; make the interval configurable (`0` disables). Surfaced by plan 05. Shares `SoundTouchSpeakerPlatformAccessory.ts` with plan 02 → serialise after 02. `fix:` → patch. |
 | 4 | **[01] Accessory type** | `feat/accessory-type` | ⚪ Planned | Independent of plans 02 and 03, but it's the gate for the Lightbulb/Brightness volume path. Delivering it after the Switch volume path avoids holding volume hostage to the larger config-threading change. |
 | 5 | **[02] Volume — Lightbulb path** | (small follow-up PR or bundled with 01) | ⚪ Planned (gated on 01) | Brightness characteristic wiring is a small addition once plan 01's `accessoryType` gate exists. Can ship in the same PR as plan 01 or immediately after. |
+| 5.5 | **[07] WebSocket push (gabbo)** | `feat/websocket-push` | 🔴 Blocked (Spike C + plan 06) | Event-driven refresh via the gabbo channel (port 8080), **augmenting** polling (polling stays as a relaxed fallback). Reuses plan 06's connection lifecycle and shares `SoundTouchSpeakerPlatformAccessory.ts`/`platform.ts` → **serialise after plan 06**. Blocked on **Spike C** (real-device behaviour). Phased: P1 connection+lifecycle, P2 per-event mapping, P3 tune polling + edges. |
 | 6 | **[03] Source selection** | `feat/source-selection` | 🔴 Blocked (spike) | Independent of 01/02. Blocked on a **spike** (verify Television+InputSource on a real device; choose TV path vs per-source Switch fallback). Cannot be committed until the spike resolves the architecture choice. |
 | 7 | **[04] PWA — Phase 1** | `feat/pwa` | 🔴 Blocked (spike A) | Architecturally separate (new `web/` workspace + embedded HTTP server). Blocked on **spike A** (reverse-engineer the hotspot provisioning HTTP API at `http://192.0.2.1`). Phase 1 must ship before phases 2 and 3 (it creates the web scaffold and embedded server). |
 | 8 | **[04] PWA — Phase 2** | `feat/pwa` | 🔴 Blocked (needs P1) | Group management via the zone API (`/getZone`, `/setZone`, etc. — already implemented in `src/devices/SoundTouch/api/zone.ts`). Needs the phase 1 PWA scaffold and embedded server to be in place. |
@@ -78,6 +89,7 @@ below.
 | **[01] Accessory type** | Heavy | Config threading through `DeviceConfiguration`, branching the hardcoded Switch in `createAccessory` (`:71`), and orphan-service pruning on type change | Plan a full session. Gates the Lightbulb volume follow-up. ~11 items. |
 | **[02] Volume — Lightbulb path** | Small | Brightness characteristic wiring once plan 01's `accessoryType` gate exists | Bundle into plan 01's PR or a quick follow-up. |
 | **[06] Polling lifecycle** | Small–Medium | Modifies existing platform + accessory lifecycle (retain wrappers, stop on unregister/shutdown) and threads two config fields; async lifecycle reasoning + a couple of tests | Contained; the integration harness already exercises the lifecycle path. |
+| **[07] WebSocket push — Phase 1** | Heavy (est.) | New stateful per-device connection (connect/parse/reconnect/teardown), a new `ws`-backed fake-gabbo harness, and async lifecycle threaded through `platform.ts`/accessory; async timing + reconnect is high iteration risk | Plan a full session. Re-estimate after Spike C. Phases 2–3 are Medium. |
 | **[03] Source selection** | TBD (blocked) | Estimate after the TV-vs-Switch spike resolves the architecture | Re-estimate once unblocked. |
 | **[04] PWA — Phase 1–3** | TBD (blocked) | New `web/` workspace + embedded `src/server/`; estimate after spike A | Each phase is its own session at minimum. |
 
@@ -96,7 +108,7 @@ When a unit ships, record actual-vs-estimate here so future estimates sharpen.
 
 ## Spikes (blockers)
 
-Two features are gated on spikes that must happen on a real device before code
+Three features are gated on spikes that must happen on a real device before code
 is written. These are not implementation tasks — they're time-boxed
 investigations with a concrete question to answer.
 
@@ -122,9 +134,60 @@ What must be resolved:
 1. `api.user.storagePath()` gives the writable directory — confirm atomic write (write-then-rename) doesn't corrupt Homebridge state.
 2. Does Homebridge Config UI X watch for external config changes and reload, or is a restart always required?
 
+### Spike C — gabbo WebSocket push feasibility
+**Blocks:** plan 07 (WebSocket push). Plan 06 is the *other* prerequisite (shared lifecycle) but is not blocked by this spike.
+
+**Question to answer:** does the gabbo channel (`ws://<ip>:8080`, sub-protocol
+`gabbo`) deliver the state-change notifications we need, reliably enough to drive
+(or augment) characteristic refresh — and what connection/reconnect/teardown
+semantics must the client implement?
+
+What we know (from `soundtouch-api-expert/api-reference.md` → "WebSocket
+notifications"):
+- Open with `new WebSocket("ws://<ip>:8080", "gabbo")`; the speaker pushes
+  `<updates deviceID="…">` frames. Most are tickles (`<volumeUpdated/>`,
+  `<nowPlayingUpdated>…`, `<bassUpdated/>`, `<zoneUpdated/>`, `<infoUpdated/>`,
+  `<sourcesUpdated/>`); a few carry data inline (`presetsUpdated`,
+  `nowPlayingUpdated`, `recentsUpdated`, `nowSelectionUpdated`).
+- Empty `<updates …></updates>` frames act as a heartbeat.
+- Node 22/24 ship a global `WebSocket` (undici) → **client needs no new runtime
+  dependency**. A local fake-gabbo **server** for tests needs `ws` (devDep).
+- **Correction to a prior assumption:** there is currently **no** WebSocket code
+  in the repo. The volume plan's 2026-06-20 finding that an "existing per-device
+  WebSocket connection" could be reused is **wrong** — confirmed by grep. The
+  channel is greenfield.
+
+**Two parts (split by hardware need):**
+
+*Part 1 — no hardware (doable in-sandbox):*
+- Build a throwaway probe client + a minimal `ws`-backed fake-gabbo server that
+  emits the reference frames; prove sub-protocol negotiation, `<updates>`
+  parsing (reuse `api/utils/xml-element.ts`), and tickle→re-GET dispatch.
+- Output: validated parse/dispatch logic + a reusable test double.
+
+*Part 2 — real hardware (needs a Bose SoundTouch speaker):*
+- Run `node scripts/gabbo-probe.mjs <ip>` (to be written): open the socket, log
+  every frame with timestamps for a session while the user toggles
+  volume/power/source/preset from the Bose app.
+- Capture and record in plan 07's findings:
+  1. Is the `gabbo` sub-protocol accepted on connect?
+  2. Do real frames match the v1.1 reference shapes?
+  3. Heartbeat / empty-update cadence and idle-timeout behaviour.
+  4. What happens to the socket on **standby/power-off** — closed? silent? Does
+     it need a reconnect, and on what trigger?
+  5. Reconnect/backoff behaviour after a drop; multi-device behaviour.
+- **Time-box:** one capture session. We'll know by the end which events fire,
+  their real shapes, and the connection lifecycle rules — enough to finalise the
+  reconnect strategy and the polling-fallback interval.
+
+**Status (2026-06-20):** docs/spike defined; **no probe or harness built yet**
+(user directive: research/docs only this session). Part 1 can proceed any time;
+Part 2 is parked until a real device is available.
+
 ## Key coupling notes
 
 - **Volume and accessory type are intentionally decoupled for delivery.** Plan 02's Switch/Speaker path ships first and independently; the Lightbulb/Brightness path is a small follow-up gated on plan 01. Users get volume control without waiting for the accessory-type rework.
 - **The integration test harness (plan 05) is infrastructure, not a feature.** It has no user impact and no release, but it provides the safety net that makes the subsequent feature PRs lower risk.
 - **The PWA (plan 04) is architecturally independent** from the HomeKit features (plans 01–03). It introduces a new `web/` workspace and a `src/server/` embedded HTTP server — concerns that don't overlap with the HAP characteristic layer. Its phases can proceed in parallel with plans 01–03 once spike A is resolved.
 - **Source selection (plan 03) is the highest-risk HomeKit feature.** The Television+InputSource pattern has real caveats (external publishing, `Active`/`On` power model clash, buried UX). The spike must answer the architecture question before any code is written; the per-source Switch fallback is the documented Plan B if the TV path is too rough.
+- **WebSocket push (plan 07) augments polling — it does not replace it.** Plan 06 makes polling stoppable and configurable; plan 07 then makes WS the primary, instant refresh trigger while polling stays as a relaxed-interval fallback for dropped sockets / missed tickles. The two **share the connection-lifecycle code** (open on init, tear down on unregister/shutdown) and both edit `SoundTouchSpeakerPlatformAccessory.ts`/`platform.ts`, so plan 07 **must serialise after plan 06** — building it earlier would implement the same lifecycle twice and guarantee merge conflicts.


### PR DESCRIPTION
## What

Planning-only PR (no code). Adds the rollout plan and spike for adopting the SoundTouch **gabbo WebSocket** notification channel (port 8080) to drive **event-driven** characteristic refresh — the deferred follow-up from the volume PR (#62).

### New plan 07 — `feat/websocket-push`
`.claude/skills/architect/plans/2026-06-20-websocket-push.md`

- **Augments** polling, doesn&#39;t replace it: WS gives instant updates; HTTP polling stays as a relaxed-interval (~30–60 s) fallback for dropped sockets / missed tickles.
- **Sequenced after plan 06 (polling lifecycle)** — they share the per-device connection lifecycle (open on init, tear down on unregister/shutdown) and both edit `SoundTouchSpeakerPlatformAccessory.ts` / `platform.ts`, so they must serialise.
- **Phased:** P1 connection + lifecycle · P2 per-event mapping · P3 tune polling + edges.

### New Spike C — gabbo feasibility (in `ROADMAP.md`)
Time-boxed investigation that answers, on real hardware, whether the channel behaves as documented:
- **Part 1 (no hardware):** throwaway probe client + `ws`-backed fake-gabbo server proving sub-protocol negotiation, `` parsing, and tickle→re-GET dispatch.
- **Part 2 (needs a Bose speaker):** a `gabbo-probe.mjs ` script capturing real frames, heartbeat cadence, idle timeout, standby/power-off socket behaviour, and reconnect semantics.

## Key findings recorded

- **Correction:** there is **no** WebSocket connection in the repo today — the volume plan&#39;s &#34;reuse the existing per-device connection&#34; assumption was wrong (confirmed by grep; only the literal `sender: &#39;Gabbo&#39;` string exists). The channel is greenfield.
- The WS **client needs no new runtime dependency** (Node 22/24 global `WebSocket`); only the **test** fake-gabbo server needs `ws` as a devDependency.

## Roadmap changes

- Dependency graph: added `[07] WebSocket push` + `Spike C` nodes.
- Delivery order: inserted plan 07 (blocked on Spike C + plan 06); refreshed current-state (#58 merged, #62 in review).
- Session-cost table: plan 07 Phase 1 estimated **Heavy** (new stateful connection + reconnect + new test harness).
- Spikes section: Spike C defined; coupling note on augment-not-replace + serialise-after-06.

## Scope

Per directive, **docs/planning only this session** — no probe or harness code. Part 1 of the spike can proceed any time; Part 2 is parked until a real device is available.