### PR TITLE
feat: let each speaker be a Switch or a Lightbulb accessory

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -23,6 +23,12 @@
           "verbose": {
             "type": "boolean",
             "default": false
+          },
+          "accessoryType": {
+            "type": "string",
+            "enum": ["switch", "lightbulb"],
+            "default": "switch",
+            "description": "Default HomeKit accessory type for all speakers. 'lightbulb' exposes volume via Brightness."
           }
         }
       },
@@ -58,6 +64,12 @@
               "type": "integer",
               "description": "Override the polling interval (ms) for this device. Set to 0 to disable polling.",
               "default": 2000
+            },
+            "accessoryType": {
+              "type": "string",
+              "enum": ["switch", "lightbulb"],
+              "required": false,
+              "description": "Override the HomeKit accessory type for this speaker. 'lightbulb' exposes volume via Brightness."
             }
           }
         },

--- a/src/ExternalPlatformConfig.ts
+++ b/src/ExternalPlatformConfig.ts
@@ -10,6 +10,7 @@ interface BaseGlobalConfig {
 
 interface GlobalConfig extends BaseGlobalConfig {
   readonly pollingInterval?: number;
+  readonly accessoryType?: 'switch' | 'lightbulb';
 }
 
 export interface AccessoryConfig extends GlobalConfig {

--- a/src/__integration__/helpers/homebridge-stub.ts
+++ b/src/__integration__/helpers/homebridge-stub.ts
@@ -103,6 +103,13 @@ export class StubPlatformAccessory {
     this.services.push(service);
     return service;
   }
+
+  removeService(service: StubService): void {
+    const index = this.services.indexOf(service);
+    if (index !== -1) {
+      this.services.splice(index, 1);
+    }
+  }
 }
 
 const noop = (): void => {};

--- a/src/__integration__/helpers/homebridge-stub.ts
+++ b/src/__integration__/helpers/homebridge-stub.ts
@@ -18,6 +18,7 @@ interface Identifier {
 
 const ServiceTypes = {
   Switch: { name: 'Switch' },
+  Lightbulb: { name: 'Lightbulb' },
   AccessoryInformation: { name: 'AccessoryInformation' },
 } satisfies Record<string, Identifier>;
 

--- a/src/__integration__/platform-lifecycle.integration.test.ts
+++ b/src/__integration__/platform-lifecycle.integration.test.ts
@@ -11,6 +11,10 @@ import type { ExternalPlatformConfig } from '../ExternalPlatformConfig.js';
 import { SoundTouchHomebridgePlatform } from '../platform.js';
 import { SoundTouchSpeakerPlatformAccessory } from '../accessories/SoundTouchSpeakerPlatformAccessory.js';
 import {
+  getServiceName,
+  ServiceType,
+} from '../accessories/services/SoundTouchSpeakerCharacteristic.js';
+import {
   FakeSoundTouchServer,
   infoXml,
   nowPlayingXml,
@@ -47,10 +51,13 @@ describe('SoundTouchHomebridgePlatform', () => {
     await server.stop();
   });
 
-  function createPlatform(): SoundTouchHomebridgePlatform {
+  function createPlatform(
+    overrides: Partial<ExternalPlatformConfig> = {}
+  ): SoundTouchHomebridgePlatform {
     const config = {
       platform: 'SoundTouchSpeaker',
       accessories: [{ ip: '127.0.0.1', port }],
+      ...overrides,
     } as ExternalPlatformConfig;
 
     return new SoundTouchHomebridgePlatform(
@@ -109,6 +116,51 @@ describe('SoundTouchHomebridgePlatform', () => {
 
       expect(stopPolling).toHaveBeenCalledTimes(1);
       stopPolling.mockRestore();
+    });
+  });
+
+  describe('when the accessory type is lightbulb', () => {
+    it('exposes the speaker as a Lightbulb service', async () => {
+      createPlatform({ global: { accessoryType: 'lightbulb' } });
+
+      await api.emitDidFinishLaunching();
+
+      const accessory = api.registeredAccessories[0];
+      expect(
+        accessory.services.some((service) => service.type.name === 'Lightbulb')
+      ).toBe(true);
+      expect(
+        accessory.services.some((service) => service.type.name === 'Switch')
+      ).toBe(false);
+    });
+  });
+
+  describe('when a cached accessory changes type from Switch to Lightbulb', () => {
+    it('removes the orphaned Switch service', async () => {
+      const uuid = api.hap.uuid.generate(DEVICE_ID);
+      const cached = new api.platformAccessory('Test Speaker', uuid);
+      // Seed the stale service the previous (Switch) configuration left behind.
+      cached.addService(
+        api.hap.Service.Switch,
+        getServiceName({
+          serviceType: ServiceType.ON_OFF,
+          device: { name: 'Test Speaker' } as never,
+        })
+      );
+
+      const platform = createPlatform({
+        global: { accessoryType: 'lightbulb' },
+      });
+      platform.configureAccessory(cached as unknown as PlatformAccessory);
+
+      await api.emitDidFinishLaunching();
+
+      expect(
+        cached.services.some((service) => service.type.name === 'Switch')
+      ).toBe(false);
+      expect(
+        cached.services.some((service) => service.type.name === 'Lightbulb')
+      ).toBe(true);
     });
   });
 });

--- a/src/__tests__/ExternalPlatformConfig.test.ts
+++ b/src/__tests__/ExternalPlatformConfig.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { flattenAccessoryConfiguration } from '../ExternalPlatformConfig.js';
 
 describe('calculateResultingAccessoryConfiguration', () => {
-  test('it merges accessory and global configurations', () => {
+  it('it merges accessory and global configurations', () => {
     const result = flattenAccessoryConfiguration({
       globalConfig: {
         verbose: true,
@@ -18,7 +18,7 @@ describe('calculateResultingAccessoryConfiguration', () => {
       pollingInterval: 2000,
     });
   });
-  test('it ignores undefined values in the global config', () => {
+  it('it ignores undefined values in the global config', () => {
     const result = flattenAccessoryConfiguration({
       globalConfig: {
         verbose: undefined,
@@ -34,7 +34,7 @@ describe('calculateResultingAccessoryConfiguration', () => {
       pollingInterval: 2000,
     });
   });
-  test('it ignores undefined values in the accessory config', () => {
+  it('it ignores undefined values in the accessory config', () => {
     const result = flattenAccessoryConfiguration({
       globalConfig: {
         verbose: true,
@@ -50,7 +50,7 @@ describe('calculateResultingAccessoryConfiguration', () => {
       pollingInterval: 5000,
     });
   });
-  test('it ignores undefined value for global config', () => {
+  it('it ignores undefined value for global config', () => {
     const result = flattenAccessoryConfiguration({
       globalConfig: undefined,
       accessory: {
@@ -63,7 +63,7 @@ describe('calculateResultingAccessoryConfiguration', () => {
       pollingInterval: 5000,
     });
   });
-  test('it returns undefined when no config is specified', () => {
+  it('it returns undefined when no config is specified', () => {
     const result = flattenAccessoryConfiguration({
       globalConfig: undefined,
       accessory: undefined,
@@ -71,7 +71,7 @@ describe('calculateResultingAccessoryConfiguration', () => {
     expect(result).toEqual(undefined);
   });
 
-  test('global accessoryType flows into accessory when accessory does not override', () => {
+  it('global accessoryType flows into accessory when accessory does not override', () => {
     const result = flattenAccessoryConfiguration({
       globalConfig: { accessoryType: 'lightbulb' },
       accessory: { ip: '10.0.0.1' },
@@ -79,7 +79,7 @@ describe('calculateResultingAccessoryConfiguration', () => {
     expect(result?.accessoryType).toBe('lightbulb');
   });
 
-  test('per-accessory accessoryType overrides global', () => {
+  it('per-accessory accessoryType overrides global', () => {
     const result = flattenAccessoryConfiguration({
       globalConfig: { accessoryType: 'lightbulb' },
       accessory: { ip: '10.0.0.1', accessoryType: 'switch' },

--- a/src/__tests__/ExternalPlatformConfig.test.ts
+++ b/src/__tests__/ExternalPlatformConfig.test.ts
@@ -70,4 +70,20 @@ describe('calculateResultingAccessoryConfiguration', () => {
     });
     expect(result).toEqual(undefined);
   });
+
+  test('global accessoryType flows into accessory when accessory does not override', () => {
+    const result = flattenAccessoryConfiguration({
+      globalConfig: { accessoryType: 'lightbulb' },
+      accessory: { ip: '10.0.0.1' },
+    });
+    expect(result?.accessoryType).toBe('lightbulb');
+  });
+
+  test('per-accessory accessoryType overrides global', () => {
+    const result = flattenAccessoryConfiguration({
+      globalConfig: { accessoryType: 'lightbulb' },
+      accessory: { ip: '10.0.0.1', accessoryType: 'switch' },
+    });
+    expect(result?.accessoryType).toBe('switch');
+  });
 });

--- a/src/__tests__/PlatformConfiguration.test.ts
+++ b/src/__tests__/PlatformConfiguration.test.ts
@@ -107,6 +107,41 @@ describe('PlatformConfiguration', () => {
       expect(config.accessories[0].pollingInterval).toBe(1000);
     });
 
+    test('accessory defaults to switch accessoryType', () => {
+      const config = PlatformConfiguration.fromExternalConfiguration({
+        platform: PLATFORM_NAME,
+        accessories: [{ name: 'Kitchen', ip: '192.168.1.10' }],
+      });
+
+      expect(config.accessories[0].accessoryType).toBe('switch');
+    });
+
+    test('global accessoryType is applied to all accessories', () => {
+      const config = PlatformConfiguration.fromExternalConfiguration({
+        platform: PLATFORM_NAME,
+        global: { accessoryType: 'lightbulb' },
+        accessories: [
+          { name: 'Kitchen', ip: '192.168.1.10' },
+          { name: 'Lounge', room: 'Lounge' },
+        ],
+      });
+
+      expect(config.accessories[0].accessoryType).toBe('lightbulb');
+      expect(config.accessories[1].accessoryType).toBe('lightbulb');
+    });
+
+    test('per-accessory accessoryType overrides global', () => {
+      const config = PlatformConfiguration.fromExternalConfiguration({
+        platform: PLATFORM_NAME,
+        global: { accessoryType: 'lightbulb' },
+        accessories: [
+          { name: 'Kitchen', ip: '192.168.1.10', accessoryType: 'switch' },
+        ],
+      });
+
+      expect(config.accessories[0].accessoryType).toBe('switch');
+    });
+
     test('accessories without ip or room are excluded', () => {
       const config = PlatformConfiguration.fromExternalConfiguration({
         platform: PLATFORM_NAME,

--- a/src/__tests__/PlatformConfiguration.test.ts
+++ b/src/__tests__/PlatformConfiguration.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { PlatformConfiguration } from '../PlatformConfiguration.js';
 import { PLATFORM_NAME } from '../settings.js';
 
 describe('PlatformConfiguration', () => {
   describe('fromExternalConfiguration', () => {
-    test('applies defaults when no config is provided', () => {
+    it('applies defaults when no config is provided', () => {
       const config = PlatformConfiguration.fromExternalConfiguration({
         platform: PLATFORM_NAME,
       });
@@ -16,7 +16,7 @@ describe('PlatformConfiguration', () => {
       expect(config.name).toBe(PLATFORM_NAME);
     });
 
-    test('uses provided name over default', () => {
+    it('uses provided name over default', () => {
       const config = PlatformConfiguration.fromExternalConfiguration({
         platform: PLATFORM_NAME,
         name: 'My Speaker Hub',
@@ -25,7 +25,7 @@ describe('PlatformConfiguration', () => {
       expect(config.name).toBe('My Speaker Hub');
     });
 
-    test('sets discoverAllAccessories when provided', () => {
+    it('sets discoverAllAccessories when provided', () => {
       const config = PlatformConfiguration.fromExternalConfiguration({
         platform: PLATFORM_NAME,
         discoverAllAccessories: true,
@@ -34,7 +34,7 @@ describe('PlatformConfiguration', () => {
       expect(config.discoverAllAccessories).toBe(true);
     });
 
-    test('builds IP-based accessory from config', () => {
+    it('builds IP-based accessory from config', () => {
       const config = PlatformConfiguration.fromExternalConfiguration({
         platform: PLATFORM_NAME,
         accessories: [{ name: 'Kitchen', ip: '192.168.1.10', port: 8090 }],
@@ -47,7 +47,7 @@ describe('PlatformConfiguration', () => {
       expect(config.accessories[0].name).toBe('Kitchen');
     });
 
-    test('builds room-based accessory from config', () => {
+    it('builds room-based accessory from config', () => {
       const config = PlatformConfiguration.fromExternalConfiguration({
         platform: PLATFORM_NAME,
         accessories: [{ name: 'Living Room', room: 'Living Room' }],
@@ -58,7 +58,7 @@ describe('PlatformConfiguration', () => {
       expect(config.accessories[0].room).toBe('Living Room');
     });
 
-    test('merges global config into accessories', () => {
+    it('merges global config into accessories', () => {
       const config = PlatformConfiguration.fromExternalConfiguration({
         platform: PLATFORM_NAME,
         global: { pollingInterval: 5000 },
@@ -68,7 +68,7 @@ describe('PlatformConfiguration', () => {
       expect(config.accessories[0].pollingInterval).toBe(5000);
     });
 
-    test('honours global.pollingInterval at the platform level', () => {
+    it('honours global.pollingInterval at the platform level', () => {
       const config = PlatformConfiguration.fromExternalConfiguration({
         platform: PLATFORM_NAME,
         global: { pollingInterval: 5000 },
@@ -77,7 +77,7 @@ describe('PlatformConfiguration', () => {
       expect(config.pollingInterval).toBe(5000);
     });
 
-    test('honours global.verbose at the platform level', () => {
+    it('honours global.verbose at the platform level', () => {
       const config = PlatformConfiguration.fromExternalConfiguration({
         platform: PLATFORM_NAME,
         global: { verbose: true },
@@ -86,7 +86,7 @@ describe('PlatformConfiguration', () => {
       expect(config.verbose).toBe(true);
     });
 
-    test('preserves an explicit pollingInterval of 0 (disabled)', () => {
+    it('preserves an explicit pollingInterval of 0 (disabled)', () => {
       const config = PlatformConfiguration.fromExternalConfiguration({
         platform: PLATFORM_NAME,
         global: { pollingInterval: 0 },
@@ -95,7 +95,7 @@ describe('PlatformConfiguration', () => {
       expect(config.pollingInterval).toBe(0);
     });
 
-    test('accessory-level pollingInterval overrides global', () => {
+    it('accessory-level pollingInterval overrides global', () => {
       const config = PlatformConfiguration.fromExternalConfiguration({
         platform: PLATFORM_NAME,
         global: { pollingInterval: 5000 },
@@ -107,7 +107,7 @@ describe('PlatformConfiguration', () => {
       expect(config.accessories[0].pollingInterval).toBe(1000);
     });
 
-    test('accessory defaults to switch accessoryType', () => {
+    it('accessory defaults to switch accessoryType', () => {
       const config = PlatformConfiguration.fromExternalConfiguration({
         platform: PLATFORM_NAME,
         accessories: [{ name: 'Kitchen', ip: '192.168.1.10' }],
@@ -116,7 +116,7 @@ describe('PlatformConfiguration', () => {
       expect(config.accessories[0].accessoryType).toBe('switch');
     });
 
-    test('global accessoryType is applied to all accessories', () => {
+    it('global accessoryType is applied to all accessories', () => {
       const config = PlatformConfiguration.fromExternalConfiguration({
         platform: PLATFORM_NAME,
         global: { accessoryType: 'lightbulb' },
@@ -130,7 +130,7 @@ describe('PlatformConfiguration', () => {
       expect(config.accessories[1].accessoryType).toBe('lightbulb');
     });
 
-    test('per-accessory accessoryType overrides global', () => {
+    it('per-accessory accessoryType overrides global', () => {
       const config = PlatformConfiguration.fromExternalConfiguration({
         platform: PLATFORM_NAME,
         global: { accessoryType: 'lightbulb' },
@@ -142,7 +142,7 @@ describe('PlatformConfiguration', () => {
       expect(config.accessories[0].accessoryType).toBe('switch');
     });
 
-    test('accessories without ip or room are excluded', () => {
+    it('accessories without ip or room are excluded', () => {
       const config = PlatformConfiguration.fromExternalConfiguration({
         platform: PLATFORM_NAME,
         accessories: [{ name: 'Mystery' }],
@@ -151,7 +151,7 @@ describe('PlatformConfiguration', () => {
       expect(config.accessories).toHaveLength(0);
     });
 
-    test('handles multiple accessories', () => {
+    it('handles multiple accessories', () => {
       const config = PlatformConfiguration.fromExternalConfiguration({
         platform: PLATFORM_NAME,
         accessories: [
@@ -167,7 +167,7 @@ describe('PlatformConfiguration', () => {
   });
 
   describe('toJson', () => {
-    test('serialises to valid JSON', () => {
+    it('serialises to valid JSON', () => {
       const config = PlatformConfiguration.fromExternalConfiguration({
         platform: PLATFORM_NAME,
       });

--- a/src/accessories/SoundTouchSpeakerPlatformAccessory.ts
+++ b/src/accessories/SoundTouchSpeakerPlatformAccessory.ts
@@ -74,9 +74,19 @@ export class SoundTouchSpeakerPlatformAccessory extends SoundTouchSpeakerCharact
     device: SoundTouchDevice;
     defaultCharacteristics: SoundTouchSpeakerCharacteristic[];
   }): Promise<SoundTouchSpeakerPlatformAccessory> {
+    const { platform, accessory, device } = props;
+    const isLightbulb = device.configuration.accessoryType === 'lightbulb';
+
+    SoundTouchSpeakerPlatformAccessory.pruneOrphanService({
+      accessory,
+      platform,
+      orphanServiceType: isLightbulb ? ServiceType.ON_OFF : ServiceType.LIGHTBULB,
+      device,
+    });
+
     const service = SoundTouchSpeakerPlatformAccessory.ensureAccessoryService({
-      serviceType: ServiceType.ON_OFF,
-      service: props.platform.service.Switch,
+      serviceType: isLightbulb ? ServiceType.LIGHTBULB : ServiceType.ON_OFF,
+      service: isLightbulb ? platform.service.Lightbulb : platform.service.Switch,
       ...props,
     });
 
@@ -111,6 +121,28 @@ export class SoundTouchSpeakerPlatformAccessory extends SoundTouchSpeakerCharact
     await accessory.init();
 
     return accessory;
+  }
+
+  private static pruneOrphanService({
+    accessory,
+    platform,
+    orphanServiceType,
+    device,
+  }: {
+    accessory: PlatformAccessory;
+    platform: SoundTouchHomebridgePlatform;
+    orphanServiceType: ServiceType;
+    device: SoundTouchDevice;
+  }): void {
+    const orphanName = getServiceName({ serviceType: orphanServiceType, device });
+    const orphan = accessory.getService(orphanName);
+    if (orphan) {
+      platform.logger.info(
+        'Removing stale service after accessory type change:',
+        orphanName
+      );
+      accessory.removeService(orphan);
+    }
   }
 
   private static ensureAccessoryService({

--- a/src/accessories/services/SoundTouchSpeakerCharacteristic.ts
+++ b/src/accessories/services/SoundTouchSpeakerCharacteristic.ts
@@ -5,6 +5,7 @@ import { DeviceLogger, Logger } from '../../utils/FormattedLogger.js';
 
 export enum ServiceType {
   'ON_OFF' = 'ON',
+  'LIGHTBULB' = 'LIGHTBULB',
 }
 
 export abstract class SoundTouchSpeakerCharacteristic {

--- a/src/devices/SoundTouch/SoundTouchDeviceConfiguration.ts
+++ b/src/devices/SoundTouch/SoundTouchDeviceConfiguration.ts
@@ -2,11 +2,15 @@ import { AccessoryConfig } from '../../ExternalPlatformConfig.js';
 
 const DEFAULT_POLLING_INTERVAL = 2 * 1000; // 2 Seconds
 const DEFAULT_VERBOSE_LOGGING = false;
+const DEFAULT_ACCESSORY_TYPE = 'switch' as const;
+
+export type AccessoryType = 'switch' | 'lightbulb';
 
 interface BaseDeviceConfiguration {
   name: string;
   pollingInterval?: number;
   verbose?: boolean;
+  accessoryType?: AccessoryType;
 }
 
 interface DeviceViaRoomConfigurationProps extends BaseDeviceConfiguration {
@@ -28,6 +32,7 @@ export class DeviceConfiguration {
 
   readonly pollingInterval: number;
   readonly verboseLogging: boolean;
+  readonly accessoryType: AccessoryType;
 
   constructor(props: {
     type: 'room' | 'ip' | 'discovered';
@@ -37,11 +42,13 @@ export class DeviceConfiguration {
     port?: number;
     pollingInterval?: number;
     verboseLogging?: boolean;
+    accessoryType?: AccessoryType;
   }) {
     this.type = props.type;
     this.name = props.name;
     this.verboseLogging = props.verboseLogging ?? DEFAULT_VERBOSE_LOGGING;
     this.pollingInterval = props.pollingInterval ?? DEFAULT_POLLING_INTERVAL;
+    this.accessoryType = props.accessoryType ?? DEFAULT_ACCESSORY_TYPE;
 
     if (props.type === 'room') {
       this.room = props.room;
@@ -74,12 +81,14 @@ export class DeviceConfiguration {
         ip: props.accessoryConfig.ip,
         port: props.accessoryConfig.port,
         pollingInterval: props.accessoryConfig.pollingInterval,
+        accessoryType: props.accessoryConfig.accessoryType,
       });
     } else if (props.accessoryConfig?.room) {
       return DeviceConfiguration.createForRoom({
         name: props?.name || props.accessoryConfig.name || '',
         room: props.accessoryConfig.room,
         pollingInterval: props.accessoryConfig.pollingInterval,
+        accessoryType: props.accessoryConfig.accessoryType,
       });
     }
     return undefined;
@@ -89,15 +98,18 @@ export class DeviceConfiguration {
     name,
     verboseLogging,
     pollingInterval,
+    accessoryType,
   }: {
     name?: string;
     verboseLogging?: boolean;
     pollingInterval?: number;
+    accessoryType?: AccessoryType;
   }) {
     return new DeviceConfiguration({
       name,
       verboseLogging,
       pollingInterval,
+      accessoryType,
       type: 'discovered',
     });
   }

--- a/src/devices/SoundTouch/__tests__/SoundTouchDeviceConfiguration.test.ts
+++ b/src/devices/SoundTouch/__tests__/SoundTouchDeviceConfiguration.test.ts
@@ -82,6 +82,19 @@ describe('DeviceConfiguration', () => {
       });
       expect(config.verboseLogging).toBe(true);
     });
+
+    test('defaults accessoryType to switch', () => {
+      const config = DeviceConfiguration.create({ name: 'Office' });
+      expect(config.accessoryType).toBe('switch');
+    });
+
+    test('uses provided accessoryType', () => {
+      const config = DeviceConfiguration.create({
+        name: 'Office',
+        accessoryType: 'lightbulb',
+      });
+      expect(config.accessoryType).toBe('lightbulb');
+    });
   });
 
   describe('fromAccessoryConfiguration', () => {
@@ -139,6 +152,30 @@ describe('DeviceConfiguration', () => {
       });
 
       expect(config?.name).toBe('Config Name');
+    });
+
+    test('defaults accessoryType to switch when not in accessoryConfig', () => {
+      const config = DeviceConfiguration.fromAccessoryConfiguration({
+        name: 'Kitchen',
+        accessoryConfig: { ip: '10.0.0.1' },
+      });
+      expect(config?.accessoryType).toBe('switch');
+    });
+
+    test('threads accessoryType from accessoryConfig (ip path)', () => {
+      const config = DeviceConfiguration.fromAccessoryConfiguration({
+        name: 'Kitchen',
+        accessoryConfig: { ip: '10.0.0.1', accessoryType: 'lightbulb' },
+      });
+      expect(config?.accessoryType).toBe('lightbulb');
+    });
+
+    test('threads accessoryType from accessoryConfig (room path)', () => {
+      const config = DeviceConfiguration.fromAccessoryConfiguration({
+        name: 'Lounge',
+        accessoryConfig: { room: 'Lounge', accessoryType: 'lightbulb' },
+      });
+      expect(config?.accessoryType).toBe('lightbulb');
     });
   });
 

--- a/src/devices/SoundTouch/__tests__/SoundTouchDeviceConfiguration.test.ts
+++ b/src/devices/SoundTouch/__tests__/SoundTouchDeviceConfiguration.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { DeviceConfiguration } from '../SoundTouchDeviceConfiguration.js';
 
 const DEFAULT_POLLING_INTERVAL = 2000;
 
 describe('DeviceConfiguration', () => {
   describe('createForRoom', () => {
-    test('creates a room-type configuration', () => {
+    it('creates a room-type configuration', () => {
       const config = DeviceConfiguration.createForRoom({
         name: 'Kitchen',
         room: 'Kitchen',
@@ -17,12 +17,12 @@ describe('DeviceConfiguration', () => {
       expect(config.port).toBeUndefined();
     });
 
-    test('applies default pollingInterval', () => {
+    it('applies default pollingInterval', () => {
       const config = DeviceConfiguration.createForRoom({ name: 'Kitchen' });
       expect(config.pollingInterval).toBe(DEFAULT_POLLING_INTERVAL);
     });
 
-    test('uses provided pollingInterval', () => {
+    it('uses provided pollingInterval', () => {
       const config = DeviceConfiguration.createForRoom({
         name: 'Kitchen',
         pollingInterval: 5000,
@@ -30,7 +30,7 @@ describe('DeviceConfiguration', () => {
       expect(config.pollingInterval).toBe(5000);
     });
 
-    test('preserves a pollingInterval of 0 (disabled) rather than defaulting', () => {
+    it('preserves a pollingInterval of 0 (disabled) rather than defaulting', () => {
       const config = DeviceConfiguration.createForRoom({
         name: 'Kitchen',
         pollingInterval: 0,
@@ -40,7 +40,7 @@ describe('DeviceConfiguration', () => {
   });
 
   describe('createForIp', () => {
-    test('creates an ip-type configuration', () => {
+    it('creates an ip-type configuration', () => {
       const config = DeviceConfiguration.createForIp({
         name: 'Lounge',
         ip: '192.168.1.10',
@@ -53,7 +53,7 @@ describe('DeviceConfiguration', () => {
       expect(config.room).toBeUndefined();
     });
 
-    test('applies default pollingInterval', () => {
+    it('applies default pollingInterval', () => {
       const config = DeviceConfiguration.createForIp({
         name: 'Lounge',
         ip: '192.168.1.10',
@@ -63,19 +63,19 @@ describe('DeviceConfiguration', () => {
   });
 
   describe('create', () => {
-    test('creates a discovered-type configuration', () => {
+    it('creates a discovered-type configuration', () => {
       const config = DeviceConfiguration.create({ name: 'Office' });
       expect(config.type).toBe('discovered');
       expect(config.ip).toBeUndefined();
       expect(config.room).toBeUndefined();
     });
 
-    test('applies default verboseLogging', () => {
+    it('applies default verboseLogging', () => {
       const config = DeviceConfiguration.create({ name: 'Office' });
       expect(config.verboseLogging).toBe(false);
     });
 
-    test('uses provided verboseLogging', () => {
+    it('uses provided verboseLogging', () => {
       const config = DeviceConfiguration.create({
         name: 'Office',
         verboseLogging: true,
@@ -83,12 +83,12 @@ describe('DeviceConfiguration', () => {
       expect(config.verboseLogging).toBe(true);
     });
 
-    test('defaults accessoryType to switch', () => {
+    it('defaults accessoryType to switch', () => {
       const config = DeviceConfiguration.create({ name: 'Office' });
       expect(config.accessoryType).toBe('switch');
     });
 
-    test('uses provided accessoryType', () => {
+    it('uses provided accessoryType', () => {
       const config = DeviceConfiguration.create({
         name: 'Office',
         accessoryType: 'lightbulb',
@@ -98,7 +98,7 @@ describe('DeviceConfiguration', () => {
   });
 
   describe('fromAccessoryConfiguration', () => {
-    test('returns ip-type config when ip is present', () => {
+    it('returns ip-type config when ip is present', () => {
       const config = DeviceConfiguration.fromAccessoryConfiguration({
         name: 'Kitchen',
         accessoryConfig: { ip: '10.0.0.1', port: 8090 },
@@ -109,7 +109,7 @@ describe('DeviceConfiguration', () => {
       expect(config?.port).toBe(8090);
     });
 
-    test('prefers ip over room when both are present', () => {
+    it('prefers ip over room when both are present', () => {
       const config = DeviceConfiguration.fromAccessoryConfiguration({
         name: 'Kitchen',
         accessoryConfig: { ip: '10.0.0.1', room: 'Kitchen' },
@@ -118,7 +118,7 @@ describe('DeviceConfiguration', () => {
       expect(config?.type).toBe('ip');
     });
 
-    test('returns room-type config when only room is present', () => {
+    it('returns room-type config when only room is present', () => {
       const config = DeviceConfiguration.fromAccessoryConfiguration({
         name: 'Lounge',
         accessoryConfig: { room: 'Lounge' },
@@ -128,7 +128,7 @@ describe('DeviceConfiguration', () => {
       expect(config?.room).toBe('Lounge');
     });
 
-    test('returns undefined when neither ip nor room provided', () => {
+    it('returns undefined when neither ip nor room provided', () => {
       const config = DeviceConfiguration.fromAccessoryConfiguration({
         name: 'Mystery',
         accessoryConfig: {},
@@ -137,7 +137,7 @@ describe('DeviceConfiguration', () => {
       expect(config).toBeUndefined();
     });
 
-    test('name from props takes precedence over accessoryConfig name', () => {
+    it('name from props takes precedence over accessoryConfig name', () => {
       const config = DeviceConfiguration.fromAccessoryConfiguration({
         name: 'Override Name',
         accessoryConfig: { ip: '10.0.0.1', name: 'Config Name' },
@@ -146,7 +146,7 @@ describe('DeviceConfiguration', () => {
       expect(config?.name).toBe('Override Name');
     });
 
-    test('falls back to accessoryConfig name when props name is absent', () => {
+    it('falls back to accessoryConfig name when props name is absent', () => {
       const config = DeviceConfiguration.fromAccessoryConfiguration({
         accessoryConfig: { ip: '10.0.0.1', name: 'Config Name' },
       });
@@ -154,7 +154,7 @@ describe('DeviceConfiguration', () => {
       expect(config?.name).toBe('Config Name');
     });
 
-    test('defaults accessoryType to switch when not in accessoryConfig', () => {
+    it('defaults accessoryType to switch when not in accessoryConfig', () => {
       const config = DeviceConfiguration.fromAccessoryConfiguration({
         name: 'Kitchen',
         accessoryConfig: { ip: '10.0.0.1' },
@@ -162,7 +162,7 @@ describe('DeviceConfiguration', () => {
       expect(config?.accessoryType).toBe('switch');
     });
 
-    test('threads accessoryType from accessoryConfig (ip path)', () => {
+    it('threads accessoryType from accessoryConfig (ip path)', () => {
       const config = DeviceConfiguration.fromAccessoryConfiguration({
         name: 'Kitchen',
         accessoryConfig: { ip: '10.0.0.1', accessoryType: 'lightbulb' },
@@ -170,7 +170,7 @@ describe('DeviceConfiguration', () => {
       expect(config?.accessoryType).toBe('lightbulb');
     });
 
-    test('threads accessoryType from accessoryConfig (room path)', () => {
+    it('threads accessoryType from accessoryConfig (room path)', () => {
       const config = DeviceConfiguration.fromAccessoryConfiguration({
         name: 'Lounge',
         accessoryConfig: { room: 'Lounge', accessoryType: 'lightbulb' },
@@ -180,7 +180,7 @@ describe('DeviceConfiguration', () => {
   });
 
   describe('toJson', () => {
-    test('serialises to valid JSON', () => {
+    it('serialises to valid JSON', () => {
       const config = DeviceConfiguration.create({ name: 'Test' });
       expect(() => JSON.parse(config.toJson())).not.toThrow();
     });


### PR DESCRIPTION
Delivers the **accessory-type** plan: [`2026-06-19-accessory-type-switch-or-lightbulb.md`](../blob/dev/.claude/skills/architect/plans/2026-06-19-accessory-type-switch-or-lightbulb.md).

**Why:** every speaker is currently a HomeKit Switch (power only). A Switch is binary, so volume can't live there — volume needs `Lightbulb.Brightness` (0–100). This adds the accessory-type gate that unblocks the Lightbulb/volume path (Plan 02). The earlier Switch-volume attempt was reverted (#62 → #70); decision recorded in the volume plan.

**What's delivered:** a per-device `accessoryType: 'switch' | 'lightbulb'` config field (global default + per-accessory override), threaded to `createAccessory` which builds a Switch or Lightbulb service. Default stays `'switch'` — no change for existing installs. Cached accessories that change type have the stale service pruned (no orphan tile), covered by integration tests.

Also converts the 3 config test files this PR touches from `test()` to `it()` per conventions; the wider repo sweep is deferred to a tracked plan (#74).

**Verification:** `npm run typecheck && npm run lint && npm test` green (224 tests). Live `npm run watch` against a real speaker still pending.