### PR TITLE
test: add gabbo WebSocket harness and notification parser (Spike C Part 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/bonjour": "^3.5.10",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.14.1",
+        "@types/ws": "^8.18.1",
         "@types/xml2js": "^0.4.9",
         "axios-mock-adapter": "^2.1.0",
         "eslint": "^10.5.0",
@@ -42,7 +43,8 @@
         "semantic-release": "25.0.5",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.61.0"
+        "typescript-eslint": "^8.61.0",
+        "ws": "^8.21.0"
       },
       "engines": {
         "homebridge": "^1.8.0 || ^2.0.0",
@@ -4006,6 +4008,16 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/xml2js": {
       "version": "0.4.14",
@@ -15664,6 +15676,28 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xml2js": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/bonjour": "^3.5.10",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.14.1",
+    "@types/ws": "^8.18.1",
     "@types/xml2js": "^0.4.9",
     "axios-mock-adapter": "^2.1.0",
     "eslint": "^10.5.0",
@@ -64,7 +65,8 @@
     "semantic-release": "25.0.5",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.61.0"
+    "typescript-eslint": "^8.61.0",
+    "ws": "^8.21.0"
   },
   "overrides": {
     "babel-plugin-istanbul": "^8.0.2",

--- a/src/__integration__/gabbo-notifications.integration.test.ts
+++ b/src/__integration__/gabbo-notifications.integration.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { FakeGabboServer } from './helpers/fake-gabbo-server.js';
+import {
+  parseGabboFrame,
+  type GabboNotification,
+} from '../devices/SoundTouch/api/notifications/gabbo-notification.js';
+import { Endpoints } from '../devices/SoundTouch/api/endpoints.js';
+
+/**
+ * Spike C, Part 1 (no hardware): prove our connect → receive → parse → dispatch
+ * chain works against a faithful fake of the gabbo channel. A real global
+ * `WebSocket` client connects to a `ws` server over an actual socket, so this
+ * exercises sub-protocol negotiation and framing for real — only the speaker
+ * itself is faked.
+ */
+describe('gabbo WebSocket notifications', () => {
+  let server: FakeGabboServer;
+  let port: number;
+  let socket: WebSocket | undefined;
+
+  beforeEach(async () => {
+    server = new FakeGabboServer();
+    port = await server.start();
+  });
+
+  afterEach(async () => {
+    socket?.close();
+    socket = undefined;
+    await server.stop();
+  });
+
+  function open(protocols?: string | string[]): Promise<WebSocket> {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`, protocols);
+    socket = ws;
+    return new Promise((resolve, reject) => {
+      ws.addEventListener('open', () => resolve(ws));
+      ws.addEventListener('error', () => reject(new Error('connection failed')));
+    });
+  }
+
+  function nextFrame(ws: WebSocket): Promise<string> {
+    return new Promise((resolve) => {
+      ws.addEventListener(
+        'message',
+        (event) => resolve(String((event as MessageEvent).data)),
+        { once: true }
+      );
+    });
+  }
+
+  describe('sub-protocol negotiation', () => {
+    it('negotiates the gabbo sub-protocol on connect', async () => {
+      const ws = await open('gabbo');
+
+      expect(ws.protocol).toBe('gabbo');
+      expect(server.connectionCount).toBe(1);
+      expect(server.negotiatedProtocols).toEqual(['gabbo']);
+    });
+
+    it('rejects a client that does not request the gabbo sub-protocol', async () => {
+      await expect(open()).rejects.toThrow();
+    });
+  });
+
+  describe('receiving and dispatching frames', () => {
+    it('parses a pushed volume tickle into a volume re-fetch', async () => {
+      const ws = await open('gabbo');
+      const frame = nextFrame(ws);
+
+      server.push('<updates deviceID="DEV1"><volumeUpdated/></updates>');
+
+      const [notification] = await parseGabboFrame(await frame);
+      expect(notification.type).toBe('volume');
+      expect(notification.refetch).toBe(Endpoints.volume);
+    });
+
+    it('parses a pushed now-playing change into a now-playing re-fetch', async () => {
+      const ws = await open('gabbo');
+      const frame = nextFrame(ws);
+
+      server.push(
+        '<updates deviceID="DEV1"><nowPlayingUpdated>' +
+          '<nowPlaying source="SPOTIFY"/></nowPlayingUpdated></updates>'
+      );
+
+      const [notification] = await parseGabboFrame(await frame);
+      expect(notification.type).toBe('nowPlaying');
+      expect(notification.refetch).toBe(Endpoints.nowPlaying);
+    });
+
+    it('treats an empty frame as a heartbeat with no notifications', async () => {
+      const ws = await open('gabbo');
+      const frame = nextFrame(ws);
+
+      server.push('<updates deviceID="DEV1"></updates>');
+
+      const notifications: GabboNotification[] = await parseGabboFrame(
+        await frame
+      );
+      expect(notifications).toEqual([]);
+    });
+  });
+});

--- a/src/__integration__/helpers/fake-gabbo-server.ts
+++ b/src/__integration__/helpers/fake-gabbo-server.ts
@@ -1,0 +1,77 @@
+import { WebSocketServer, type WebSocket } from 'ws';
+import type { AddressInfo } from 'node:net';
+import type { IncomingMessage } from 'node:http';
+
+/**
+ * An in-process stand-in for a SoundTouch speaker's `gabbo` notification
+ * WebSocket (normally port 8080). Node ships a global `WebSocket` *client*, but
+ * no server, so the harness needs `ws` (a devDependency) to accept connections
+ * and push `<updates>` frames.
+ *
+ * The server only accepts the `gabbo` sub-protocol — a client that fails to
+ * request it is rejected, which is exactly the handshake behaviour Spike C
+ * needs to validate. Tests drive it with `push()` to emit a frame to every
+ * connected client.
+ */
+export class FakeGabboServer {
+  private server?: WebSocketServer;
+  private readonly sockets = new Set<WebSocket>();
+
+  /** The sub-protocol each connection negotiated, in connection order. */
+  readonly negotiatedProtocols: string[] = [];
+
+  start(): Promise<number> {
+    const server = new WebSocketServer({
+      host: '127.0.0.1',
+      port: 0,
+      // Reject the upgrade outright unless the client offered `gabbo`...
+      verifyClient: (info: { req: IncomingMessage }) =>
+        String(info.req.headers['sec-websocket-protocol'] ?? '')
+          .split(',')
+          .map((protocol) => protocol.trim())
+          .includes('gabbo'),
+      // ...then echo `gabbo` back as the negotiated sub-protocol.
+      handleProtocols: (protocols) => (protocols.has('gabbo') ? 'gabbo' : false),
+    });
+    this.server = server;
+
+    server.on('connection', (socket) => {
+      this.sockets.add(socket);
+      this.negotiatedProtocols.push(socket.protocol);
+      socket.on('close', () => this.sockets.delete(socket));
+    });
+
+    return new Promise((resolve, reject) => {
+      server.once('error', reject);
+      server.once('listening', () => {
+        resolve((server.address() as AddressInfo).port);
+      });
+    });
+  }
+
+  /** Push a raw frame (e.g. an `<updates>` XML string) to every client. */
+  push(frame: string): void {
+    for (const socket of this.sockets) {
+      socket.send(frame);
+    }
+  }
+
+  get connectionCount(): number {
+    return this.sockets.size;
+  }
+
+  stop(): Promise<void> {
+    const server = this.server;
+    this.server = undefined;
+    if (!server) {
+      return Promise.resolve();
+    }
+    for (const socket of this.sockets) {
+      socket.terminate();
+    }
+    this.sockets.clear();
+    return new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+}

--- a/src/devices/SoundTouch/api/notifications/__tests__/gabbo-notification.test.ts
+++ b/src/devices/SoundTouch/api/notifications/__tests__/gabbo-notification.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from '@jest/globals';
+import { parseGabboFrame } from '../gabbo-notification.js';
+import { Endpoints } from '../../endpoints.js';
+
+describe('parseGabboFrame', () => {
+  it('maps a volume tickle to a volume re-fetch', async () => {
+    const [notification] = await parseGabboFrame(
+      '<updates deviceID="DEV1"><volumeUpdated/></updates>'
+    );
+
+    expect(notification.type).toBe('volume');
+    expect(notification.refetch).toBe(Endpoints.volume);
+    expect(notification.deviceId).toBe('DEV1');
+  });
+
+  it('maps a now-playing change to a now-playing re-fetch', async () => {
+    const [notification] = await parseGabboFrame(
+      '<updates deviceID="DEV1"><nowPlayingUpdated>' +
+        '<nowPlaying source="SPOTIFY"/></nowPlayingUpdated></updates>'
+    );
+
+    expect(notification.type).toBe('nowPlaying');
+    expect(notification.refetch).toBe(Endpoints.nowPlaying);
+  });
+
+  it('maps a bass tickle to a bass re-fetch', async () => {
+    const [notification] = await parseGabboFrame(
+      '<updates deviceID="DEV1"><bassUpdated/></updates>'
+    );
+
+    expect(notification.type).toBe('bass');
+    expect(notification.refetch).toBe(Endpoints.bass);
+  });
+
+  it('maps a zone tickle to a getZone re-fetch', async () => {
+    const [notification] = await parseGabboFrame(
+      '<updates deviceID="DEV1"><zoneUpdated/></updates>'
+    );
+
+    expect(notification.type).toBe('zone');
+    expect(notification.refetch).toBe(Endpoints.getZone);
+  });
+
+  it('maps an info tickle to an info re-fetch', async () => {
+    const [notification] = await parseGabboFrame(
+      '<updates deviceID="DEV1"><infoUpdated/></updates>'
+    );
+
+    expect(notification.type).toBe('info');
+    expect(notification.refetch).toBe(Endpoints.info);
+  });
+
+  it('maps a presets tickle to a presets re-fetch', async () => {
+    const [notification] = await parseGabboFrame(
+      '<updates deviceID="DEV1"><presetsUpdated><presets/></presetsUpdated></updates>'
+    );
+
+    expect(notification.type).toBe('presets');
+    expect(notification.refetch).toBe(Endpoints.presets);
+  });
+
+  it('maps a now-selection change with no re-fetch (inline only)', async () => {
+    const [notification] = await parseGabboFrame(
+      '<updates deviceID="DEV1"><nowSelectionUpdated><preset id="1"/>' +
+        '</nowSelectionUpdated></updates>'
+    );
+
+    expect(notification.type).toBe('nowSelection');
+    expect(notification.refetch).toBeUndefined();
+  });
+
+  it('exposes the updates element for inline-data consumers', async () => {
+    const [notification] = await parseGabboFrame(
+      '<updates deviceID="DEV1"><volumeUpdated/></updates>'
+    );
+
+    expect(notification.element.getAttribute('deviceID')).toBe('DEV1');
+  });
+
+  it('returns no notifications for an empty heartbeat frame', async () => {
+    const notifications = await parseGabboFrame(
+      '<updates deviceID="DEV1"></updates>'
+    );
+
+    expect(notifications).toEqual([]);
+  });
+
+  it('ignores unrecognised update children', async () => {
+    const notifications = await parseGabboFrame(
+      '<updates deviceID="DEV1"><somethingNewUpdated/></updates>'
+    );
+
+    expect(notifications).toEqual([]);
+  });
+
+  it('returns nothing when the frame is not an updates element', async () => {
+    const notifications = await parseGabboFrame('<status>/standby</status>');
+
+    expect(notifications).toEqual([]);
+  });
+});

--- a/src/devices/SoundTouch/api/notifications/gabbo-notification.ts
+++ b/src/devices/SoundTouch/api/notifications/gabbo-notification.ts
@@ -1,0 +1,100 @@
+import { parseString } from 'xml2js';
+import { promisify } from 'util';
+import { Endpoints } from '../endpoints.js';
+import { XMLElement } from '../utils/index.js';
+
+/**
+ * The SoundTouch speaker pushes `<updates>` frames over its `gabbo` WebSocket
+ * (port 8080) when state changes. Most are "tickles" — they name *what*
+ * changed; the client re-fetches the matching GET endpoint. A few carry data
+ * inline. This module turns a raw `<updates>` frame into typed notifications,
+ * each naming the endpoint to re-GET (where one applies).
+ *
+ * Reference: `soundtouch-api-expert/api-reference.md` → "WebSocket
+ * notifications". This is the parse/dispatch logic Spike C validates against
+ * the documented frame shapes.
+ */
+
+export type GabboNotificationType =
+  | 'volume'
+  | 'nowPlaying'
+  | 'bass'
+  | 'zone'
+  | 'presets'
+  | 'sources'
+  | 'info'
+  | 'nowSelection'
+  | 'recents'
+  | 'connectionState'
+  | 'swUpdateStatus'
+  | 'siteSurveyResults'
+  | 'acctMode';
+
+export interface GabboNotification {
+  readonly type: GabboNotificationType;
+  /** The GET endpoint to re-fetch for this change, when the tickle carries no
+   *  usable inline data. `undefined` ⇒ inline-only or no action needed. */
+  readonly refetch?: Endpoints;
+  readonly deviceId?: string;
+  /** The full `<updates>` element, so inline-data consumers can read it. */
+  readonly element: XMLElement;
+}
+
+interface Mapping {
+  readonly type: GabboNotificationType;
+  readonly refetch?: Endpoints;
+}
+
+// `<updates>` child element name → notification type + the endpoint to re-GET.
+const UPDATE_MAP: Readonly<Record<string, Mapping>> = {
+  volumeUpdated: { type: 'volume', refetch: Endpoints.volume },
+  nowPlayingUpdated: { type: 'nowPlaying', refetch: Endpoints.nowPlaying },
+  bassUpdated: { type: 'bass', refetch: Endpoints.bass },
+  zoneUpdated: { type: 'zone', refetch: Endpoints.getZone },
+  presetsUpdated: { type: 'presets', refetch: Endpoints.presets },
+  sourcesUpdated: { type: 'sources', refetch: Endpoints.sources },
+  infoUpdated: { type: 'info', refetch: Endpoints.info },
+  nowSelectionUpdated: { type: 'nowSelection' },
+  recentsUpdated: { type: 'recents' },
+  connectionStateUpdated: { type: 'connectionState' },
+  swUpdateStatusUpdated: { type: 'swUpdateStatus' },
+  siteSurveyResultsUpdated: { type: 'siteSurveyResults' },
+  acctModeUpdated: { type: 'acctMode' },
+};
+
+const parseXML = promisify(
+  (xml: string, cb: (err: Error | null, res: unknown) => void) =>
+    parseString(xml, { trim: true }, cb)
+);
+
+/**
+ * Map a parsed `<updates>` element to the notifications it carries. A frame
+ * usually carries a single change; an empty frame (heartbeat) yields none.
+ */
+export function notificationsFromUpdates(
+  updates: XMLElement
+): GabboNotification[] {
+  const deviceId = updates.getAttribute('deviceID');
+
+  return Object.entries(UPDATE_MAP)
+    .filter(([child]) => updates.hasChild(child))
+    .map(([, mapping]) => ({
+      type: mapping.type,
+      refetch: mapping.refetch,
+      deviceId,
+      element: updates,
+    }));
+}
+
+/** Parse a raw `<updates>` WebSocket frame into typed notifications. */
+export async function parseGabboFrame(
+  xml: string
+): Promise<GabboNotification[]> {
+  const data = await parseXML(xml);
+  const root = new XMLElement(data);
+  const updates = root.getChild('updates');
+  if (!updates) {
+    return [];
+  }
+  return notificationsFromUpdates(updates);
+}


### PR DESCRIPTION
## What

**Spike C, Part 1** — the no-hardware half of the gabbo WebSocket feasibility spike. Validates that the SoundTouch notification channel can drive characteristic refresh, *before* committing to the stateful Phase 1 client.

### Deliverables
- **`gabbo-notification.ts`** — a pure parser (`parseGabboFrame` / `notificationsFromUpdates`) mapping each documented `` frame to a typed notification + the GET endpoint to re-fetch (volume, nowPlaying, bass, zone, presets, sources, info, nowSelection, …). Empty heartbeats and unknown children yield nothing.
- **`fake-gabbo-server.ts`** — a `ws`-backed test double (the reusable output of the spike). Enforces the `gabbo` sub-protocol via `verifyClient` (rejects clients that don&#39;t request it) and can `push()` frames to connected clients.
- **Tests** — a parser unit test over the documented frame shapes, plus an integration test that connects a real Node global `WebSocket` to the fake server over an actual socket, negotiates the sub-protocol, receives a pushed frame, and parses it to the right dispatch.

## Findings confirmed (recorded for Spike C)

- ✅ **Client needs no runtime dependency** — Node 22/24 ship a global `WebSocket` (verified on **v22.22.2**, `typeof WebSocket === &#39;function&#39;`). Only the *test* server needs `ws` (added as a **devDependency**; `@types/ws` too).
- ✅ **Sub-protocol negotiation works** over a real socket — gabbo is accepted; a client that omits it is rejected at the handshake.
- ✅ **The documented frame shapes parse and dispatch correctly**, including the tickle→re-GET mapping and inline-only frames.

## Still open — Spike C Part 2 (needs a real Bose speaker)

Heartbeat/idle cadence, idle-timeout, **standby/power-off socket behaviour**, and **reconnect/backoff** semantics. These shape the *stateful, reconnecting* Phase 1 client, which remains **blocked on plan 06** (shared connection lifecycle) and Part 2.

## Scope notes

- This adds only **pure parse/dispatch logic + test infra** — *not* the stateful connecting client (open/reconnect/teardown), which is Phase 1 and stays blocked.
- The Spike C status / ROADMAP update is a *planning* change; per the planning-vs-implementation branch split I&#39;ve kept it off this code branch — happy to land it on a planning branch next.

## Verification

- ✅ `npm run typecheck`
- ✅ `npm run lint`
- ✅ `npm test` — 203 passing (unit + integration), coverage gate green
- ✅ `npm run knip` — clean (no unused-dependency flag for `ws`/`@types/ws`)