### PR TITLE
revert: chore: use version placeholder for tag-based releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "homebridge-soundtouchspeaker",
   "displayName": "SoundTouch Speaker",
   "type": "module",
-  "version": "0.0.0-development",
+  "version": "0.2.4-beta.2",
   "description": "Updates homebridge-soundtouch-platform to work on latest homebridge.",
   "author": "Andrew Trainor",
   "license": "Apache-2.0",


### PR DESCRIPTION
Reverts forktrucka/homebridge-soundtouch-speaker#69