### PR TITLE
ci: only comment & label feat/fix/perf PRs on release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,6 +4,11 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semantic-release/npm",
-    "@semantic-release/github"
+    [
+      "@semantic-release/github",
+      {
+        "successCommentCondition": "<% return !issue.pull_request || /^(feat|fix|perf)(\\(.+\\))?!?:/.test(issue.title); %>"
+      }
+    ]
   ]
 }


### PR DESCRIPTION
## What

Restrict the post-release &#34;released&#34; comment and label so they only land on **functional/performance** PRs.

## Background

The release comment + `released` (or `released on @beta`) label come from **`@semantic-release/github`** (last plugin in `.releaserc.json`), run by `publish.yml` on push to `latest`/`beta`.

By default that plugin comments on and labels **every** PR/issue in the release range — `feat`, `fix`, `perf`, **and** `chore`, `docs`, `refactor`, etc. There is no built-in commit-type filter. Since the repo squash-merges (PR title → commit message), that means basically every merged PR got tagged, including non-user-facing ones.

## Change

Added a `successCommentCondition` Lodash template to the `@semantic-release/github` plugin config:

```json
&#34;&lt;% return !issue.pull_request || /^(feat|fix|perf)(\\(.+\\))?!?:/.test(issue.title); %&gt;&#34;
```

- **PRs**: commented/labeled only when the title is `feat` / `fix` / `perf` (incl. scopes and `!` breaking marker). `chore`, `docs`, `style`, `refactor`, `test`, `ci`, `build` are skipped.
- **Issues** (referenced via `fixes #N`): still commented on regardless of type — `!issue.pull_request` short-circuits to `true`.

Relies on PR titles being valid Conventional Commits, already enforced by the `PR Title` workflow.

## Notes
- Labeling is gated by the same condition (the plugin only labels what it comments on), so the `released` label is now feat/fix/perf-only too.
- To broaden later, just add types to the regex alternation (e.g. `|revert`).