### PR TITLE
chore: set package.json version to 0.0.0-development placeholder

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "homebridge-soundtouchspeaker",
   "displayName": "SoundTouch Speaker",
   "type": "module",
-  "version": "0.2.4-beta.2",
+  "version": "0.0.0-development",
   "description": "Updates homebridge-soundtouch-platform to work on latest homebridge.",
   "author": "Andrew Trainor",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What & why

PR #69 set the version placeholder but was never merged into `dev` — the branch jumped from #70 to #68, skipping it. This re-applies the same change: `0.2.4-beta.2` → `0.0.0-development`, the conventional semantic-release placeholder that signals versioning is managed by git tags.

## Verification

No source code changed; `npm run typecheck && npm run lint && npm test` would be unaffected.