### PR TITLE
fix: prevent brightness-zero/setOn race that bounced volume to previous level

### DIFF
--- a/src/accessories/services/SoundTouchSpeakerBrightnessCharacteristic.ts
+++ b/src/accessories/services/SoundTouchSpeakerBrightnessCharacteristic.ts
@@ -6,7 +6,6 @@ import {
 } from 'homebridge';
 import { SoundTouchDevice } from '../../devices/SoundTouch/SoundTouchDevice.js';
 import { SoundTouchHomebridgePlatform } from '../../platform.js';
-import { KeyValue } from '../../devices/SoundTouch/api/index.js';
 import { SoundTouchSpeakerCharacteristic } from './SoundTouchSpeakerCharacteristic.js';
 
 export class SoundTouchSpeakerBrightnessCharacteristic extends SoundTouchSpeakerCharacteristic {
@@ -64,16 +63,13 @@ export class SoundTouchSpeakerBrightnessCharacteristic extends SoundTouchSpeaker
 
   async setBrightness(value: CharacteristicValue): Promise<void> {
     const brightness = value as number;
+    if (brightness === 0) {
+      // HomeKit always sends On=false alongside Brightness=0; setOn owns power-off.
+      return;
+    }
     try {
-      if (brightness === 0) {
-        const isOn = await SoundTouchDevice.deviceIsOn(this.device);
-        if (isOn) {
-          await this.device.api.pressKey(KeyValue.power);
-        }
-      } else {
-        await this.device.api.setVolume(brightness);
-      }
-      this.log.success('set brightness - %s', brightness);
+      await this.device.api.setVolume(brightness);
+      this.log.debug('set brightness - %s', brightness);
     } catch (e: unknown) {
       this.log.error('error setting brightness', e);
       throw new this.platform.api.hap.HapStatusError(

--- a/src/accessories/services/SoundTouchSpeakerOnCharacteristic.ts
+++ b/src/accessories/services/SoundTouchSpeakerOnCharacteristic.ts
@@ -55,7 +55,7 @@ export class SoundTouchSpeakerOnCharacteristic extends SoundTouchSpeakerCharacte
       if (this.characteristic.value !== desiredPowerStatus) {
         await this.device.api.pressKey(KeyValue.power);
       }
-      this.log.success('set status - %s', desiredPowerStatus ? 'on' : 'off');
+      this.log.debug('set status - %s', desiredPowerStatus ? 'on' : 'off');
     } catch (e: unknown) {
       this.log.error('error setting on status', e);
       throw new this.platform.api.hap.HapStatusError(

--- a/src/accessories/services/__tests__/SoundTouchSpeakerBrightnessCharacteristic.test.ts
+++ b/src/accessories/services/__tests__/SoundTouchSpeakerBrightnessCharacteristic.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { SoundTouchSpeakerBrightnessCharacteristic } from '../SoundTouchSpeakerBrightnessCharacteristic.js';
-import { SoundTouchDevice } from '../../../devices/SoundTouch/SoundTouchDevice.js';
-import { KeyValue } from '../../../devices/SoundTouch/api/index.js';
 
 class FakeHapStatusError extends Error {
   constructor(public readonly hapStatus: number) {
@@ -9,10 +7,7 @@ class FakeHapStatusError extends Error {
   }
 }
 
-function build({
-  volume = 50,
-  isOn = true,
-}: { volume?: number; isOn?: boolean } = {}) {
+function build({ volume = 50 }: { volume?: number } = {}) {
   const updateValue = jest.fn();
   const hapCharacteristic = {
     value: volume as number | boolean,
@@ -60,8 +55,6 @@ function build({
     },
     logger: { homebridgeLogger: { log: jest.fn() }, requiredLogLevel: 'debug' },
   };
-
-  jest.spyOn(SoundTouchDevice, 'deviceIsOn').mockResolvedValue(isOn);
 
   const subject = new SoundTouchSpeakerBrightnessCharacteristic({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -148,35 +141,19 @@ describe('SoundTouchSpeakerBrightnessCharacteristic', () => {
 
   describe('#setBrightness', () => {
     describe('when value is 0', () => {
-      it('powers off the device when it is on', async () => {
-        const { subject, pressKey } = build({ isOn: true });
-
-        await subject.setBrightness(0);
-
-        expect(pressKey).toHaveBeenCalledWith(KeyValue.power);
-      });
-
-      it('does nothing when the device is already off', async () => {
-        const { subject, pressKey } = build({ isOn: false });
+      it('is a no-op — power-off is owned by setOn', async () => {
+        const { subject, pressKey, setVolume } = build();
 
         await subject.setBrightness(0);
 
         expect(pressKey).not.toHaveBeenCalled();
-      });
-
-      it('throws HapStatusError when the power-off command fails', async () => {
-        const { subject, pressKey } = build({ isOn: true });
-        pressKey.mockRejectedValue(new Error('network error'));
-
-        await expect(subject.setBrightness(0)).rejects.toBeInstanceOf(
-          FakeHapStatusError
-        );
+        expect(setVolume).not.toHaveBeenCalled();
       });
     });
 
     describe('when value is greater than 0', () => {
       it('sets the volume to the given value', async () => {
-        const { subject, setVolume } = build({ isOn: true });
+        const { subject, setVolume } = build();
 
         await subject.setBrightness(65);
 
@@ -184,7 +161,7 @@ describe('SoundTouchSpeakerBrightnessCharacteristic', () => {
       });
 
       it('throws HapStatusError when the volume set fails', async () => {
-        const { subject, setVolume } = build({ isOn: true });
+        const { subject, setVolume } = build();
         setVolume.mockRejectedValue(new Error('network error'));
 
         await expect(subject.setBrightness(65)).rejects.toBeInstanceOf(


### PR DESCRIPTION
When HomeKit turns off a Lightbulb it fires both `setOn(false)` and `setBrightness(0)` simultaneously. Both previously called `pressKey(power)`, turning the speaker off then immediately back on — the slider then snapped back to the speaker's previous volume (10% in testing).

`setBrightness(0)` is now a no-op. Power-off is owned entirely by `setOn`, which already handles it correctly. HomeKit always sends `On=false` alongside `Brightness=0`, so the behaviour is unchanged from the user's perspective.

Also moves set-operation success logs to `debug` so they are suppressed at the default `verbose: false` level — they now only appear when `global.verbose: true` is set.

**Verification:** `npm run typecheck && npm run lint && npm test` — 236/236 pass. Manual: drag Lightbulb brightness to 0, confirm speaker powers off and slider stays at 0.