### PR TITLE
fix: stop device polling on accessory removal/shutdown and honour polling config

### DIFF
--- a/.claude/skills/architect/plans/2026-06-20-polling-lifecycle.md
+++ b/.claude/skills/architect/plans/2026-06-20-polling-lifecycle.md
@@ -1,6 +1,6 @@
 ---
 feature: Polling lifecycle — stop polling on accessory removal/shutdown and make it configurable
-status: planned # planned | in-progress | done | cancelled
+status: in-progress # planned | in-progress | done | cancelled
 date: 2026-06-20
 branch: fix/polling-lifecycle
 commit-type: fix
@@ -44,6 +44,9 @@ loop. This plan fixes the underlying lifecycle in production code.
 | 2026-06-20 | Finding: `PlatformConfiguration.fromExternalConfiguration` hardcodes `pollingInterval` **and** `verbose`, ignoring `props.global?.pollingInterval`/`verbose` (`PlatformConfiguration.ts:41-42`) | Global config for these two fields is silently dropped — a related config-threading bug worth fixing in the same pass | — |
 | 2026-06-20 | Decision: retain wrappers in a `Map<uuid, SoundTouchSpeakerPlatformAccessory>` on the platform and call `stopPolling()` on unregister and on Homebridge `shutdown` | Smallest change that makes the loop stoppable; mirrors the existing `_accessories` map | Passing an `AbortSignal` into the accessory (larger refactor); a global polling scheduler (over-engineered for the device count) |
 | 2026-06-20 | Decision: treat `pollingInterval <= 0` as "disable polling" | Gives users an off switch without a new boolean field | A separate `polling: boolean` field (more schema surface for the same effect) |
+| 2026-06-20 | Finding: `DeviceConfiguration` already preserves `0` — its constructor uses `?? DEFAULT` (nullish), not `\|\|`, so an explicit `0` survives | No code change needed there; locked it with a regression test. The real config bug was `PlatformConfiguration.fromExternalConfiguration` hardcoding `verbose`/`pollingInterval` (now threaded from `props.global`) | Coercing `0`→default with `\|\|` (would silently re-enable polling) |
+| 2026-06-20 | Finding: the unregister-time `stopPolling()` is **defensive** — in a single process, discovery runs once at `didFinishLaunching`, so a not-rediscovered device never had a wrapper created this run. The load-bearing fix is the `shutdown` handler that stops all wrappers | Kept the unregister guard for any future re-discovery path, but the integration test exercises the `shutdown` path (a discovered accessory's loop is stopped) as the meaningful assertion | Dropping the unregister guard (leaves a gap if discovery is ever re-run) |
+| 2026-06-20 | Implemented the stop as a non-blocking flag flip (`stopPolling()` sets `_isPolling = false`); the loop exits at its next guard check | Already idempotent and safe to call when not polling; covered by a fake-timer accessory test that proves `refresh` stops being called | An `AbortController` (larger change for no extra benefit at this device count) |
 
 ## If cancelled
 
@@ -78,14 +81,14 @@ loop. This plan fixes the underlying lifecycle in production code.
 
 ## Implementation checklist
 
-- [ ] Platform: retain wrappers in a `Map<uuid, SoundTouchSpeakerPlatformAccessory>`
-- [ ] Platform: call `stopPolling()` when unregistering a stale cached accessory
-- [ ] Platform: add an `api.on('shutdown', …)` handler that stops all wrappers
-- [ ] Accessory: start polling only when `pollingInterval > 0`; make `stopPolling()` idempotent
-- [ ] Config: thread `global.pollingInterval` and `global.verbose` through `PlatformConfiguration`
-- [ ] Config: let `pollingInterval: 0` survive as "disabled" through `DeviceConfiguration`
-- [ ] Add/update tests (config + integration lifecycle)
-- [ ] Update `config.schema.json` description noting `0` disables polling
+- [x] Platform: retain wrappers in a `Map<uuid, SoundTouchSpeakerPlatformAccessory>`
+- [x] Platform: call `stopPolling()` when unregistering a stale cached accessory (defensive — see findings)
+- [x] Platform: add an `api.on('shutdown', …)` handler that stops all wrappers
+- [x] Accessory: start polling only when `pollingInterval > 0`; `stopPolling()` is idempotent
+- [x] Config: thread `global.pollingInterval` and `global.verbose` through `PlatformConfiguration`
+- [x] Config: `pollingInterval: 0` survives as "disabled" through `DeviceConfiguration` (already did via `??`; locked with a test)
+- [x] Add/update tests (config + accessory polling lifecycle + integration shutdown)
+- [x] Update `config.schema.json` description noting `0` disables polling
 
 ## Verification
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -17,6 +17,7 @@
         "properties": {
           "pollingInterval": {
             "type": "number",
+            "description": "How often (ms) to poll each device for state. Set to 0 to disable polling.",
             "placeholder": "2000"
           },
           "verbose": {
@@ -55,6 +56,7 @@
             },
             "pollingInterval": {
               "type": "integer",
+              "description": "Override the polling interval (ms) for this device. Set to 0 to disable polling.",
               "default": 2000
             }
           }

--- a/src/PlatformConfiguration.ts
+++ b/src/PlatformConfiguration.ts
@@ -38,8 +38,9 @@ export class PlatformConfiguration {
     return new PlatformConfiguration({
       discoverAllAccessories:
         props.discoverAllAccessories ?? DEFAULT_DISCOVER_ALL_ACCESSORIES,
-      verbose: DEFAULT_VERBOSE,
-      pollingInterval: DEFAULT_POLLING_INTERVAL,
+      verbose: props.global?.verbose ?? DEFAULT_VERBOSE,
+      // `??` (not `||`) so an explicit `0` survives as "polling disabled".
+      pollingInterval: props.global?.pollingInterval ?? DEFAULT_POLLING_INTERVAL,
       accessories:
         props.accessories
           ?.map((accessory) => {

--- a/src/__integration__/helpers/homebridge-stub.ts
+++ b/src/__integration__/helpers/homebridge-stub.ts
@@ -139,10 +139,14 @@ export class HomebridgeApiStub {
   } as unknown as Logging;
 
   private didFinishLaunching?: () => unknown;
+  private shutdown?: () => unknown;
 
   on(event: string, callback: () => unknown): this {
     if (event === 'didFinishLaunching') {
       this.didFinishLaunching = callback;
+    }
+    if (event === 'shutdown') {
+      this.shutdown = callback;
     }
     return this;
   }
@@ -165,6 +169,10 @@ export class HomebridgeApiStub {
 
   async emitDidFinishLaunching(): Promise<void> {
     await this.didFinishLaunching?.();
+  }
+
+  emitShutdown(): void {
+    this.shutdown?.();
   }
 
   asHomebridgeApi(): API {

--- a/src/__integration__/platform-lifecycle.integration.test.ts
+++ b/src/__integration__/platform-lifecycle.integration.test.ts
@@ -9,6 +9,7 @@ import {
 import type { PlatformAccessory } from 'homebridge';
 import type { ExternalPlatformConfig } from '../ExternalPlatformConfig.js';
 import { SoundTouchHomebridgePlatform } from '../platform.js';
+import { SoundTouchSpeakerPlatformAccessory } from '../accessories/SoundTouchSpeakerPlatformAccessory.js';
 import {
   FakeSoundTouchServer,
   infoXml,
@@ -94,6 +95,20 @@ describe('SoundTouchHomebridgePlatform', () => {
       await api.emitDidFinishLaunching();
 
       expect(api.unregisteredAccessories).toContain(stale);
+    });
+
+    it('stops the discovered accessory polling loop on shutdown', async () => {
+      const stopPolling = jest.spyOn(
+        SoundTouchSpeakerPlatformAccessory.prototype,
+        'stopPolling'
+      );
+      createPlatform();
+      await api.emitDidFinishLaunching();
+
+      api.emitShutdown();
+
+      expect(stopPolling).toHaveBeenCalledTimes(1);
+      stopPolling.mockRestore();
     });
   });
 });

--- a/src/__tests__/PlatformConfiguration.test.ts
+++ b/src/__tests__/PlatformConfiguration.test.ts
@@ -68,6 +68,33 @@ describe('PlatformConfiguration', () => {
       expect(config.accessories[0].pollingInterval).toBe(5000);
     });
 
+    test('honours global.pollingInterval at the platform level', () => {
+      const config = PlatformConfiguration.fromExternalConfiguration({
+        platform: PLATFORM_NAME,
+        global: { pollingInterval: 5000 },
+      });
+
+      expect(config.pollingInterval).toBe(5000);
+    });
+
+    test('honours global.verbose at the platform level', () => {
+      const config = PlatformConfiguration.fromExternalConfiguration({
+        platform: PLATFORM_NAME,
+        global: { verbose: true },
+      });
+
+      expect(config.verbose).toBe(true);
+    });
+
+    test('preserves an explicit pollingInterval of 0 (disabled)', () => {
+      const config = PlatformConfiguration.fromExternalConfiguration({
+        platform: PLATFORM_NAME,
+        global: { pollingInterval: 0 },
+      });
+
+      expect(config.pollingInterval).toBe(0);
+    });
+
     test('accessory-level pollingInterval overrides global', () => {
       const config = PlatformConfiguration.fromExternalConfiguration({
         platform: PLATFORM_NAME,

--- a/src/accessories/SoundTouchSpeakerPlatformAccessory.ts
+++ b/src/accessories/SoundTouchSpeakerPlatformAccessory.ts
@@ -33,7 +33,7 @@ export class SoundTouchSpeakerPlatformAccessory extends SoundTouchSpeakerCharact
       }
     }
 
-    if (this.device.configuration.pollingInterval !== undefined) {
+    if (this.device.configuration.pollingInterval > 0) {
       this._isPolling = true;
       this._refreshDeviceServices().then(() => {
         //no-op

--- a/src/accessories/__tests__/SoundTouchSpeakerPlatformAccessory.test.ts
+++ b/src/accessories/__tests__/SoundTouchSpeakerPlatformAccessory.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { SoundTouchSpeakerPlatformAccessory } from '../SoundTouchSpeakerPlatformAccessory.js';
+import type { SoundTouchSpeakerCharacteristic } from '../services/SoundTouchSpeakerCharacteristic.js';
+
+function build(pollingInterval: number) {
+  const refresh = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+  const init = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+  const characteristic = { init, refresh } as unknown as SoundTouchSpeakerCharacteristic;
+
+  const device = { name: 'Kitchen', configuration: { pollingInterval } };
+  const platform = {
+    logger: { homebridgeLogger: { log: jest.fn() }, requiredLogLevel: 'debug' },
+  };
+
+  const subject = new SoundTouchSpeakerPlatformAccessory({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    accessory: {} as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    device: device as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    platform: platform as any,
+    speakerCharacteristics: [characteristic],
+  });
+
+  return { subject, refresh };
+}
+
+describe('SoundTouchSpeakerPlatformAccessory', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('polling lifecycle', () => {
+    it('does not start polling when the interval is 0 (disabled)', async () => {
+      jest.useFakeTimers();
+      const { subject, refresh } = build(0);
+
+      await subject.init();
+      await jest.advanceTimersByTimeAsync(10000);
+
+      expect(refresh).not.toHaveBeenCalled();
+    });
+
+    it('polls on the configured interval when it is greater than 0', async () => {
+      jest.useFakeTimers();
+      const { subject, refresh } = build(1000);
+
+      await subject.init();
+      await jest.advanceTimersByTimeAsync(1000);
+
+      expect(refresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops the polling loop after stopPolling is called', async () => {
+      jest.useFakeTimers();
+      const { subject, refresh } = build(1000);
+
+      await subject.init();
+      await jest.advanceTimersByTimeAsync(1000);
+
+      subject.stopPolling();
+      // Drain any iteration already scheduled before the stop took effect.
+      await jest.advanceTimersByTimeAsync(1000);
+      const callsAfterStop = refresh.mock.calls.length;
+      await jest.advanceTimersByTimeAsync(10000);
+
+      expect(refresh.mock.calls).toHaveLength(callsAfterStop);
+    });
+
+    it('is safe to call stopPolling when not polling', () => {
+      const { subject } = build(0);
+
+      expect(() => subject.stopPolling()).not.toThrow();
+    });
+  });
+});

--- a/src/devices/SoundTouch/__tests__/SoundTouchDeviceConfiguration.test.ts
+++ b/src/devices/SoundTouch/__tests__/SoundTouchDeviceConfiguration.test.ts
@@ -29,6 +29,14 @@ describe('DeviceConfiguration', () => {
       });
       expect(config.pollingInterval).toBe(5000);
     });
+
+    test('preserves a pollingInterval of 0 (disabled) rather than defaulting', () => {
+      const config = DeviceConfiguration.createForRoom({
+        name: 'Kitchen',
+        pollingInterval: 0,
+      });
+      expect(config.pollingInterval).toBe(0);
+    });
   });
 
   describe('createForIp', () => {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -22,6 +22,10 @@ export class SoundTouchHomebridgePlatform implements DynamicPlatformPlugin {
   public readonly api: API;
 
   private readonly _accessories: Map<string, PlatformAccessory> = new Map();
+  private readonly _accessoryWrappers: Map<
+    string,
+    SoundTouchSpeakerPlatformAccessory
+  > = new Map();
   private readonly _discoveredCacheUUIDs: string[] = [];
 
   constructor(
@@ -50,6 +54,13 @@ export class SoundTouchHomebridgePlatform implements DynamicPlatformPlugin {
       this.logger.debug('Started didFinishLaunching callback');
       await this.discoverDevices();
       this.logger.debug('Finished didFinishLaunching callback');
+    });
+
+    this.api.on('shutdown', () => {
+      this.logger.debug('Stopping polling on shutdown');
+      for (const wrapper of this._accessoryWrappers.values()) {
+        wrapper.stopPolling();
+      }
     });
   }
 
@@ -111,11 +122,12 @@ export class SoundTouchHomebridgePlatform implements DynamicPlatformPlugin {
             existingAccessory.displayName
           );
 
-          await SoundTouchSpeakerPlatformAccessory.create({
+          const wrapper = await SoundTouchSpeakerPlatformAccessory.create({
             platform: this,
             accessory: existingAccessory,
             device,
           });
+          this._accessoryWrappers.set(uuid, wrapper);
         } else {
           this.logger.info('Adding new accessory:', device.name);
 
@@ -123,11 +135,12 @@ export class SoundTouchHomebridgePlatform implements DynamicPlatformPlugin {
 
           accessory.context.device = device;
 
-          await SoundTouchSpeakerPlatformAccessory.create({
+          const wrapper = await SoundTouchSpeakerPlatformAccessory.create({
             platform: this,
             accessory,
             device,
           });
+          this._accessoryWrappers.set(uuid, wrapper);
 
           this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [
             accessory,
@@ -146,6 +159,15 @@ export class SoundTouchHomebridgePlatform implements DynamicPlatformPlugin {
           'Removing existing accessory from cache:',
           accessory.displayName
         );
+
+        // Stop the orphaned wrapper's polling loop before it's unregistered,
+        // otherwise it keeps firing requests at a device that's gone.
+        const wrapper = this._accessoryWrappers.get(uuid);
+        if (wrapper) {
+          wrapper.stopPolling();
+          this._accessoryWrappers.delete(uuid);
+        }
+
         this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [
           accessory,
         ]);


### PR DESCRIPTION
## What

Implements **Plan 06 — Polling lifecycle**. The device polling loop could never be stopped and was effectively always-on at 2 s.

### Problems fixed
- The platform **discarded the `SoundTouchSpeakerPlatformAccessory` wrapper** returned by `create()`, so `stopPolling()` was unreachable — the loop ran until the process died (no clean shutdown), and an orphaned wrapper would keep polling a removed device.
- `PlatformConfiguration.fromExternalConfiguration` **hardcoded** `pollingInterval` and `verbose`, silently dropping `global` config for both.
- `init()` started polling whenever `pollingInterval` was *defined* (always true), so there was **no way to disable** it.

### Changes
- **`platform.ts`** — retain wrappers in a `Map`; stop them on stale-accessory unregister and via a new `api.on(&#39;shutdown&#39;)` handler.
- **`SoundTouchSpeakerPlatformAccessory.ts`** — start polling only when `pollingInterval &gt; 0` (so `0` disables it); `stopPolling()` is idempotent.
- **`PlatformConfiguration.ts`** — thread `global.pollingInterval` / `global.verbose` (preserving an explicit `0` via `??`).
- **`config.schema.json`** — document that `0` disables polling.

### Notes from the findings
- `DeviceConfiguration` already preserved `0` (it used `??`, not `||`) — no code change there, locked with a regression test.
- The unregister-time `stopPolling()` is **defensive**: in a single process, discovery runs once, so a not-rediscovered device never had a wrapper that run. The load-bearing fix is the `shutdown` handler — which is what the integration test exercises.

## Tests
- `PlatformConfiguration` — honours `global.pollingInterval`/`verbose`; preserves `0`.
- `SoundTouchDeviceConfiguration` — `0` preserved, not defaulted.
- **New** `SoundTouchSpeakerPlatformAccessory` unit test — no polling when interval is `0`; polls when `&gt;0`; `stopPolling()` halts the loop (deterministic via fake timers).
- Integration — `shutdown` stops the discovered accessory&#39;s polling loop (stub extended with a `shutdown` hook).

## Verification

- ✅ `npm run typecheck`
- ✅ `npm run lint`
- ✅ `npm test` — 196 passing (unit + integration), coverage gate green
- ⬜ `npm run watch` — confirm a removed accessory stops polling and a restart shuts the loop down cleanly (needs a running Homebridge; not done in sandbox).

## Sequencing note

The roadmap sequences this **after** Plan 02 (volume, PR #62) because both touch `SoundTouchSpeakerPlatformAccessory.ts`. Since #62 is on hold, this was built off `dev` without it — the overlap is small (this touches `init`/polling lifecycle; #62 touches `createAccessory`/the `On` setter), so #62 will need a minor rebase over this when it un-holds.