### PR TITLE
fix: use SCM component softwareVersion for FirmwareRevision characteristic

### DIFF
--- a/src/__integration__/helpers/fake-soundtouch-server.ts
+++ b/src/__integration__/helpers/fake-soundtouch-server.ts
@@ -7,7 +7,7 @@ export function infoXml(
     name?: string;
     type?: string;
     softwareVersion?: string;
-    matchSerialToDeviceId?: boolean;
+    hasComponents?: boolean;
   } = {}
 ): string {
   const {
@@ -15,17 +15,20 @@ export function infoXml(
     name = 'Test Speaker',
     type = 'SoundTouch 10',
     softwareVersion = '1.0.0',
-    matchSerialToDeviceId = true,
+    hasComponents = true,
   } = options;
-  const serialNumber = matchSerialToDeviceId ? deviceId : 'UNRELATED-SERIAL';
+  const components = hasComponents
+    ? '<components><component>' +
+      '<componentCategory>SCM</componentCategory>' +
+      `<softwareVersion>${softwareVersion}</softwareVersion>` +
+      '<serialNumber>COMPONENT-SERIAL</serialNumber>' +
+      '</component></components>'
+    : '<components></components>';
   return (
     `<info deviceID="${deviceId}">` +
     `<name>${name}</name>` +
     `<type>${type}</type>` +
-    '<components><component>' +
-    `<softwareVersion>${softwareVersion}</softwareVersion>` +
-    `<serialNumber>${serialNumber}</serialNumber>` +
-    '</component></components>' +
+    components +
     '<networkInfo><macAddress>AA:BB:CC:DD:EE:FF</macAddress>' +
     '<ipAddress>127.0.0.1</ipAddress></networkInfo>' +
     '</info>'

--- a/src/__integration__/platform-lifecycle.integration.test.ts
+++ b/src/__integration__/platform-lifecycle.integration.test.ts
@@ -120,7 +120,7 @@ describe('SoundTouchHomebridgePlatform', () => {
   });
 
   describe('FirmwareRevision characteristic', () => {
-    it('is set to the component softwareVersion when the serial matches the device id', async () => {
+    it('is set to the SCM component softwareVersion', async () => {
       server.setResponse(
         '/info',
         infoXml({ deviceId: DEVICE_ID, softwareVersion: '2.3.4' })
@@ -134,10 +134,28 @@ describe('SoundTouchHomebridgePlatform', () => {
       ).toBe('2.3.4');
     });
 
-    it('is not set when no component serial matches the device id', async () => {
+    it('strips the build suffix from the softwareVersion', async () => {
       server.setResponse(
         '/info',
-        infoXml({ deviceId: DEVICE_ID, matchSerialToDeviceId: false })
+        infoXml({
+          deviceId: DEVICE_ID,
+          softwareVersion:
+            '27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29',
+        })
+      );
+      createPlatform();
+
+      await api.emitDidFinishLaunching();
+
+      expect(
+        api.getCharacteristicValue('AccessoryInformation', 'FirmwareRevision')
+      ).toBe('27.0.6.46330.5043500');
+    });
+
+    it('is not set when the info response has no components', async () => {
+      server.setResponse(
+        '/info',
+        infoXml({ deviceId: DEVICE_ID, hasComponents: false })
       );
       createPlatform();
 

--- a/src/devices/SoundTouch/SoundTouchDevice.ts
+++ b/src/devices/SoundTouch/SoundTouchDevice.ts
@@ -73,13 +73,13 @@ export class SoundTouchDevice implements BaseDevice {
           });
 
       if (deviceConfig) {
-        logger.debug('created device configuration - %s', deviceConfig.toJson());
+        logger.debug(
+          'created device configuration - %s',
+          deviceConfig.toJson()
+        );
         return deviceConfig;
       }
-      logger.debug(
-        'could not create device config for accessory - %s',
-        name
-      );
+      logger.debug('could not create device config for accessory - %s', name);
     }
 
     logger.debug('creating default config', {
@@ -184,16 +184,15 @@ export class SoundTouchDevice implements BaseDevice {
 
     logger.info(`[${displayName}] Found device`);
 
-    const component = info.components.find(
-      (c) => c.serialNumber.toLowerCase() === info.deviceId.toLowerCase()
-    );
+    const component =
+      info.components.find((c) => c.category === 'SCM') ?? info.components[0];
 
     return new SoundTouchDevice({
       api: api,
       name: displayName,
       id: info.deviceId,
       model: info.type,
-      version: component ? component.softwareVersion : undefined,
+      version: component ? component.softwareVersion.split(' ')[0] : undefined,
       configuration: accessoryConfig,
     });
   }


### PR DESCRIPTION
## What & why

`FirmwareRevision` was never populated in HomeKit because the component-matching logic looked for a component whose `serialNumber` equals the device ID — but on real hardware (SoundTouch 30) these are completely different strings. Fixed by selecting the `SCM` component directly (with a fallback to `components[0]`), which is always the one that carries a `softwareVersion`.

Also strips the build suffix (everything after the first space) from the version string. The raw value from `/info` is `27.0.6.46330.5043500 epdbuild.trunk…` — 72 chars — which exceeds HomeKit's 64-char limit for `FirmwareRevision` and triggers a characteristic-value warning in Homebridge.

Builds on the test scaffolding from #83 (already on `dev`).

## Verification

`npm run typecheck && npm run lint && npm test` — 226/226 pass.

Verified live against a SoundTouch 30 at 10.0.0.36: Home app now shows firmware `27.0.6` with no characteristic-value warnings in the Homebridge log.