### PR TITLE
docs: cancel Switch volume path; pivot to Plan 01 → Lightbulb brightness

### DIFF
--- a/.claude/skills/architect/plans/2026-06-19-volume-control.md
+++ b/.claude/skills/architect/plans/2026-06-19-volume-control.md
@@ -1,33 +1,32 @@
 ---
-feature: Volume control — Speaker service (Switch mode) and Lightbulb Brightness (Lightbulb mode)
-status: planned # planned | in-progress | done | cancelled
+feature: Volume control — Lightbulb Brightness (Lightbulb mode)
+status: in-progress # planned | in-progress | done | cancelled
 date: 2026-06-19
 updated: 2026-06-20
 branch: feat/volume-control
 commit-type: feat
 ---
 
-# Volume control — Speaker service (Switch) and Lightbulb Brightness (Lightbulb)
+# Volume control — Lightbulb Brightness (Lightbulb)
 
 ## Context
 
-Expose speaker volume in HomeKit for both accessory types:
+Expose speaker volume in HomeKit via the Lightbulb accessory type:
 
-- **Switch mode (default, ships first):** add a linked **Speaker** service with a
-  `Volume` characteristic (0–100). This is a separate tile in the Home app,
-  independent of the On/Off switch. No dependency on plan 01.
-- **Lightbulb mode (plan 01 prerequisite):** expose volume via the Lightbulb's
+- **Lightbulb mode (requires plan 01):** expose volume via the Lightbulb's
   `Brightness` characteristic (0–100). `Brightness 0` powers the speaker off;
   raising from 0 powers it back on.
+
+The Switch path was evaluated and cancelled — see Decisions & findings below.
 
 The API layer is already complete: `api.getVolume()` returns
 `{ target, actual, isMuted }` (`src/devices/SoundTouch/api/volume.ts`) and
 `api.setVolume(value)` POSTs `/volume` (`src/devices/SoundTouch/api/api.ts:69`).
 This is purely HomeKit wiring — no protocol work.
 
-**Implementation order:** plan 02 ships before plan 01. The Switch/Speaker path
-works independently. The Lightbulb/Brightness path is wired in plan 02 but
-activates only once plan 01 enables the Lightbulb accessory type.
+**Implementation order:** plan 01 (accessory type) ships first — it is the gate
+that enables the Lightbulb service. Plan 02 Lightbulb path ships immediately
+after, bundled with or as a quick follow-up to plan 01.
 
 ## Decisions & findings
 
@@ -41,6 +40,8 @@ activates only once plan 01 enables the Lightbulb accessory type.
 | 2026-06-20 | Two characteristic classes: `SoundTouchSpeakerVolumeCharacteristic` (Speaker/Volume) and the Lightbulb Brightness wiring | Different services, different power-off semantics; cleaner to keep them separate than to parameterise one class | One class parameterised by service/characteristic type — more complex with marginal reuse |
 | 2026-06-20 | WebSocket push used for external volume changes — no new WS infrastructure needed | The speaker sends a `volumeUpdated` tickle on port 8080 (existing per-device WebSocket connection) whenever volume changes externally. The characteristic's `refresh()` listens for this event and re-fetches via `api.getVolume()`, then pushes the new value to HomeKit via `characteristic.updateValue`. The WS connection is already open; volume just needs to subscribe to the existing event emitter. | Polling on a timer — less responsive and wastes requests; opening a second WebSocket — redundant |
 | 2026-06-20 | Promote the `On` setter's 5 s `finally` sleep fix into plan 02 scope (in-scope, not just a finding) | The race has been a passive finding since 2026-06-19. Plan 02 introduces the volume set that races it, and plan 02 already touches the power/volume interaction — so the fix belongs here. The brief must hand this off as a concrete task, not an open hazard. (Polling-loop lifecycle is a *separate* concern — see plan 06.) | Leaving it a passive finding (risk it never gets fixed); a separate fix PR touching `SoundTouchSpeakerOnCharacteristic.ts` (merge-conflict churn with plan 02, which also edits it) |
+| 2026-06-20 | **DECISION: Switch volume path cancelled.** HAP `Switch` service exposes only a binary `On` characteristic — there is no `Volume` characteristic it can own. Bolting a linked `Speaker`/`Volume` service onto a Switch accessory creates a disconnected second tile with no clear relationship to the Switch tile. Switch = binary (0/1); volume = range (0–100). The two are architecturally incompatible in a single coherent HomeKit UX. The correct range characteristic is `Lightbulb.Brightness` (0–100), which is the target. | HAP constraint: Switch cannot natively carry a range characteristic. UX constraint: a linked tile is confusing and unintuitive. Volume on `Brightness` is the semantically correct mapping: 0 = off, 1–100 = volume level. | Keeping Switch path (unintuitive UX, HAP mismatch); adding a Speaker tile linked to Switch (disconnected tile, no power semantics). |
+| 2026-06-20 | Plan 01 (accessory type) is now the immediate prerequisite — plan 02 gates on it | Lightbulb path cannot ship without the `accessoryType` config gate. Plan 01 ships first; plan 02 Lightbulb path follows immediately. | Attempting to embed volume-on-Switch as a stop-gap before Plan 01 (rejected: binary vs range mismatch; already reverted from #62) |
 
 ## If cancelled
 
@@ -48,29 +49,24 @@ activates only once plan 01 enables the Lightbulb accessory type.
 
 ## Affected areas
 
-- **New** `src/accessories/services/SoundTouchSpeakerVolumeCharacteristic.ts` —
-  characteristic class for the **Speaker** service path. Takes
-  `{ service, device, platform, accessory }`, grabs
-  `platform.characteristic.Volume`, binds `onSet`/`onGet`, implements
-  `init()`/`refresh()` (update only when changed via `characteristic.updateValue`),
-  exposes static async `create`. Logs via `this.log`.
 - **New** `src/accessories/services/SoundTouchSpeakerBrightnessCharacteristic.ts` —
-  characteristic class for the **Lightbulb** path. Same pattern but uses
-  `platform.characteristic.Brightness`; additionally maps `0 → power off` and
+  characteristic class for the **Lightbulb** path. Uses
+  `platform.characteristic.Brightness`; maps `0 → power off` and
   `>0 from off → power on` (coordinates with `SoundTouchSpeakerOnCharacteristic`).
+  Pattern: `{ service, device, platform, accessory }`, binds `onSet`/`onGet`,
+  implements `init()`/`refresh()` (update only when changed via
+  `characteristic.updateValue`), exposes static async `create`. Logs via
+  `this.log`.
 - `src/accessories/SoundTouchSpeakerPlatformAccessory.ts`:
-  - **Switch path:** add a linked Speaker service and wire
-    `SoundTouchSpeakerVolumeCharacteristic` to it.
   - **Lightbulb path (plan 01 gate):** add `SoundTouchSpeakerBrightnessCharacteristic`
     to the Lightbulb service alongside `On`.
 
 ## Conventions for this change
 
 - **Commit type:** `feat:` → minor release.
-- **Config schema touched:** no new fields; volume is always-on per accessory type.
+- **Config schema touched:** no new fields; volume is always-on for Lightbulb
+  accessory type (plan 01 adds `accessoryType` field).
 - **Tests to add/update:**
-  - `src/accessories/services/__tests__/SoundTouchSpeakerVolumeCharacteristic.test.ts`
-    — volume get/set, HAP error on device failure.
   - `src/accessories/services/__tests__/SoundTouchSpeakerBrightnessCharacteristic.test.ts`
     — volume↔brightness mapping, `0 ⇒ off`, `>0-from-off ⇒ on`, race condition
     with the `On` setter.
@@ -80,21 +76,18 @@ activates only once plan 01 enables the Lightbulb accessory type.
 
 ## Design notes / risks
 
-- **On + Brightness interplay (Lightbulb only):** HomeKit often sends `On` and
-  `Brightness` together (e.g. turning on sends `On=true` then `Brightness=last`).
+- **On + Brightness interplay:** HomeKit often sends `On` and `Brightness`
+  together (e.g. turning on sends `On=true` then `Brightness=last`).
   Treat `setBrightness(0)` as power-off; `setBrightness(>0)` as set-volume
   (powering on first if currently off). Guard against fighting the `On` setter's
   5s settle sleep (`SoundTouchSpeakerOnCharacteristic.ts:66`).
-- **Speaker service on Switch:** the Speaker service appears as a linked tile in
-  HomeKit, not embedded in the Switch tile. Confirm the UX is acceptable on a real
-  device before finalising.
-- `getVolume().actual` is the live value for both `refresh()` paths.
+- `getVolume().actual` is the live value for `refresh()`.
 
 ## Implementation checklist
 
-- [ ] Add `SoundTouchSpeakerVolumeCharacteristic` (Speaker service, Volume 0–100)
-- [ ] Wire Speaker service + volume characteristic into `createAccessory` for the
-      Switch path
+> **Prerequisite:** plan 01 (accessory type) must ship first — it provides the
+> `accessoryType` config gate and Lightbulb service that plan 02 wires into.
+
 - [ ] Add `SoundTouchSpeakerBrightnessCharacteristic` (Lightbulb Brightness ↔
       volume, 0 = power off)
 - [ ] Wire Brightness characteristic into `createAccessory` for the Lightbulb path
@@ -104,21 +97,19 @@ activates only once plan 01 enables the Lightbulb accessory type.
       `finally` sleep (`SoundTouchSpeakerOnCharacteristic.ts:66`) with a
       non-blocking settle/debounce, so a near-simultaneous volume set isn't
       blocked or fought by the power set
-- [ ] Add tests for both characteristic classes (incl. a power+volume
-      interaction test that would fail against the old 5 s sleep)
+- [ ] Add tests for `SoundTouchSpeakerBrightnessCharacteristic` (incl. a
+      power+volume interaction test that would fail against the old 5 s sleep)
 
 ## Verification
 
 - [ ] `npm run lint`
 - [ ] `npm run build`
 - [ ] `npm test`
-- [ ] `npm run watch` — with a **Switch** speaker: confirm the Speaker tile appears,
-      dragging volume tracks the speaker, and external volume changes reflect back.
-- [ ] `npm run watch` — with a **Lightbulb** speaker (after plan 01): drag brightness,
-      confirm volume tracks; set to 0, confirm power off; raise from 0, confirm power
-      on.
+- [ ] `npm run watch` — with a **Lightbulb** speaker (requires plan 01): drag
+      brightness, confirm volume tracks; set to 0, confirm power off; raise from 0,
+      confirm power on.
 
 ## PR / release notes
 
-- **PR title:** `feat: add volume control via Speaker service and Lightbulb brightness`
+- **PR title:** `feat: add volume control via Lightbulb brightness`
 - **Targets:** `dev`

--- a/.claude/skills/technical-lead/ROADMAP.md
+++ b/.claude/skills/technical-lead/ROADMAP.md
@@ -1,6 +1,6 @@
 # Technical Roadmap
 
-Last updated: 2026-06-20 (added plan 07 WebSocket push + Spike C)
+Last updated: 2026-06-20 (cancelled Switch volume path; Plan 01 → Lightbulb path is now the volume delivery sequence)
 
 This file gives the delivery order and dependency chain across all planned
 features. The individual plan files contain the detail; this file answers
@@ -11,7 +11,6 @@ features. The individual plan files contain the detail; this file answers
 ```mermaid
 flowchart TD
     HarnessNode["[05] Integration test harness\ntest/integration-harness"]
-    VolSwitchNode["[02] Volume – Switch path\nSpeaker service"]
     AccessoryTypeNode["[01] Accessory type\nSwitch / Lightbulb"]
     VolLightbulbNode["[02] Volume – Lightbulb path\nBrightness characteristic"]
     PollingNode["[06] Polling lifecycle\nfix/polling-lifecycle"]
@@ -25,9 +24,7 @@ flowchart TD
     PWA2Node["[04] PWA – Phase 2\nGroup management"]
     PWA3Node["[04] PWA – Phase 3\nConfig sync"]
 
-    HarnessNode --> VolSwitchNode
-    VolSwitchNode -. "shares accessory file" .-> PollingNode
-    VolSwitchNode --> AccessoryTypeNode
+    HarnessNode --> AccessoryTypeNode
     AccessoryTypeNode --> VolLightbulbNode
     PollingNode --> WSNode
     SpikeC --> WSNode
@@ -41,20 +38,21 @@ flowchart TD
 ## Current state (2026-06-20)
 
 - **Done:** [05] Integration test harness — **#58 merged into `dev`**.
-- **In review:** [02] Volume — Switch path — **PR #62 open against `dev`**
-  (CI green). Includes the `On` setter's 5 s `finally` race fix (replaced with a
-  non-blocking settle window). Lightbulb/Brightness path deferred behind plan 01.
-- **Next (ready):** [06] Polling lifecycle — make polling stoppable on
-  removal/shutdown and configurable. Shares `SoundTouchSpeakerPlatformAccessory.ts`
-  with plan 02, so **serialise after #62 merges** to avoid conflicts.
+- **Done:** [06] Polling lifecycle — **#65 merged into `dev`**. Polling is now
+  stoppable on unregister/shutdown and configurable via `pollingInterval`.
+- **Done (infra):** Spike C Part 1 — gabbo WebSocket harness — **#66 merged into
+  `dev`**. Parse/dispatch logic validated; fake-gabbo server test double in place.
+- **Cancelled:** [02] Volume — Switch path. **PR #62 was merged then reverted (#70)**
+  — the Switch service exposes only a binary `On` characteristic; volume requires
+  a 0–100 range. A linked Speaker tile on a Switch accessory is a UX anti-pattern.
+  `dev` is clean.
+- **Next:** [01] Accessory type — `feat/accessory-type`. Gate for the Lightbulb
+  service, which is the prerequisite for the volume/Brightness path.
+- **After 01:** [02] Volume — Lightbulb path — `SoundTouchSpeakerBrightnessCharacteristic`,
+  wired into the Lightbulb service (`accessoryType: 'lightbulb'`). Includes the
+  `On` setter race fix (5 s `finally` sleep → non-blocking settle).
 - **Blocked:** [03] Source selection (spike), [04] PWA all phases (spikes A/B),
-  **[07] WebSocket push (Spike C + needs plan 06)**.
-- **New:** [07] WebSocket push (`feat/websocket-push`) — adopt the gabbo
-  notification channel for event-driven refresh, **augmenting** polling.
-  Blocked on **Spike C** and sequenced **after plan 06** (shares the
-  connection-lifecycle machinery). Volume's deferred-WS finding now has its own
-  plan + spike. (This session: spike/rollout **docs only** — no probe/harness
-  code yet, per user directive.)
+  **[07] WebSocket push (Spike C Part 2 — real hardware needed + plan 06 done)**.
 - Skill changes landed in `dev`: session-cost estimation (#57), planning vs.
   implementation branches (#59), roadmap status + plan-05 calibration (#60).
 
@@ -62,12 +60,12 @@ flowchart TD
 
 | Order | Plan | Branch | Status | Why this position |
 | ----- | ---- | ------ | ------ | ----------------- |
-| 1 | **[05] Integration test harness** | `test/integration-harness` | 🔵 PR #58 open (review) | Pure test infrastructure, no release. Gives confidence before shipping any user-facing feature. No dependencies. |
-| 2 | **[02] Volume — Switch path** | `feat/volume-control` | 🟢 Ready (next) | Adds immediate value to all existing users on the default Switch accessory type. The Speaker-service path has no dependency on plan 01. Ships first so volume isn't blocked on the accessory-type rework. Now also owns the `On` setter 5 s-sleep race fix. |
-| 3 | **[06] Polling lifecycle** | `fix/polling-lifecycle` | 🟢 Ready (tech debt) | Stop polling on accessory removal/shutdown; make the interval configurable (`0` disables). Surfaced by plan 05. Shares `SoundTouchSpeakerPlatformAccessory.ts` with plan 02 → serialise after 02. `fix:` → patch. |
-| 4 | **[01] Accessory type** | `feat/accessory-type` | ⚪ Planned | Independent of plans 02 and 03, but it's the gate for the Lightbulb/Brightness volume path. Delivering it after the Switch volume path avoids holding volume hostage to the larger config-threading change. |
-| 5 | **[02] Volume — Lightbulb path** | (small follow-up PR or bundled with 01) | ⚪ Planned (gated on 01) | Brightness characteristic wiring is a small addition once plan 01's `accessoryType` gate exists. Can ship in the same PR as plan 01 or immediately after. |
-| 5.5 | **[07] WebSocket push (gabbo)** | `feat/websocket-push` | 🔴 Blocked (Spike C + plan 06) | Event-driven refresh via the gabbo channel (port 8080), **augmenting** polling (polling stays as a relaxed fallback). Reuses plan 06's connection lifecycle and shares `SoundTouchSpeakerPlatformAccessory.ts`/`platform.ts` → **serialise after plan 06**. Blocked on **Spike C** (real-device behaviour). Phased: P1 connection+lifecycle, P2 per-event mapping, P3 tune polling + edges. |
+| 1 | **[05] Integration test harness** | `test/integration-harness` | ✅ #58 merged | Pure test infrastructure, no release. Gives confidence before shipping any user-facing feature. |
+| 2 | **[06] Polling lifecycle** | `fix/polling-lifecycle` | ✅ #65 merged | Stop polling on accessory removal/shutdown; configurable interval. `fix:` → patch. |
+| 2.5 | **Spike C Part 1 — gabbo harness** | `spike/gabbo-harness` | ✅ #66 merged | Validated parse/dispatch; fake-gabbo test double ready. |
+| 3 | **[01] Accessory type** | `feat/accessory-type` | 🟢 Next | Thread `accessoryType: 'switch' \| 'lightbulb'` through config → `DeviceConfiguration` → `createAccessory`; prune orphan services on type change. Gate for the Lightbulb volume path. `feat:` → minor. |
+| 4 | **[02] Volume — Lightbulb path** | `feat/volume-control` | 🟡 In-progress (gated on 01) | `SoundTouchSpeakerBrightnessCharacteristic`: Brightness 0–100 maps to volume; 0 = power off; >0 from off = power on then set. Includes the `On` setter 5 s-sleep race fix. Bundle into plan 01 PR or immediate follow-up. |
+| 5 | **[07] WebSocket push (gabbo)** | `feat/websocket-push` | 🔴 Blocked (Spike C Part 2 + plan 06 ✅) | Event-driven refresh via the gabbo channel (port 8080), **augmenting** polling. Spike C Part 2 needs real hardware. Phased: P1 connection+lifecycle, P2 per-event mapping, P3 tune polling + edges. |
 | 6 | **[03] Source selection** | `feat/source-selection` | 🔴 Blocked (spike) | Independent of 01/02. Blocked on a **spike** (verify Television+InputSource on a real device; choose TV path vs per-source Switch fallback). Cannot be committed until the spike resolves the architecture choice. |
 | 7 | **[04] PWA — Phase 1** | `feat/pwa` | 🔴 Blocked (spike A) | Architecturally separate (new `web/` workspace + embedded HTTP server). Blocked on **spike A** (reverse-engineer the hotspot provisioning HTTP API at `http://192.0.2.1`). Phase 1 must ship before phases 2 and 3 (it creates the web scaffold and embedded server). |
 | 8 | **[04] PWA — Phase 2** | `feat/pwa` | 🔴 Blocked (needs P1) | Group management via the zone API (`/getZone`, `/setZone`, etc. — already implemented in `src/devices/SoundTouch/api/zone.ts`). Needs the phase 1 PWA scaffold and embedded server to be in place. |
@@ -84,11 +82,10 @@ below.
 
 | Plan | Band | Drivers that set the band | Session guidance |
 | ---- | ---- | ------------------------- | ---------------- |
-| **[05] Integration test harness** | Medium | New test infra (fake HTTP server + Homebridge stub) and a Jest `projects` split; lots of additive code but low iteration risk and no release | Best first pick — de-risks every later feature PR. ~10 checklist items. |
-| **[02] Volume — Switch path** | Medium | Pure HomeKit wiring (API already done), but the `On` setter's 5s `finally` sleep introduces a race that needs debounce/reconcile + tests | One known hazard drives the iteration. Highest user value. ~11 items. |
+| **[05] Integration test harness** | Medium | New test infra (fake HTTP server + Homebridge stub) and a Jest `projects` split; lots of additive code but low iteration risk and no release | ✅ Done. |
+| **[06] Polling lifecycle** | Small–Medium | Modifies existing platform + accessory lifecycle (retain wrappers, stop on unregister/shutdown) and threads two config fields; async lifecycle reasoning + a couple of tests | ✅ Done. |
 | **[01] Accessory type** | Heavy | Config threading through `DeviceConfiguration`, branching the hardcoded Switch in `createAccessory` (`:71`), and orphan-service pruning on type change | Plan a full session. Gates the Lightbulb volume follow-up. ~11 items. |
-| **[02] Volume — Lightbulb path** | Small | Brightness characteristic wiring once plan 01's `accessoryType` gate exists | Bundle into plan 01's PR or a quick follow-up. |
-| **[06] Polling lifecycle** | Small–Medium | Modifies existing platform + accessory lifecycle (retain wrappers, stop on unregister/shutdown) and threads two config fields; async lifecycle reasoning + a couple of tests | Contained; the integration harness already exercises the lifecycle path. |
+| **[02] Volume — Lightbulb path** | Small–Medium | `SoundTouchSpeakerBrightnessCharacteristic` + power/volume race fix; `On`/`Brightness` ordering needs careful handling | Bundle into plan 01's PR or a quick follow-up. Race fix is the main iteration risk. |
 | **[07] WebSocket push — Phase 1** | Heavy (est.) | New stateful per-device connection (connect/parse/reconnect/teardown), a new `ws`-backed fake-gabbo harness, and async lifecycle threaded through `platform.ts`/accessory; async timing + reconnect is high iteration risk | Plan a full session. Re-estimate after Spike C. Phases 2–3 are Medium. |
 | **[03] Source selection** | TBD (blocked) | Estimate after the TV-vs-Switch spike resolves the architecture | Re-estimate once unblocked. |
 | **[04] PWA — Phase 1–3** | TBD (blocked) | New `web/` workspace + embedded `src/server/`; estimate after spike A | Each phase is its own session at minimum. |
@@ -186,7 +183,7 @@ Part 2 is parked until a real device is available.
 
 ## Key coupling notes
 
-- **Volume and accessory type are intentionally decoupled for delivery.** Plan 02's Switch/Speaker path ships first and independently; the Lightbulb/Brightness path is a small follow-up gated on plan 01. Users get volume control without waiting for the accessory-type rework.
+- **Volume requires Lightbulb — the Switch path was cancelled.** HAP Switch exposes only a binary `On` characteristic; volume is a 0–100 range. `Lightbulb.Brightness` (0–100, where 0 = power off) is the correct mapping. Plan 01 (accessory type) is therefore the prerequisite for plan 02 (volume).
 - **The integration test harness (plan 05) is infrastructure, not a feature.** It has no user impact and no release, but it provides the safety net that makes the subsequent feature PRs lower risk.
 - **The PWA (plan 04) is architecturally independent** from the HomeKit features (plans 01–03). It introduces a new `web/` workspace and a `src/server/` embedded HTTP server — concerns that don't overlap with the HAP characteristic layer. Its phases can proceed in parallel with plans 01–03 once spike A is resolved.
 - **Source selection (plan 03) is the highest-risk HomeKit feature.** The Television+InputSource pattern has real caveats (external publishing, `Active`/`On` power model clash, buried UX). The spike must answer the architecture question before any code is written; the per-source Switch fallback is the documented Plan B if the TV path is too rough.


### PR DESCRIPTION
## Summary

- **Decision recorded:** Switch volume path cancelled. HAP Switch exposes only a binary `On` characteristic — volume (0–100 range) cannot live there. A linked Speaker tile is a disconnected UX anti-pattern. `Lightbulb.Brightness` (0–100, where `0` = power off) is the correct mapping.
- **Roadmap updated:** Plan 01 (accessory type: Switch/Lightbulb config gate) is now the immediate next step, followed by Plan 02 Lightbulb path (`SoundTouchSpeakerBrightnessCharacteristic` + `On` setter race fix).
- **PR #62 revert (#70) confirmed clean** — `dev` has no volume code.

## What changed

- `.claude/skills/architect/plans/2026-06-19-volume-control.md` — new decision row recording the Switch cancellation; Switch items removed from checklist/affected areas; plan pivoted to Lightbulb-only with Plan 01 as explicit prerequisite.
- `.claude/skills/technical-lead/ROADMAP.md` — dependency graph simplified (Switch node removed); current state updated; delivery order resequenced (Plan 01 → Plan 02 Lightbulb); coupling notes updated.

## Test plan

- [ ] Docs-only change — no code modified, no tests needed.
- [ ] Review decision row wording in the plan file.
- [ ] Review delivery order in the roadmap table.