### PR TITLE
test: verify FirmwareRevision is published from /info component softwareVersion

### DIFF
--- a/.claude/skills/architect/plans/2026-06-20-firmware-revision-characteristic.md
+++ b/.claude/skills/architect/plans/2026-06-20-firmware-revision-characteristic.md
@@ -1,0 +1,62 @@
+---
+feature: Publish firmware version as FirmwareRevision characteristic
+status: planned
+date: 2026-06-20
+branch: test/firmware-revision-coverage
+commit-type: test
+---
+
+# Publish firmware version as FirmwareRevision characteristic
+
+## Context
+
+The user asked whether the plugin can fetch and publish the SoundTouch speaker's
+firmware version to HomeKit's `FirmwareRevision` characteristic. **The production
+code already does this end-to-end** — no new feature code is needed. The only gap
+is test coverage: nothing currently asserts that `FirmwareRevision` is actually
+populated on the `AccessoryInformation` service.
+
+## Decisions & findings
+
+| Date | Decision / finding | Rationale / evidence | Alternatives rejected |
+| --- | --- | --- | --- |
+| 2026-06-20 | Feature is already fully implemented | `component.ts` parses `softwareVersion`; `SoundTouchDevice.fromDiscoveredAccessory` sets `device.version`; `SoundTouchSpeakerInformationCharacteristic.init()` conditionally sets `FirmwareRevision` | N/A |
+| 2026-06-20 | Version is derived from the component whose `serialNumber` matches `info.deviceId` (case-insensitive) | `SoundTouchDevice.ts:187-189` | Could use first component or `componentCategory === 'DEVICE'` — but serial=deviceId is the established convention in the codebase and matches what real SoundTouch devices return |
+| 2026-06-20 | `FirmwareRevision` is only set when a matching component is found (`if (this.device.version)`) | `SoundTouchSpeakerInformationCharacteristic.ts:40-45` — the conditional avoids publishing an empty string | Skipping the conditional would set an empty value in HAP |
+| 2026-06-20 | Homebridge stub already has `FirmwareRevision` in `CharacteristicTypes` and `AccessoryInformation` service pre-populated | `homebridge-stub.ts:31`, `85-88` | — |
+| 2026-06-20 | `infoXml()` in the fake server already sets `serialNumber: deviceId` so the component match succeeds | `fake-soundtouch-server.ts:17-18` | — |
+
+## If cancelled
+
+> Leave empty — not cancelled.
+
+## Affected areas
+
+- `src/__integration__/platform-lifecycle.integration.test.ts` — add two new `it` blocks (firmware present / firmware absent)
+- `src/__integration__/helpers/fake-soundtouch-server.ts` — expose an option to omit the matching component so the "absent" case can be tested
+
+## Conventions for this change
+
+- **Commit type:** `test:` → no release
+- **Config schema touched:** no
+- **Tests to add/update:** `src/__integration__/platform-lifecycle.integration.test.ts`
+- **Target branch:** `dev` (squash-merged; PR title is the released commit message).
+
+## Implementation checklist
+
+- [ ] Extend `infoXml()` in `fake-soundtouch-server.ts` to accept an optional `softwareVersion` parameter (default `'1.0.0'`) and a `matchSerialToDeviceId` flag (default `true`); when `false`, emit a component with a different serial so no version match occurs
+- [ ] In `platform-lifecycle.integration.test.ts`, add a `describe('FirmwareRevision characteristic')` block with:
+  - [ ] `it('sets FirmwareRevision to the component softwareVersion when the serial matches')` — assert `api.getCharacteristicValue('AccessoryInformation', 'FirmwareRevision')` equals `'1.0.0'`
+  - [ ] `it('does not set FirmwareRevision when no component serial matches the device id')` — assert value is `undefined`
+
+## Verification
+
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] `npm test`
+
+## PR / release notes
+
+- **PR title (Conventional Commit, becomes the release commit):**
+  `test: verify FirmwareRevision is published from /info component softwareVersion`
+- **Targets:** `dev`

--- a/src/__integration__/helpers/fake-soundtouch-server.ts
+++ b/src/__integration__/helpers/fake-soundtouch-server.ts
@@ -2,20 +2,29 @@ import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 
 export function infoXml(
-  options: { deviceId?: string; name?: string; type?: string } = {}
+  options: {
+    deviceId?: string;
+    name?: string;
+    type?: string;
+    softwareVersion?: string;
+    matchSerialToDeviceId?: boolean;
+  } = {}
 ): string {
   const {
     deviceId = 'DEV-INT-1',
     name = 'Test Speaker',
     type = 'SoundTouch 10',
+    softwareVersion = '1.0.0',
+    matchSerialToDeviceId = true,
   } = options;
+  const serialNumber = matchSerialToDeviceId ? deviceId : 'UNRELATED-SERIAL';
   return (
     `<info deviceID="${deviceId}">` +
     `<name>${name}</name>` +
     `<type>${type}</type>` +
     '<components><component>' +
-    '<softwareVersion>1.0.0</softwareVersion>' +
-    `<serialNumber>${deviceId}</serialNumber>` +
+    `<softwareVersion>${softwareVersion}</softwareVersion>` +
+    `<serialNumber>${serialNumber}</serialNumber>` +
     '</component></components>' +
     '<networkInfo><macAddress>AA:BB:CC:DD:EE:FF</macAddress>' +
     '<ipAddress>127.0.0.1</ipAddress></networkInfo>' +
@@ -73,7 +82,9 @@ export class FakeSoundTouchServer {
       // Drain the request body so POST sockets close cleanly.
       req.resume();
 
-      const path = FakeSoundTouchServer.normalise((req.url ?? '').split('?')[0]);
+      const path = FakeSoundTouchServer.normalise(
+        (req.url ?? '').split('?')[0]
+      );
       const xml = this.responses.get(path);
 
       if (xml === undefined) {

--- a/src/__integration__/platform-lifecycle.integration.test.ts
+++ b/src/__integration__/platform-lifecycle.integration.test.ts
@@ -119,6 +119,36 @@ describe('SoundTouchHomebridgePlatform', () => {
     });
   });
 
+  describe('FirmwareRevision characteristic', () => {
+    it('is set to the component softwareVersion when the serial matches the device id', async () => {
+      server.setResponse(
+        '/info',
+        infoXml({ deviceId: DEVICE_ID, softwareVersion: '2.3.4' })
+      );
+      createPlatform();
+
+      await api.emitDidFinishLaunching();
+
+      expect(
+        api.getCharacteristicValue('AccessoryInformation', 'FirmwareRevision')
+      ).toBe('2.3.4');
+    });
+
+    it('is not set when no component serial matches the device id', async () => {
+      server.setResponse(
+        '/info',
+        infoXml({ deviceId: DEVICE_ID, matchSerialToDeviceId: false })
+      );
+      createPlatform();
+
+      await api.emitDidFinishLaunching();
+
+      expect(
+        api.getCharacteristicValue('AccessoryInformation', 'FirmwareRevision')
+      ).toBeUndefined();
+    });
+  });
+
   describe('when the accessory type is lightbulb', () => {
     it('exposes the speaker as a Lightbulb service', async () => {
       createPlatform({ global: { accessoryType: 'lightbulb' } });


### PR DESCRIPTION
## What & why

The firmware version pipeline (`/info` → `component.softwareVersion` → `device.version` → `FirmwareRevision` characteristic) was already fully implemented in production code but had no test coverage. This PR adds two integration tests that assert the behaviour end-to-end.

See plan: `.claude/skills/architect/plans/2026-06-20-firmware-revision-characteristic.md`

Also extends `infoXml()` in the fake server with `softwareVersion` and `matchSerialToDeviceId` options so the absent-firmware case can be exercised.

## Verification

`npm run typecheck && npm run lint && npm test` — 226 tests pass.