### PR TITLE
ci: wire publish job to release environment for approval gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: release
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ dist
 .idea
 
 /test/hbConfig
+test/hbConfig/config.office.json


### PR DESCRIPTION
## What & why

Wires the publish job to a GitHub release environment so deployments to npm require manual approval before proceeding.

## Verification

Pending — will confirm the approval gate appears on next release run.