### PR TITLE
fix(deps): pin undici >=6.27.0 (Dependabot alerts #62, #64, #65)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,13 +75,15 @@
     "babel-plugin-istanbul": "^8.0.2",
     "glob": "^13.0.6",
     "js-yaml": "^4.2.0",
-    "q": "^1.5.1"
+    "q": "^1.5.1",
+    "undici": ">=6.27.0"
   },
   "resolutions": {
     "babel-plugin-istanbul": "^8.0.2",
     "glob": "^13.0.6",
     "js-yaml": "^4.2.0",
-    "q": "^1.5.1"
+    "q": "^1.5.1",
+    "undici": ">=6.27.0"
   },
   "dependencies": {
     "axios": "^1.17.0",


### PR DESCRIPTION
## Summary

- Adds `undici: >=6.27.0` to both `overrides` and `resolutions` in `package.json`
- Resolves three open Dependabot security alerts affecting `undici < 6.27.0`:
  - #62 — HTTP response queue poisoning via keep-alive socket reuse (low)
  - #64 — HTTP header injection via Set-Cookie percent-decoding (medium)
  - #65 — Set-Cookie SameSite attribute downgrade via substring matching (low)

## Notes

`undici` is a transitive dependency (not direct). The override pins the version used by `@actions/http-client` (via `@semantic-release/npm → @actions/core`) to 6.27.0. A separate bundled copy inside `npm@11.17.0 → node-gyp` cannot be reached by overrides — this is a known npm limitation and unrelated to the plugin's runtime.

## Test plan

- [x] `npm ls undici` confirms `@actions/http-client`'s undici resolves to 6.27.0
- [x] All 236 tests pass (`npm test`)