### PR TITLE
chore: add NOTICE file attributing soundtouch-api BSD-3-Clause copyright

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,36 @@
+homebridge-soundtouch-speaker
+Copyright (c) Andrew Trainor
+
+This product includes code derived from soundtouch-api
+(https://github.com/bbriatte/soundtouch-api), used under the BSD 3-Clause
+License:
+
+BSD 3-Clause License
+
+Copyright (c) 2023, Briatte Benoit
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
## What & why

The plugin is derived from two BSD 3-Clause licensed works by [@bbriatte](https://github.com/bbriatte):

- [`soundtouch-api`](https://github.com/bbriatte/soundtouch-api) (Copyright (c) 2023) — the `src/devices/SoundTouch/api/` layer is a port of this package.
- [`homebridge-soundtouch-platform`](https://github.com/bbriatte/homebridge-soundtouch-platform) (Copyright (c) 2019) — the platform and accessory code is a port of this plugin.

BSD 3-Clause requires that redistributions reproduce the copyright notice and license text. This adds a `NOTICE` file at the repo root with both attributions to satisfy that requirement.

## Verification

No source changes — no typecheck/lint/test run needed.