### PR TITLE
docs: mark beta v0.3.0-beta.1 features in plans and roadmap

### DIFF
--- a/.claude/skills/architect/plan-template.md
+++ b/.claude/skills/architect/plan-template.md
@@ -1,6 +1,6 @@
 ---
 feature: <one-line feature name>
-status: planned # planned | in-progress | done | cancelled
+status: planned # planned | in-progress | beta | done | cancelled
 date: <YYYY-MM-DD>
 branch: <feat/…, branched off dev>
 commit-type: <feat | fix | feat! | chore | docs | ci | test | refactor>

--- a/.claude/skills/architect/plans/2026-06-19-accessory-type-switch-or-lightbulb.md
+++ b/.claude/skills/architect/plans/2026-06-19-accessory-type-switch-or-lightbulb.md
@@ -1,6 +1,6 @@
 ---
 feature: Configurable accessory type — Switch or Lightbulb
-status: planned # planned | in-progress | done | cancelled
+status: beta # v0.3.0-beta.1 — feat: let each speaker be a Switch or a Lightbulb accessory (#72)
 date: 2026-06-19
 branch: feat/accessory-type
 commit-type: feat

--- a/.claude/skills/architect/plans/2026-06-19-volume-control.md
+++ b/.claude/skills/architect/plans/2026-06-19-volume-control.md
@@ -1,6 +1,6 @@
 ---
 feature: Volume control — Lightbulb Brightness (Lightbulb mode)
-status: in-progress # planned | in-progress | done | cancelled
+status: beta # v0.3.0-beta.1 — feat: add volume control via Lightbulb brightness (#86); fix: race (#91)
 date: 2026-06-19
 updated: 2026-06-20
 branch: feat/lightbulb-brightness-volume

--- a/.claude/skills/architect/plans/2026-06-20-firmware-revision-characteristic.md
+++ b/.claude/skills/architect/plans/2026-06-20-firmware-revision-characteristic.md
@@ -1,6 +1,6 @@
 ---
 feature: Publish firmware version as FirmwareRevision characteristic
-status: planned
+status: beta # v0.3.0-beta.1 — fix: use SCM component softwareVersion for FirmwareRevision (#85); test: (#83)
 date: 2026-06-20
 branch: test/firmware-revision-coverage
 commit-type: test

--- a/.claude/skills/architect/plans/2026-06-20-integration-test-harness.md
+++ b/.claude/skills/architect/plans/2026-06-20-integration-test-harness.md
@@ -1,6 +1,6 @@
 ---
 feature: Integration test harness for end-to-end plugin coverage
-status: in-progress
+status: beta # v0.3.0-beta.1 — test: add in-process integration test harness (#58); no version bump (test: type)
 date: 2026-06-20
 branch: test/integration-harness
 commit-type: test

--- a/.claude/skills/architect/plans/2026-06-20-polling-lifecycle.md
+++ b/.claude/skills/architect/plans/2026-06-20-polling-lifecycle.md
@@ -1,6 +1,6 @@
 ---
 feature: Polling lifecycle — stop polling on accessory removal/shutdown and make it configurable
-status: in-progress # planned | in-progress | done | cancelled
+status: beta # v0.3.0-beta.1 — fix: stop polling on removal/shutdown and honour pollingInterval (#65)
 date: 2026-06-20
 branch: fix/polling-lifecycle
 commit-type: fix

--- a/.claude/skills/technical-lead/ROADMAP.md
+++ b/.claude/skills/technical-lead/ROADMAP.md
@@ -1,6 +1,6 @@
 # Technical Roadmap
 
-Last updated: 2026-06-20 (cancelled Switch volume path; Plan 01 → Lightbulb path is now the volume delivery sequence)
+Last updated: 2026-06-20
 
 This file gives the delivery order and dependency chain across all planned
 features. The individual plan files contain the detail; this file answers
@@ -37,35 +37,29 @@ flowchart TD
 
 ## Current state (2026-06-20)
 
-- **Done:** [05] Integration test harness — **#58 merged into `dev`**.
-- **Done:** [06] Polling lifecycle — **#65 merged into `dev`**. Polling is now
-  stoppable on unregister/shutdown and configurable via `pollingInterval`.
-- **Done (infra):** Spike C Part 1 — gabbo WebSocket harness — **#66 merged into
-  `dev`**. Parse/dispatch logic validated; fake-gabbo server test double in place.
-- **Cancelled:** [02] Volume — Switch path. **PR #62 was merged then reverted (#70)**
-  — the Switch service exposes only a binary `On` characteristic; volume requires
-  a 0–100 range. A linked Speaker tile on a Switch accessory is a UX anti-pattern.
-  `dev` is clean.
-- **Next:** [01] Accessory type — `feat/accessory-type`. Gate for the Lightbulb
-  service, which is the prerequisite for the volume/Brightness path.
-- **After 01:** [02] Volume — Lightbulb path — `SoundTouchSpeakerBrightnessCharacteristic`,
-  wired into the Lightbulb service (`accessoryType: 'lightbulb'`). Includes the
-  `On` setter race fix (5 s `finally` sleep → non-blocking settle).
-- **Blocked:** [03] Source selection (spike), [04] PWA all phases (spikes A/B),
-  **[07] WebSocket push (Spike C Part 2 — real hardware needed + plan 06 done)**.
-- Skill changes landed in `dev`: session-cost estimation (#57), planning vs.
-  implementation branches (#59), roadmap status + plan-05 calibration (#60).
+- **Beta (v0.3.0-beta.1):** [05] Integration test harness — **#58**. Fake HTTP server + HAP stub; polling neutralised with fake timers.
+- **Beta (v0.3.0-beta.1):** [06] Polling lifecycle — **#65**. Polling stoppable on unregister/shutdown; `pollingInterval` config field.
+- **Beta (v0.3.0-beta.1):** Spike C Part 1 — gabbo WebSocket harness — **#66**. Parse/dispatch validated; fake-gabbo test double in place.
+- **Beta (v0.3.0-beta.1):** FirmwareRevision characteristic — **#83** (test), **#85** (fix). SCM `softwareVersion` component correctly sourced.
+- **Beta (v0.3.0-beta.1):** [01] Accessory type — **#72**. `accessoryType: 'switch' | 'lightbulb'` threaded through config → accessory; orphan-service pruning on type change.
+- **Beta (v0.3.0-beta.1):** [02] Volume — Lightbulb path — **#86** (feat), **#91** (race fix). Brightness 0–100 maps to volume; 0 = power off; non-blocking settle.
+- **Cancelled:** [02] Volume — Switch path. **PR #62 was merged then reverted (#70)** — binary `On` only; volume requires 0–100 range.
+- **Next (unblocked):** `prefer-it-over-test` sweep — mechanical `test()` → `it()` rename across ~21 test files. Small, no production code.
+- **Next (unblocked):** Spike C Part 2 — real hardware capture session. Unblocks [07] WebSocket push (plan 06 ✅, Spike C Part 1 ✅).
+- **Blocked:** [03] Source selection (TV-vs-Switch spike), [04] PWA all phases (spikes A/B).
 
 ## Anticipated delivery order
 
 | Order | Plan | Branch | Status | Why this position |
 | ----- | ---- | ------ | ------ | ----------------- |
-| 1 | **[05] Integration test harness** | `test/integration-harness` | ✅ #58 merged | Pure test infrastructure, no release. Gives confidence before shipping any user-facing feature. |
-| 2 | **[06] Polling lifecycle** | `fix/polling-lifecycle` | ✅ #65 merged | Stop polling on accessory removal/shutdown; configurable interval. `fix:` → patch. |
-| 2.5 | **Spike C Part 1 — gabbo harness** | `spike/gabbo-harness` | ✅ #66 merged | Validated parse/dispatch; fake-gabbo test double ready. |
-| 3 | **[01] Accessory type** | `feat/accessory-type` | 🟢 Next | Thread `accessoryType: 'switch' \| 'lightbulb'` through config → `DeviceConfiguration` → `createAccessory`; prune orphan services on type change. Gate for the Lightbulb volume path. `feat:` → minor. |
-| 4 | **[02] Volume — Lightbulb path** | `feat/volume-control` | 🟡 In-progress (gated on 01) | `SoundTouchSpeakerBrightnessCharacteristic`: Brightness 0–100 maps to volume; 0 = power off; >0 from off = power on then set. Includes the `On` setter 5 s-sleep race fix. Bundle into plan 01 PR or immediate follow-up. |
-| 5 | **[07] WebSocket push (gabbo)** | `feat/websocket-push` | 🔴 Blocked (Spike C Part 2 + plan 06 ✅) | Event-driven refresh via the gabbo channel (port 8080), **augmenting** polling. Spike C Part 2 needs real hardware. Phased: P1 connection+lifecycle, P2 per-event mapping, P3 tune polling + edges. |
+| 1 | **[05] Integration test harness** | `test/integration-harness` | ✅ beta v0.3.0-beta.1 (#58) | Pure test infrastructure, no release. Gives confidence before shipping any user-facing feature. |
+| 2 | **[06] Polling lifecycle** | `fix/polling-lifecycle` | ✅ beta v0.3.0-beta.1 (#65) | Stop polling on accessory removal/shutdown; configurable interval. `fix:` → patch. |
+| 2.5 | **Spike C Part 1 — gabbo harness** | `spike/gabbo-harness` | ✅ beta v0.3.0-beta.1 (#66) | Validated parse/dispatch; fake-gabbo test double ready. |
+| 2.6 | **FirmwareRevision characteristic** | `test/firmware-revision-coverage` | ✅ beta v0.3.0-beta.1 (#83, #85) | SCM `softwareVersion` component correctly sourced and published. |
+| 3 | **[01] Accessory type** | `feat/accessory-type` | ✅ beta v0.3.0-beta.1 (#72) | `accessoryType: 'switch' \| 'lightbulb'` threaded through config → accessory; orphan-service pruning on type change. `feat:` → minor. |
+| 4 | **[02] Volume — Lightbulb path** | `feat/volume-control` | ✅ beta v0.3.0-beta.1 (#86, #91) | Brightness 0–100 maps to volume; 0 = power off; non-blocking settle for the `On`/`Brightness` race. |
+| 4.5 | **prefer-it-over-test sweep** | `test/prefer-it-over-test` | 🟢 Next (unblocked) | Mechanical `test()` → `it()` rename across ~21 test files. Small, no production code, no release. |
+| 5 | **[07] WebSocket push (gabbo)** | `feat/websocket-push` | 🟡 Spike C Part 2 needed | Event-driven refresh via the gabbo channel (port 8080), **augmenting** polling. Spike C Part 2 needs real hardware (device available). Phased: P1 connection+lifecycle, P2 per-event mapping, P3 tune polling + edges. |
 | 6 | **[03] Source selection** | `feat/source-selection` | 🔴 Blocked (spike) | Independent of 01/02. Blocked on a **spike** (verify Television+InputSource on a real device; choose TV path vs per-source Switch fallback). Cannot be committed until the spike resolves the architecture choice. |
 | 7 | **[04] PWA — Phase 1** | `feat/pwa` | 🔴 Blocked (spike A) | Architecturally separate (new `web/` workspace + embedded HTTP server). Blocked on **spike A** (reverse-engineer the hotspot provisioning HTTP API at `http://192.0.2.1`). Phase 1 must ship before phases 2 and 3 (it creates the web scaffold and embedded server). |
 | 8 | **[04] PWA — Phase 2** | `feat/pwa` | 🔴 Blocked (needs P1) | Group management via the zone API (`/getZone`, `/setZone`, etc. — already implemented in `src/devices/SoundTouch/api/zone.ts`). Needs the phase 1 PWA scaffold and embedded server to be in place. |
@@ -82,10 +76,11 @@ below.
 
 | Plan | Band | Drivers that set the band | Session guidance |
 | ---- | ---- | ------------------------- | ---------------- |
-| **[05] Integration test harness** | Medium | New test infra (fake HTTP server + Homebridge stub) and a Jest `projects` split; lots of additive code but low iteration risk and no release | ✅ Done. |
-| **[06] Polling lifecycle** | Small–Medium | Modifies existing platform + accessory lifecycle (retain wrappers, stop on unregister/shutdown) and threads two config fields; async lifecycle reasoning + a couple of tests | ✅ Done. |
-| **[01] Accessory type** | Heavy | Config threading through `DeviceConfiguration`, branching the hardcoded Switch in `createAccessory` (`:71`), and orphan-service pruning on type change | Plan a full session. Gates the Lightbulb volume follow-up. ~11 items. |
-| **[02] Volume — Lightbulb path** | Small–Medium | `SoundTouchSpeakerBrightnessCharacteristic` + power/volume race fix; `On`/`Brightness` ordering needs careful handling | Bundle into plan 01's PR or a quick follow-up. Race fix is the main iteration risk. |
+| **[05] Integration test harness** | Medium | New test infra (fake HTTP server + Homebridge stub) and a Jest `projects` split; lots of additive code but low iteration risk and no release | ✅ beta v0.3.0-beta.1 |
+| **[06] Polling lifecycle** | Small–Medium | Modifies existing platform + accessory lifecycle (retain wrappers, stop on unregister/shutdown) and threads two config fields; async lifecycle reasoning + a couple of tests | ✅ beta v0.3.0-beta.1 |
+| **[01] Accessory type** | Heavy | Config threading through `DeviceConfiguration`, branching the hardcoded Switch in `createAccessory`, and orphan-service pruning on type change | ✅ beta v0.3.0-beta.1 |
+| **[02] Volume — Lightbulb path** | Small–Medium | `SoundTouchSpeakerBrightnessCharacteristic` + power/volume race fix; `On`/`Brightness` ordering needs careful handling | ✅ beta v0.3.0-beta.1 |
+| **prefer-it-over-test sweep** | Small | Pure mechanical rename, no production code, no iteration risk | 🟢 Next. |
 | **[07] WebSocket push — Phase 1** | Heavy (est.) | New stateful per-device connection (connect/parse/reconnect/teardown), a new `ws`-backed fake-gabbo harness, and async lifecycle threaded through `platform.ts`/accessory; async timing + reconnect is high iteration risk | Plan a full session. Re-estimate after Spike C. Phases 2–3 are Medium. |
 | **[03] Source selection** | TBD (blocked) | Estimate after the TV-vs-Switch spike resolves the architecture | Re-estimate once unblocked. |
 | **[04] PWA — Phase 1–3** | TBD (blocked) | New `web/` workspace + embedded `src/server/`; estimate after spike A | Each phase is its own session at minimum. |
@@ -102,6 +97,8 @@ When a unit ships, record actual-vs-estimate here so future estimates sharpen.
 | Date | Plan | Estimate | Actual | Variance / note |
 | ---- | ---- | -------- | ------ | --------------- |
 | 2026-06-20 | [05] Integration test harness | Medium | Medium–Heavy | HTTP fake server was trivial as predicted, but two unforeseen drivers pushed it up: the manual homebridge mock provides no Service/Characteristic (HAP stub written from scratch), and polling is hardcoded on (neutralised with fake timers). Lesson: when a test exercises framework wiring, budget for stubbing the framework surface, not just the protocol. |
+| 2026-06-20 | [01] Accessory type | Heavy | Heavy | Full session as estimated. Config threading + orphan pruning touched many files; pruning logic needed extra iteration. |
+| 2026-06-20 | [02] Volume — Lightbulb path | Small–Medium | Small–Medium | Landed as estimated. Race fix was the main loop as predicted; the `On`/`Brightness` ordering required a follow-up fix PR (#91). |
 
 ## Spikes (blockers)
 
@@ -177,9 +174,7 @@ notifications"):
   their real shapes, and the connection lifecycle rules — enough to finalise the
   reconnect strategy and the polling-fallback interval.
 
-**Status (2026-06-20):** docs/spike defined; **no probe or harness built yet**
-(user directive: research/docs only this session). Part 1 can proceed any time;
-Part 2 is parked until a real device is available.
+**Status (2026-06-20):** Part 1 complete — gabbo harness shipped in #66 (beta v0.3.0-beta.1). Part 2 unblocked — real device available; run `node scripts/gabbo-probe.mjs <ip>` against the device to capture frames and answer the connection lifecycle questions above.
 
 ## Key coupling notes
 

--- a/.claude/skills/technical-lead/SKILL.md
+++ b/.claude/skills/technical-lead/SKILL.md
@@ -51,7 +51,7 @@ Read these files before saying anything:
 1. `.claude/skills/technical-lead/ROADMAP.md` — delivery order, dependency
    graph, spike blockers. This is the authoritative sequencing document.
 2. All files in `.claude/skills/architect/plans/` — check `status:` frontmatter
-   and open checklist items to see what's planned, in-progress, or done.
+   and open checklist items to see what's planned, in-progress, in beta, or done.
 
 ### 2. Assess readiness
 
@@ -61,6 +61,7 @@ For each plan in roadmap order, determine:
   no unresolved spike or open decision blocking it.
 - **Blocked:** depends on a spike, a prerequisite plan, or an open decision.
 - **In-progress:** `status: in-progress` — check if it's stalled or moving.
+- **Beta:** `status: beta` — merged to dev and released to the beta channel; awaiting promotion to `latest`. The status comment includes the version (e.g. `# v0.3.0-beta.1`). Skip for planning purposes — work is done; only promotion remains.
 - **Done / cancelled:** skip.
 
 The ROADMAP table captures anticipated order, but re-check: if a dependency has
@@ -218,9 +219,10 @@ opened. If the plan lists additional manual verification steps, list them.
 ### 7. Update plan status and roadmap
 
 When handing off to the engineer, set `status: in-progress` in the plan file
-frontmatter. When all checklist items are done and the PR is merged, set
-`status: done`. If the work is cancelled or found impossible, set
-`status: cancelled` and fill in the plan's "If cancelled" section.
+frontmatter. When the PR is merged to dev and a beta release is cut, set
+`status: beta` with the version in a comment (e.g. `# v0.3.0-beta.1`). When
+promoted to `latest`, set `status: done`. If the work is cancelled or found
+impossible, set `status: cancelled` and fill in the plan's "If cancelled" section.
 
 When delivery order changes, update `ROADMAP.md`. The roadmap is your
 document — keep it current.


### PR DESCRIPTION
## What & why

Syncs plan files and the roadmap with what actually shipped in v0.3.0-beta.1. Introduces `status: beta` as a new lifecycle state (between `in-progress` and `done`) so plans reflect which channel they're on.

**Plan files updated to `status: beta # v0.3.0-beta.1`:** integration test harness, polling lifecycle, FirmwareRevision characteristic, accessory type, volume control (Lightbulb path).

**ROADMAP.md:** current state refreshed, delivery table updated with beta version references, calibration rows added for plans 01 and 02, Spike C Part 2 noted as unblocked (device available).

**SKILL.md (technical-lead):** `beta` added to the readiness states in step 2 and to the status-update guidance in step 7.

**plan-template.md:** `beta` added to the status comment.

## Verification

Docs-only change — no code or tests.