### PR TITLE
chore: use conventionalcommits preset to control release note sections

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,7 +2,27 @@
   "branches": ["latest", { "name": "beta", "prerelease": true }],
   "plugins": [
     "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            { "type": "feat", "section": "New Features" },
+            { "type": "fix", "section": "Fixes" },
+            { "type": "perf", "hidden": true },
+            { "type": "revert", "hidden": true },
+            { "type": "docs", "hidden": true },
+            { "type": "style", "hidden": true },
+            { "type": "chore", "hidden": true },
+            { "type": "refactor", "hidden": true },
+            { "type": "test", "hidden": true },
+            { "type": "build", "hidden": true },
+            { "type": "ci", "hidden": true }
+          ]
+        }
+      }
+    ],
     "@semantic-release/npm",
     [
       "@semantic-release/github",

--- a/knip.json
+++ b/knip.json
@@ -13,7 +13,8 @@
     "nodemon",
     "prettier",
     "rimraf",
-    "semantic-release"
+    "semantic-release",
+    "conventional-changelog-conventionalcommits"
   ],
   "ignoreBinaries": [
     "semantic-release",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-soundtouchspeaker",
-  "version": "0.2.4-beta.2",
+  "version": "0.0.0-development",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-soundtouchspeaker",
-      "version": "0.2.4-beta.2",
+      "version": "0.0.0-development",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.17.0",
@@ -29,6 +29,7 @@
         "@types/ws": "^8.18.1",
         "@types/xml2js": "^0.4.9",
         "axios-mock-adapter": "^2.1.0",
+        "conventional-changelog-conventionalcommits": "^9.3.1",
         "eslint": "^10.5.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-jest": "^29.15.2",
@@ -9567,6 +9568,8 @@
     },
     "node_modules/npm/node_modules/@gar/promise-retry": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
+      "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9576,6 +9579,8 @@
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9588,12 +9593,16 @@
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
+      "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.2.tgz",
+      "integrity": "sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9610,6 +9619,8 @@
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
       "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-9.8.0.tgz",
+      "integrity": "sha512-bqjei/1+uait6wA30G7IElMs5VCyGpuVPFQYsvzqhTEEAVmDMsHBCFstcT2lLfeQDvi8MeUQHStfHSArvdTQuw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9658,6 +9669,8 @@
     },
     "node_modules/npm/node_modules/@npmcli/config": {
       "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/config/-/config-10.11.0.tgz",
+      "integrity": "sha512-YeRrOREeF9rYlwQfqbjJc8bjplzdzz2dapOVfV3gl3kSMFn0wEI9+QZQADmAvdd+MKTeOr/ISgNmdxJj6layAA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9677,6 +9690,8 @@
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+      "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9689,6 +9704,8 @@
     },
     "node_modules/npm/node_modules/@npmcli/git": {
       "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.2.tgz",
+      "integrity": "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9708,6 +9725,8 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
+      "integrity": "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9724,6 +9743,8 @@
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
       "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-5.0.3.tgz",
+      "integrity": "sha512-o2grssXo1e774E5OtEwwrgoszYRh0lqkJH+Pb9r78UcqdGJRDRfhpM8DvZPjzNLLNYeD/rNbjOKM3Ss5UABROw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9739,6 +9760,8 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/metavuln-calculator/-/metavuln-calculator-9.0.3.tgz",
+      "integrity": "sha512-94GLSYhLXF2t2LAC7pDwLaM4uCARzxShyAQKsirmlNcpidH89VA4/+K1LbJmRMgz5gy65E/QBBWQdUvGLe2Frg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9755,6 +9778,8 @@
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-4.0.0.tgz",
+      "integrity": "sha512-qfrhVlOSqmKM8i6rkNdZzABj8MKEITGFAY+4teqBziksCQAOLutiAxM1wY2BKEd8KjUSpWmWCYxvXr0y4VTlPg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9764,6 +9789,8 @@
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-5.0.0.tgz",
+      "integrity": "sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9773,6 +9800,8 @@
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
       "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.5.tgz",
+      "integrity": "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9791,6 +9820,8 @@
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
+      "integrity": "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9803,6 +9834,8 @@
     },
     "node_modules/npm/node_modules/@npmcli/query": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/query/-/query-5.0.0.tgz",
+      "integrity": "sha512-8TZWfTQOsODpLqo9SVhVjHovmKXNpevHU0gO9e+y4V4fRIOneiXy0u0sMP9LmS71XivrEWfZWg50ReH4WRT4aQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9815,6 +9848,8 @@
     },
     "node_modules/npm/node_modules/@npmcli/redact": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+      "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9824,6 +9859,8 @@
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
       "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-10.0.4.tgz",
+      "integrity": "sha512-mGUWr1uMnf0le2TwfOZY4SFxZGXGfm4Jtay/nwAa2FLNAKXUoUwaGwBMNH36UHPtinWfTSJ3nqFQr0091CxVGg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9840,6 +9877,8 @@
     },
     "node_modules/npm/node_modules/@sigstore/bundle": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
+      "integrity": "sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -9852,6 +9891,8 @@
     },
     "node_modules/npm/node_modules/@sigstore/core": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-3.2.1.tgz",
+      "integrity": "sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -9861,6 +9902,8 @@
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
       "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.5.1.tgz",
+      "integrity": "sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -9870,6 +9913,8 @@
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.1.1.tgz",
+      "integrity": "sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -9887,6 +9932,8 @@
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.2.tgz",
+      "integrity": "sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -9900,6 +9947,8 @@
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-3.1.1.tgz",
+      "integrity": "sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -9914,6 +9963,8 @@
     },
     "node_modules/npm/node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
+      "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9923,6 +9974,8 @@
     },
     "node_modules/npm/node_modules/@tufjs/models": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-4.1.0.tgz",
+      "integrity": "sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9936,6 +9989,8 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9945,6 +10000,8 @@
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9954,18 +10011,24 @@
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9975,6 +10038,8 @@
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.2.tgz",
+      "integrity": "sha512-frE1t78WOwJ45PKV2cF2tNPjTcs9L1J9s6VkrV59wanRP4GlaomuxYPVma7BwthMg8WnfSory4w5PTE6FZZ81w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9991,6 +10056,8 @@
     },
     "node_modules/npm/node_modules/binary-extensions": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-3.1.0.tgz",
+      "integrity": "sha512-Jvvd9hy1w+xUad8+ckQsWA/V1AoyubOvqn0aygjMOVM4BfIaRav1NFS3LsTSDaV4n4FtcCtQXvzep1E6MboqwQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10003,6 +10070,8 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10015,6 +10084,8 @@
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "20.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+      "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10036,6 +10107,8 @@
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10048,6 +10121,8 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -10057,6 +10132,8 @@
     },
     "node_modules/npm/node_modules/ci-info": {
       "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
       "dev": true,
       "funding": [
         {
@@ -10072,6 +10149,8 @@
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-5.0.5.tgz",
+      "integrity": "sha512-59tdLZcC+BJXa4C5rOmVSuJTy/UneqfJJtCraqwdx5BDHTkGrBtKCUl3u2uiCFvXu+wk0kVuX8axX7yHCZOI9w==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -10081,6 +10160,8 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
+      "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10090,6 +10171,8 @@
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
+      "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -10099,6 +10182,8 @@
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10111,6 +10196,8 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10128,6 +10215,8 @@
     },
     "node_modules/npm/node_modules/diff": {
       "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -10137,6 +10226,8 @@
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10146,12 +10237,16 @@
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10161,6 +10256,8 @@
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10173,6 +10270,8 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -10190,12 +10289,16 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10208,12 +10311,16 @@
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10227,6 +10334,8 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10240,6 +10349,8 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10257,6 +10368,8 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
+      "integrity": "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10269,6 +10382,8 @@
     },
     "node_modules/npm/node_modules/ini": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10278,6 +10393,8 @@
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-8.2.5.tgz",
+      "integrity": "sha512-IknQ+upLuJU6t3p0uo9wS3GjFD/1GtxIwcIGYOWR8zL2HxQeJwvxYTgZr9brJ8pyZ4kvpkebM8ZKcyqOeLOHSg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10295,6 +10412,8 @@
     },
     "node_modules/npm/node_modules/ip-address": {
       "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10304,6 +10423,8 @@
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-6.0.4.tgz",
+      "integrity": "sha512-tOIBU3QiXy0W4LvHbcKWAWSuQfGwDiEILphFCAZtDqj7C57uv3ClO6K8aNEGV4VTA7bWJlpQ0suKQkUe6Rd6ag==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -10316,6 +10437,8 @@
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -10325,6 +10448,8 @@
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
+      "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10334,6 +10459,8 @@
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz",
+      "integrity": "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10343,6 +10470,8 @@
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
       "dev": true,
       "engines": [
         "node >= 0.2.0"
@@ -10352,18 +10481,24 @@
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/just-diff/-/just-diff-6.0.2.tgz",
+      "integrity": "sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/just-diff-apply/-/just-diff-apply-5.5.0.tgz",
+      "integrity": "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-10.0.3.tgz",
+      "integrity": "sha512-JPHTfWJxIK+NVPdNMNGnkz4XGX56iijPbe0qFWbdt68HL+kIvSzh+euBL8npLZvl2fpaxo+1eZSdoG15f5YdIQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10377,6 +10512,8 @@
     },
     "node_modules/npm/node_modules/libnpmdiff": {
       "version": "8.1.10",
+      "resolved": "https://registry.npmjs.org/libnpmdiff/-/libnpmdiff-8.1.10.tgz",
+      "integrity": "sha512-UWZPUjkaCuE6+b5kgFrfeIjCR/4IWdU1QRu6jAGgUrk4sKMgnrHKdZ5JzNM4SnPfzLC51+Ts/woEKG7JMEJsPw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10396,6 +10533,8 @@
     },
     "node_modules/npm/node_modules/libnpmexec": {
       "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/libnpmexec/-/libnpmexec-10.3.0.tgz",
+      "integrity": "sha512-JzRj0fVmvBpqrQJ+3Cv0VGPjiDvJbnBu+nbUXKJ/5BUISoSYd0KShyjZsZaIiMZLlDjzFgvDXMZZP2bhVhhVdQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10419,6 +10558,8 @@
     },
     "node_modules/npm/node_modules/libnpmfund": {
       "version": "7.0.24",
+      "resolved": "https://registry.npmjs.org/libnpmfund/-/libnpmfund-7.0.24.tgz",
+      "integrity": "sha512-ubiggibzvG9TQr8KO0Jf6hLQbvfJHr+I4Lo740qV+/03e0SLSRjnHArqgffubEFtmtvrHfeNX/YYFfZaeaiE7A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10431,6 +10572,8 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/libnpmorg/-/libnpmorg-8.0.1.tgz",
+      "integrity": "sha512-/QeyXXg4hqMw0ESM7pERjIT2wbR29qtFOWIOug/xO4fRjS3jJJhoAPQNsnHtdwnCqgBdFpGQ45aIdFFZx2YhTA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10444,6 +10587,8 @@
     },
     "node_modules/npm/node_modules/libnpmpack": {
       "version": "9.1.10",
+      "resolved": "https://registry.npmjs.org/libnpmpack/-/libnpmpack-9.1.10.tgz",
+      "integrity": "sha512-J8V8wUBkqRRVtAn43zTMcw3vFyODlOGkS9jq4esolBLCwxuMDjNarWn5Og+DeZLocsHYtlqc963a1hUFOrKIHQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10459,6 +10604,8 @@
     },
     "node_modules/npm/node_modules/libnpmpublish": {
       "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-11.2.0.tgz",
+      "integrity": "sha512-fAEts7UCM2r1xhI82Dv9PK4gFGZoyD7Z5sfIwBQKoO/f67VNVDC0DeH3uH1Yi+T4kwt5iBuCKkZ5XcpxfvsGHQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10478,6 +10625,8 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-9.0.1.tgz",
+      "integrity": "sha512-oKw58X415ERY/BOGV3jQPVMcep8YeMRWMzuuqB0BAIM5VxicOU1tQt19ExCu4SV77SiTOEoziHxGEgJGw3FBYQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10490,6 +10639,8 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/libnpmteam/-/libnpmteam-8.0.2.tgz",
+      "integrity": "sha512-ypLrDUQoi8EhG+gzx5ENMcYq23YjPV17Mfvx4nOnQiHOi8vp47+4GvZBrMsEM4yeHPwxguF/HZoXH4rJfHdH/w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10503,6 +10654,8 @@
     },
     "node_modules/npm/node_modules/libnpmversion": {
       "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/libnpmversion/-/libnpmversion-8.0.4.tgz",
+      "integrity": "sha512-5NiNpLxXkNeLHCYVTLxX/qRgdAoRAjiR0arFdVpQ5kZOJ2b0pHdXS9G3qC7uiqVsLa/gfQQIbQIEPdmSMKXF2A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10519,6 +10672,8 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -10528,6 +10683,8 @@
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "15.0.6",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.6.tgz",
+      "integrity": "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10551,6 +10708,8 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -10566,6 +10725,8 @@
     },
     "node_modules/npm/node_modules/minipass": {
       "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -10575,6 +10736,8 @@
     },
     "node_modules/npm/node_modules/minipass-collect": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10587,6 +10750,8 @@
     },
     "node_modules/npm/node_modules/minipass-fetch": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
+      "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10616,6 +10781,8 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10628,6 +10795,8 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10640,12 +10809,16 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline/node_modules/yallist": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
+      "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10658,6 +10831,8 @@
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10670,12 +10845,16 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10685,6 +10864,8 @@
     },
     "node_modules/npm/node_modules/negotiator": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10694,6 +10875,8 @@
     },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+      "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10718,6 +10901,8 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10733,6 +10918,8 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-7.0.0.tgz",
+      "integrity": "sha512-bluLL4xwGr/3PERYz50h2Upco0TJMDcLcymuFnfDWeGO99NqH724MNzhWi5sXXuXf2jbytFF0LyR8W+w1jTI6A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10742,6 +10929,8 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-5.0.0.tgz",
+      "integrity": "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10754,6 +10943,8 @@
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-8.0.0.tgz",
+      "integrity": "sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -10766,6 +10957,8 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+      "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10775,6 +10968,8 @@
     },
     "node_modules/npm/node_modules/npm-package-arg": {
       "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+      "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10790,6 +10985,8 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.4.tgz",
+      "integrity": "sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10803,6 +11000,8 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
+      "integrity": "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10831,6 +11030,8 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-19.1.1.tgz",
+      "integrity": "sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10850,6 +11051,8 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-4.0.0.tgz",
+      "integrity": "sha512-TP+Ziq/qPi/JRdhaEhnaiMkqfMGjhDLoh/oRfW+t5aCuIfJxIUxvwk6Sg/6ZJ069N/Be6gs00r+aZeJTfS9uHQ==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -10859,6 +11062,8 @@
     },
     "node_modules/npm/node_modules/p-map": {
       "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10871,6 +11076,8 @@
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "21.5.1",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.1.tgz",
+      "integrity": "sha512-KvcJ9iy3crysCsgqc4+PknH/w6jkrp8JN36mpZBPwNaDRwTfMZD37YzRazNstiZUOhuF5pno9f78n9mEJBavwg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10902,6 +11109,8 @@
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/parse-conflict-json/-/parse-conflict-json-5.0.1.tgz",
+      "integrity": "sha512-ZHEmNKMq1wyJXNwLxyHnluPfRAFSIliBvbK/UiOceROt4Xh9Pz0fq49NytIaeaCUf5VR86hwQ/34FCcNU5/LKQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10916,6 +11125,8 @@
     },
     "node_modules/npm/node_modules/path-scurry": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -10932,6 +11143,8 @@
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
       "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10945,6 +11158,8 @@
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10954,6 +11169,8 @@
     },
     "node_modules/npm/node_modules/proggy": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/proggy/-/proggy-4.0.0.tgz",
+      "integrity": "sha512-MbA4R+WQT76ZBm/5JUpV9yqcJt92175+Y0Bodg3HgiXzrmKu7Ggq+bpn6y6wHH+gN9NcyKn3yg1+d47VaKwNAQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10963,6 +11180,8 @@
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
+      "integrity": "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10972,6 +11191,8 @@
     },
     "node_modules/npm/node_modules/promise-call-limit": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/promise-call-limit/-/promise-call-limit-3.0.2.tgz",
+      "integrity": "sha512-mRPQO2T1QQVw11E7+UdCJu7S61eJVWknzml9sC1heAdj1jxl0fWMBypIt9ZOcLFf8FkG995ZD7RnVk7HH72fZw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10981,6 +11202,8 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/promzard/-/promzard-3.0.1.tgz",
+      "integrity": "sha512-M5mHhWh+Adz0BIxgSrqcc6GTCSconR7zWQV9vnOSptNtr6cSFlApLc28GbQhuN6oOWBQeV2C0bNE47JCY/zu3Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10993,6 +11216,8 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
       "dev": true,
       "inBundle": true,
       "bin": {
@@ -11001,6 +11226,8 @@
     },
     "node_modules/npm/node_modules/read": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/read/-/read-5.0.1.tgz",
+      "integrity": "sha512-+nsqpqYkkpet2UVPG8ZiuE8d113DK4vHYEoEhcrXBAlPiq6di7QRTuNiKQAbaRYegobuX2BpZ6QjanKOXnJdTA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11013,6 +11240,8 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
+      "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11022,6 +11251,8 @@
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11041,6 +11272,8 @@
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11053,6 +11286,8 @@
     },
     "node_modules/npm/node_modules/sigstore": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-4.1.1.tgz",
+      "integrity": "sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -11070,6 +11305,8 @@
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11080,6 +11317,8 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11094,6 +11333,8 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11108,12 +11349,16 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
       "dev": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11124,12 +11369,16 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+      "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11142,6 +11391,8 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11154,6 +11405,8 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -11170,18 +11423,24 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-2.0.2.tgz",
+      "integrity": "sha512-rGxAbeL9z3J4pI2GtBEoFaavHdO4RKAU54hEuOef5kfx5aPqiQtbhYktMOTL5OA33db8BjsDcLXuNp+/v19PHw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
       "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11198,6 +11457,8 @@
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
       "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11215,6 +11476,8 @@
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11227,6 +11490,8 @@
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-3.0.0.tgz",
+      "integrity": "sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11236,6 +11501,8 @@
     },
     "node_modules/npm/node_modules/tuf-js": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-4.1.0.tgz",
+      "integrity": "sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11259,12 +11526,16 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+      "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11274,6 +11545,8 @@
     },
     "node_modules/npm/node_modules/walk-up-path": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11283,6 +11556,8 @@
     },
     "node_modules/npm/node_modules/which": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11298,6 +11573,8 @@
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11310,6 +11587,8 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/ws": "^8.18.1",
     "@types/xml2js": "^0.4.9",
     "axios-mock-adapter": "^2.1.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "eslint": "^10.5.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-jest": "^29.15.2",


### PR DESCRIPTION
## What & why

Switches `@semantic-release/release-notes-generator` from the default `angular` preset to `conventionalcommits`, which lets us explicitly configure which commit types appear in GitHub releases and what their section headings are.

- `revert`, `perf`, `docs`, `style`, `chore`, `refactor`, `test`, `build`, `ci` are now hidden
- `feat` → "New Features", `fix` → "Fixes"
- Adds `conventional-changelog-conventionalcommits` as a direct devDependency (was previously only available transitively)
- Adds it to `knip.json` `ignoreDependencies` since it's consumed by `.releaserc.json` at runtime, not via TypeScript imports

## Verification

Pre-commit hook passed (lint-staged + knip).