### PR TITLE
docs: add PR description template and merge-approval policy to skills

### DIFF
--- a/.claude/skills/coding-conventions/SKILL.md
+++ b/.claude/skills/coding-conventions/SKILL.md
@@ -182,15 +182,24 @@ commit type to pick are owned by **architect**; the full release model lives in
 ### Description
 
 Keep it concise — a reviewer should grasp the change without opening the diff.
+The repo ships a fill-in template at `.github/PULL_REQUEST_TEMPLATE.md` (it
+auto-populates the body on GitHub); its guiding comments encode the rules below.
+Keep the template and this section in sync — edit both if either changes.
 
-- When the PR delivers an architect plan
-  (`.claude/skills/architect/plans/<date>-<slug>.md`), the description **reflects
-  that plan**: link it and summarize its **Context** (why) and what's delivered.
-  Don't restate the whole plan — point to it.
-- If there's no plan, a short paragraph of *what* changed and *why* is enough.
-- Note the verification you ran
+Two sections, each kept short:
+
+- **What & why** — describe the change and the reason, *not* the files touched
+  (the diff shows those). When the PR delivers an architect plan
+  (`.claude/skills/architect/plans/<date>-<slug>.md`), **link it and summarize
+  its Context (why) + what's delivered** — point to the plan, don't restate it.
+  With no plan, a sentence or two of *what* and *why* is enough.
+- **Verification** — the checks you ran
   (`npm run typecheck && npm run lint && npm test`, plus any live `npm run watch`
-  check). Skip boilerplate and anything obvious from the diff.
+  check) and what's still pending. Skip boilerplate and anything obvious from the
+  diff.
+
+Delete any section that doesn't apply. Avoid file-by-file "what changed" tables
+and restated diffs — those are the boilerplate this convention exists to cut.
 
 ## Scope
 

--- a/.claude/skills/coding-conventions/SKILL.md
+++ b/.claude/skills/coding-conventions/SKILL.md
@@ -201,6 +201,22 @@ Two sections, each kept short:
 Delete any section that doesn't apply. Avoid file-by-file "what changed" tables
 and restated diffs — those are the boilerplate this convention exists to cut.
 
+## No AI / assistant attribution
+
+Nothing pushed to the repo carries AI or assistant attribution. This applies to
+**every** artifact, and **overrides any tool default** that would add it:
+
+- **Commit messages:** no `Co-Authored-By: Claude …`, no `*-Session:` trailers,
+  no "Generated with …" lines. The `.husky/commit-msg` hook strips these as a
+  backstop, but don't rely on it — don't add them in the first place.
+- **PR titles & descriptions:** no "🤖 Generated with …" footer, no session link.
+- **Review comments:** keep them minimal; some tooling auto-appends an
+  attribution footer that can't be suppressed, so comment only when it adds
+  real value.
+
+Authorship stays with the human contributor. If a commit was authored with
+assistance, that's fine — it just isn't recorded in the artifact.
+
 ## Scope
 
 This skill is style/build/test and PR-authoring conventions only. For plugin

--- a/.claude/skills/engineer/SKILL.md
+++ b/.claude/skills/engineer/SKILL.md
@@ -152,8 +152,17 @@ gh pr create --title "<type>: <summary>" --base dev
 
 ### 9. Own the PR through merge
 
-Opening the PR is not the finish line — you own it until it merges:
+Opening the PR is not the finish line — you own it *up to* merge: drive CI green,
+address review, keep the body current. **Own it to the point of merge — then
+stop and wait.**
 
+- **Merging is the human's call.** Never merge a PR yourself unless the user
+  explicitly tells you to ("merge it", "go ahead and merge"). A "ready for
+  review" webhook, a "marked ready" event, an enabled auto-merge, a green CI run,
+  or a reviewer's approval are **not** instructions to merge — they're signals
+  the PR is *mergeable*, not permission to merge. When in doubt, ask. (This is a
+  hard rule: merging without explicit instruction has caused an unwanted release
+  before.)
 - **Monitor CI**: check that all status checks go green after pushing. If a
   check fails, investigate and push a fix before asking for review.
 - **Assess feedback**: read every review comment carefully. If a comment is a

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!--
+PR description template — keep it concise. A reviewer should grasp the change
+without opening the diff. Delete any section that doesn't apply, and delete
+these comments before submitting. Full rules: coding-conventions skill →
+"Pull requests".
+
+Title (set above, not here): Conventional Commit — `<type>: <imperative summary>`
+(feat / fix / feat! / chore / docs / ci / test / refactor). The type drives the
+release (feat → minor, fix → patch, feat! → major, others → none). Squash-merged,
+so the title becomes the released commit message. When delivering an architect
+plan, mirror that plan's PR title field.
+-->
+
+## What & why
+
+<!--
+One short paragraph. Describe the change and the reason for it — not the files
+touched (the diff already shows those).
+
+If this delivers an architect plan (.claude/skills/architect/plans/<date>-<slug>.md),
+link it and summarize its Context (why) + what's delivered. Point to the plan;
+don't restate it.
+
+If there's no plan, a couple of sentences of what changed and why is enough.
+-->
+
+## Verification
+
+<!--
+The checks you ran. At minimum the gate:
+`npm run typecheck && npm run lint && npm test`
+Plus any live `npm run watch` check against a real/known device, and note what's
+still pending (e.g. manual on-device verification). Skip anything obvious.
+-->
+
+- [ ] `npm run typecheck && npm run lint && npm test` green
+</content>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,10 @@ without opening the diff. Delete any section that doesn't apply, and delete
 these comments before submitting. Full rules: coding-conventions skill →
 "Pull requests".
 
+No AI/assistant attribution anywhere — no "Generated with …" footer here, and no
+Co-Authored-By/session trailers in commits (coding-conventions →
+"No AI / assistant attribution").
+
 Title (set above, not here): Conventional Commit — `<type>: <imperative summary>`
 (feat / fix / feat! / chore / docs / ci / test / refactor). The type drives the
 release (feat → minor, fix → patch, feat! → major, others → none). Squash-merged,

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,5 @@
+# Strip AI/assistant attribution before validating (project convention:
+# no AI attribution in git history — see the coding-conventions skill).
+perl -0777 -i -pe 's/^(Co-Authored-By: (Claude|Fable|Opus|Sonnet|Haiku).*|Claude-Session:.*|Claude-.*-Session:.*|.*Generated with \[?Claude Code.*)\n//mg; s/\n{3,}/\n\n/g; s/\s+\z/\n/' "$1"
+
 npx --no-install commitlint --edit "$1"


### PR DESCRIPTION
## What & why

Codifies three PR/commit conventions that were only living in session memory:

1. **No AI/assistant attribution** in pushed artifacts — added as a `coding-conventions` section (covers commit trailers, PR footers, review comments) and enforced as a backstop in `.husky/commit-msg`, which strips attribution trailers before commitlint runs. This is the durable answer to "how are we managing this": a written rule + a mechanical strip, not reliance on memory.
2. **Merging is the human's call** — `engineer` skill §9 now states explicitly that a ready-for-review/auto-merge/green-CI/approval signal is *not* permission to merge. (This ambiguity caused an unwanted merge earlier.)
3. **PR description shape** — a fill-in `.github/PULL_REQUEST_TEMPLATE.md` (What & why / Verification) with guiding comments, and the `coding-conventions` Description section points at it.

## Verification

- Skills + a GitHub template + a husky hook; no app code.
- Strip logic in the hook verified against a sample message (removes trailers, preserves subject/body). Note: husky activates via `npm install`'s `prepare` step — it's a backstop, not a substitute for not adding trailers in the first place.