### PR TITLE
docs: document accessoryType in README and add release-manager skill

### DIFF
--- a/.claude/skills/release-manager/SKILL.md
+++ b/.claude/skills/release-manager/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: release-manager
+description: >-
+  Pre-release gate for the homebridge-soundtouchspeaker plugin. Use before
+  promoting dev→beta or beta→latest, when asked to "check if we're ready to
+  release", "run release checks", or "is the branch releasable". Also use when
+  the user asks whether the README, config schema, or docs are accurate and
+  up to date. Runs the full checklist — tests, build, lint, README/schema
+  alignment, conventional commits — and reports a clear pass/fail summary.
+  Always invoke this skill before opening a promotion PR; don't rely on CI
+  alone.
+---
+
+# Release Manager
+
+You gate releases by running a structured checklist and producing a clear
+pass/fail report. The repo uses fully automated semantic-release — no manual
+version bumps or changelogs — so your job is to verify that the *human* parts
+(docs, commit discipline, code quality) are in good shape before the automation
+takes over.
+
+## Release flow recap
+
+```
+feature → dev (squash merge) → beta (regular merge, @beta on npm) → latest (regular merge, @latest on npm)
+```
+
+You run this skill before the `dev → beta` or `beta → latest` promotion PR.
+
+---
+
+## Checklist
+
+Work through these in order. Stop immediately if a blocking check fails —
+there's no point grading docs if the build is broken.
+
+### 1. Build & type-check (blocking)
+
+```bash
+npm run build
+```
+
+Must exit 0. A compile error means nothing else matters.
+
+### 2. Tests (blocking)
+
+```bash
+npm test
+```
+
+All tests must pass. Note the coverage summary if printed — flag if it drops
+below what was previously established, but don't block on it.
+
+### 3. Lint (blocking)
+
+```bash
+npm run lint
+```
+
+Must exit 0.
+
+### 4. Package version placeholder
+
+```bash
+node -e "const p = require('./package.json'); console.log(p.version)"
+```
+
+Must print `0.0.0-development`. If it's anything else the version was bumped by
+hand — that's a mistake (semantic-release owns versions).
+
+### 5. Config schema ↔ README alignment
+
+Read both files:
+- `config.schema.json` — the source of truth for every config property
+- `README.md` — the user-facing docs
+
+For every property in the schema, check it appears in the README with an
+accurate description. Pay particular attention to:
+- `global` properties (under **Global element**)
+- per-`accessories` properties (under **Accessory element**)
+- new enum values (e.g. `accessoryType` choices)
+
+Flag any property that is in the schema but missing from the README, described
+inaccurately, or still referred to as a "future" or "planned" feature when it
+is already implemented.
+
+Also check the reverse: if the README documents an option that doesn't exist in
+the schema, flag it.
+
+### 6. README — no stale "future feature" language
+
+Scan README.md for phrases like "future versions", "if there is demand",
+"planned", "coming soon", or "not yet supported". Cross-reference against the
+actual source code. Flag any feature described as future that is already
+implemented.
+
+To find what's implemented, check:
+- `src/ExternalPlatformConfig.ts` — the canonical type for config fields
+- `src/devices/SoundTouch/SoundTouchDeviceConfiguration.ts`
+- `config.schema.json`
+
+### 7. Conventional commits on the branch
+
+Identify the merge base between the current branch and its target
+(`dev`→`beta` target is `beta`; `beta`→`latest` target is `latest`):
+
+```bash
+git log --oneline $(git merge-base HEAD origin/<target>)..HEAD
+```
+
+Every commit message must follow [Conventional Commits](https://www.conventionalcommits.org/).
+Valid types for this repo: `feat`, `fix`, `chore`, `docs`, `ci`, `test`,
+`refactor`, `build`, `perf`.
+
+Release-triggering types: `feat` (minor), `fix` (patch), `feat!` / `BREAKING
+CHANGE` (major). Everything else produces no release — that's fine.
+
+Flag any commit that doesn't start with a valid `type:` or `type(scope):` prefix.
+
+### 8. PR title (if reviewing a PR rather than a local branch)
+
+The PR title becomes the squash-merge commit message. It must follow
+conventional commits — same rules as above.
+
+---
+
+## Output format
+
+After completing all checks, produce this report. Use ✅ for pass, ❌ for fail,
+⚠️ for warnings (non-blocking issues worth noting).
+
+```
+## Release Readiness — <branch> → <target>
+
+| Check                        | Status | Notes                          |
+|------------------------------|--------|--------------------------------|
+| Build                        | ✅/❌  | ...                            |
+| Tests                        | ✅/❌  | ...                            |
+| Lint                         | ✅/❌  | ...                            |
+| Package version placeholder  | ✅/❌  | ...                            |
+| Schema ↔ README alignment    | ✅/❌  | ...                            |
+| No stale "future" language   | ✅/❌  | ...                            |
+| Conventional commits         | ✅/❌  | ...                            |
+
+### Verdict
+READY TO PROMOTE  ← or →  NOT READY — fix the ❌ items above first
+```
+
+List each failing check with specific details: what file, what line, what
+needs to change. Be concrete — "README line 14 says lightbulb is a future
+feature but it's implemented via `accessoryType: 'lightbulb'`" is more useful
+than "README is out of date."
+
+---
+
+## What you don't need to do
+
+- **Don't write or commit a CHANGELOG.** GitHub Releases is the changelog;
+  semantic-release generates it automatically from commit messages.
+- **Don't bump the version.** `0.0.0-development` is correct in
+  `package.json`; semantic-release handles the real version at publish time.
+- **Don't push or open the promotion PR yourself** unless the user explicitly
+  asks. Your job is the gate check; the human decides when to promote.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ This allows you to control your SoundTouch devices with HomeKit and Siri.
 Attempts to repair the [plugin](https://github.com/bbriatte/homebridge-soundtouch-platform/blob/master/README.md) originally
 made by [@bbriatte](http://github.com/bbriatte) to work on current Homebridge (v1.8 and v2).
 
-Initial version only supports a switch accessory type, to power a speaker on and off. Future versions hope to reinstate support
-for other features like volume control, sources, presets, lightbulb mode if there is demand.
+Currently supports powering speakers on and off as a Switch or Lightbulb accessory. The Lightbulb type exposes volume via the Brightness characteristic, so Siri commands like "set Kitchen Speaker to 40%" control the volume.
 
 ## Prerequisites
 1. [Homebridge](https://github.com/homebridge/homebridge) v1.8.0 or later (Homebridge v2 is supported)
@@ -104,6 +103,7 @@ Each accessory must be matched to a device using either `ip` or `room`. If both 
 * `port`: The port used to reach the device. Only used with `ip`. __default__: **8090**
 * `room`: Must match exactly the name of the SoundTouch device (as set in the Bose app). Ignored if `ip` is set.
 * `pollingInterval`: Poll this device every interval in milliseconds. Overrides the global value.
+* `accessoryType`: Override the HomeKit accessory type for this speaker — `switch` or `lightbulb`. Overrides the global value.
 
 
 ### Global element
@@ -112,6 +112,7 @@ Default configuration applied to all accessories. Any value here can be overridd
 *Optional fields*
 * `verbose`: Log all device information __default__: **false**
 * `pollingInterval`: Poll each device every interval in milliseconds __default__: **2000**
+* `accessoryType`: HomeKit accessory type for all speakers — `switch` (default) or `lightbulb`. The `lightbulb` type exposes volume via the Brightness characteristic. __default__: **switch**
 
 ## References
 * [SoundTouch Web API](https://assets.bosecreative.com/m/496577402d128874/original/SoundTouch-Web-API.pdf) — Bose's official API specification this plugin is built against.


### PR DESCRIPTION
## Summary

- README described lightbulb mode as a future feature ("if there is demand") — it has been implemented for some time via `accessoryType: 'lightbulb'`
- Added `accessoryType` to both the **Global element** and **Accessory element** config reference sections in the README
- Added a new `.claude/skills/release-manager` skill that gates promotion PRs with a structured checklist (build, tests, lint, schema↔README alignment, stale-language scan, conventional commits) — would have caught this exact gap

## Test plan

- [ ] README renders correctly on GitHub/npm — config tables include `accessoryType` with accurate descriptions
- [ ] No "future" or "planned" language remains for implemented features
- [ ] The `release-manager` skill is reachable via `/release-manager` in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)