### PR TITLE
ci: run impacted-only tests on PRs, full regression on merge to dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,84 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded validation runs on the same PR/branch.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  # PR validation: run only the tests impacted by the changed files.
+  # Jest resolves the (transitive) import graph, so a changed source file
+  # runs every suite that exercises it — not just changed test files.
+  pr-validation:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      BASE_REF: ${{ github.base_ref }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22.x, 24.x]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Check out the PR head (not the synthetic merge commit) with full
+          # history so Jest can diff against the base branch.
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Fetch base branch
+        run: git fetch --no-tags origin "$BASE_REF"
+
+      # Impacted-test selection only follows import/require edges. Changes to
+      # config, the lockfile, mocks, fixtures, or committed snapshots fall
+      # outside that graph, so fall back to the full suite when they change.
+      - name: Determine test scope
+        id: scope
+        run: |
+          changed=$(git diff --name-only "origin/${BASE_REF}...HEAD")
+          echo "Changed files:"
+          echo "$changed"
+          if echo "$changed" | grep -qE '^(jest\.config\.ts|tsconfig\.json|package\.json|package-lock\.json|\.swcrc|__mocks__/|test/|.*\.snap)$'; then
+            echo "Config/lockfile/fixture/snapshot change detected — running full suite."
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=impacted" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Test (impacted)
+        if: steps.scope.outputs.mode == 'impacted'
+        run: npm run test:impacted
+
+      - name: Test (full — config/fixture change)
+        if: steps.scope.outputs.mode == 'full'
+        run: npm run test:ci
+
+      - name: Audit dependencies
+        run: |
+          npm list --outdated || true
+          npm audit || true
+
+  # Full regression: runs on merge/push to dev. Always the complete suite.
+  regression:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -48,8 +124,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Test
-        run: npm test
+      - name: Test (full regression)
+        run: npm run test:ci
 
       - name: Audit dependencies
         run: |

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "test": "jest",
     "test:unit": "jest --selectProjects unit",
     "test:integration": "jest --selectProjects integration",
+    "test:ci": "jest --ci",
+    "test:impacted": "jest --ci --changedSince=origin/${BASE_REF:-dev} --passWithNoTests --coverage=false",
     "knip": "knip",
     "prepare": "husky"
   },


### PR DESCRIPTION
## What

Splits CI so **PR validation runs only the tests impacted by the changed files**, while **full regression runs on merge/push to `dev`**.

Works with `dev`&#39;s existing **unit / integration** Jest projects — impacted selection spans both, and full regression runs everything.

## How

`.github/workflows/ci.yml` now has two gated jobs:

### `pr-validation` (`on: pull_request`)
- Checks out the **PR head** with full history (`fetch-depth: 0`) so the diff against the base is exact.
- Runs `jest --changedSince=origin/`. Jest resolves the **transitive import graph**, so a changed *source* file runs every suite that exercises it — across **both** the `unit` and `integration` projects — not just changed test files. (Verified: editing `platform.ts` selects the integration lifecycle suite + the accessory unit suite that reach it.)
- `--passWithNoTests` → docs-only PRs stay green instead of failing.
- `--ci` → new/missing snapshots **fail** instead of being silently written.
- **Full-suite fallback** when changes fall outside the import graph: `jest.config.ts`, `tsconfig.json`, `package.json`, `package-lock.json`, `.swcrc`, `__mocks__/`, `test/` fixtures, or `*.snap`.
- Coverage off for impacted runs (partial coverage numbers are misleading).

### `regression` (`on: push` to `dev`)
- Always runs the complete suite (unit + integration) **with** coverage (`test:ci`).

Also adds a `concurrency` group to cancel superseded PR runs, and two npm scripts (alongside dev&#39;s `test:unit` / `test:integration`):
- `test:ci` → `jest --ci`
- `test:impacted` → `jest --ci --changedSince=origin/${BASE_REF:-dev} --passWithNoTests --coverage=false`

## Validation (run locally against `dev`)
- Full suite (`test:ci`) → **28 suites / 212 tests** pass (unit + integration).
- Change a unit-covered source file → selects only the impacted unit **and** integration suites.
- Change `platform.ts` → selects the integration lifecycle suite + accessory unit suite (dependency-graph resolved).
- Docs-only change → `No tests found … passWithNoTests` → green.

## Notes / boundaries
- Impacted selection follows `import`/`require` edges only; everything outside that graph is handled by the config/fixture fallback **and** the full regression on `dev`.
- Impacted **integration** tests do run on PRs (they cover changed functionality). If you&#39;d prefer PRs to run impacted *unit* tests only and defer all integration to `dev`, that&#39;s a one-line change to the PR job — say the word.
- Snapshot specifics: impacted suites compare their snapshots normally; obsolete-snapshot pruning and snapshot-only edits are deferred to the full `dev` run (by design).
- Node `22.x`+`24.x` matrix kept on both PR and regression jobs.