### PR TITLE
chore: use version placeholder for tag-based releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "homebridge-soundtouchspeaker",
   "displayName": "SoundTouch Speaker",
   "type": "module",
-  "version": "0.2.4-beta.2",
+  "version": "0.0.0-development",
   "description": "Updates homebridge-soundtouch-platform to work on latest homebridge.",
   "author": "Andrew Trainor",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Versioning for this plugin is handled by **semantic-release** via git tags (see `.releaserc.json`). The `version` field in `package.json` is overwritten at publish time, so a hardcoded value (`0.2.4-beta.2`) is misleading.

This PR sets it to the conventional semantic-release placeholder `0.0.0-development`.

## Why `0.0.0-development` instead of removing it

npm requires a valid `version` field for `package.json` to be processed (`npm install`, packing, etc. error without it), so the field can't simply be omitted. `0.0.0-development` is the documented semantic-release convention that signals "this is managed by tags."