### PR TITLE
docs: add CLAUDE.md noting dev as the base branch for all work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,17 @@
 plugin that controls Bose SoundTouch speakers over their local HTTP/XML +
 WebSocket API.
 
+## Branching
+
+All work branches from `dev`. Cut a new branch from the latest `dev` before starting any task:
+
+```sh
+git fetch origin dev
+git checkout -b <type>/<slug> origin/dev
+```
+
+`main` is release-only and is never worked on directly.
+
 ## Use the skills
 
 This repo's working knowledge lives in `.claude/skills/`. Consult the relevant

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "homebridge-soundtouchspeaker",
   "displayName": "SoundTouch Speaker",
   "type": "module",
-  "version": "0.0.0-development",
+  "version": "0.2.4-beta.2",
   "description": "Updates homebridge-soundtouch-platform to work on latest homebridge.",
   "author": "Andrew Trainor",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "homebridge-soundtouchspeaker",
   "displayName": "SoundTouch Speaker",
   "type": "module",
-  "version": "0.2.4-beta.2",
+  "version": "0.0.0-development",
   "description": "Updates homebridge-soundtouch-platform to work on latest homebridge.",
   "author": "Andrew Trainor",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What & why

Adds a `CLAUDE.md` so Claude Code sessions know to branch from `dev` rather than `main`. Includes the standard branch-cutting command as a quick reference.

## Verification

Docs-only change — no code or tests.