### PR TITLE
test: prefer it() over test() across all remaining test suites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,6 @@ dist
 
 /test/hbConfig
 test/hbConfig/config.office.json
+
+# Claude Code agent worktrees
+.claude/worktrees/

--- a/src/devices/SoundTouch/api/__tests__/api.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/api.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { API } from '../api.js';
@@ -23,13 +23,13 @@ describe('API', () => {
   });
 
   describe('request plumbing', () => {
-    test('GET targets the host, default port and endpoint', async () => {
+    it('GET targets the host, default port and endpoint', async () => {
       mock.onGet(`${BASE}/info`).reply(200, '<info deviceID="D"></info>');
       await api.getInfo();
       expect(mock.history.get[0].url).toBe(`${BASE}/info`);
     });
 
-    test('honours a custom port', async () => {
+    it('honours a custom port', async () => {
       const instance = axios.create();
       const customMock = new MockAdapter(instance);
       const customApi = new API('10.0.0.9', 9999, instance);
@@ -41,12 +41,12 @@ describe('API', () => {
       customMock.restore();
     });
 
-    test('re-throws network errors that carry no response', async () => {
+    it('re-throws network errors that carry no response', async () => {
       mock.onGet(`${BASE}/info`).networkError();
       await expect(api.getInfo()).rejects.toThrow();
     });
 
-    test('parses the body of an error (non-2xx) response instead of throwing it', async () => {
+    it('parses the body of an error (non-2xx) response instead of throwing it', async () => {
       // A 4xx with a parseable (but non-error) body should resolve, not reject.
       mock
         .onGet(`${BASE}/info`)
@@ -56,7 +56,7 @@ describe('API', () => {
   });
 
   describe('error handling', () => {
-    test('throws APIErrors when the response contains an <errors> block', async () => {
+    it('throws APIErrors when the response contains an <errors> block', async () => {
       mock
         .onGet(`${BASE}/info`)
         .reply(
@@ -66,14 +66,14 @@ describe('API', () => {
       await expect(api.getInfo()).rejects.toBeInstanceOf(APIErrors);
     });
 
-    test('throws APIErrors when the response contains a single <error>', async () => {
+    it('throws APIErrors when the response contains a single <error>', async () => {
       mock
         .onGet(`${BASE}/info`)
         .reply(200, '<error value="1" name="X" severity="Low">bad</error>');
       await expect(api.getInfo()).rejects.toBeInstanceOf(APIErrors);
     });
 
-    test('surfaces APIErrors carried in a 4xx error response body', async () => {
+    it('surfaces APIErrors carried in a 4xx error response body', async () => {
       mock
         .onGet(`${BASE}/info`)
         .reply(
@@ -85,7 +85,7 @@ describe('API', () => {
   });
 
   describe('getInfo', () => {
-    test('parses an info document', async () => {
+    it('parses an info document', async () => {
       mock
         .onGet(`${BASE}/info`)
         .reply(
@@ -103,14 +103,14 @@ describe('API', () => {
       });
     });
 
-    test('returns undefined when there is no info element', async () => {
+    it('returns undefined when there is no info element', async () => {
       mock.onGet(`${BASE}/info`).reply(200, '<nothing/>');
       await expect(api.getInfo()).resolves.toBeUndefined();
     });
   });
 
   describe('getVolume / setVolume', () => {
-    test('parses a volume document', async () => {
+    it('parses a volume document', async () => {
       mock
         .onGet(`${BASE}/volume`)
         .reply(
@@ -126,13 +126,13 @@ describe('API', () => {
       });
     });
 
-    test('setVolume posts the value and reports success on a status reply', async () => {
+    it('setVolume posts the value and reports success on a status reply', async () => {
       mock.onPost(`${BASE}/volume`).reply(200, '<status>/volume</status>');
       await expect(api.setVolume(30)).resolves.toBe(true);
       expect(mock.history.post[0].data).toContain('<volume>30</volume>');
     });
 
-    test('setVolume reports failure when there is no status reply', async () => {
+    it('setVolume reports failure when there is no status reply', async () => {
       mock.onPost(`${BASE}/volume`).reply(200, '<nope/>');
       await expect(api.setVolume(30)).resolves.toBe(false);
     });
@@ -145,7 +145,7 @@ describe('API', () => {
       '<track>T</track><art artImageStatus="IMAGE_PRESENT">http://art</art>' +
       '<time total="200">5</time></nowPlaying>';
 
-    test('getNowPlaying parses a playing document', async () => {
+    it('getNowPlaying parses a playing document', async () => {
       mock.onGet(`${BASE}/nowPlaying`).reply(200, nowPlayingXml);
       const np = await api.getNowPlaying();
       expect(np).toMatchObject({
@@ -155,7 +155,7 @@ describe('API', () => {
       });
     });
 
-    test('getSource returns the source attribute', async () => {
+    it('getSource returns the source attribute', async () => {
       mock
         .onGet(`${BASE}/nowPlaying`)
         .reply(
@@ -165,7 +165,7 @@ describe('API', () => {
       await expect(api.getSource()).resolves.toBe('STANDBY');
     });
 
-    test('getNowPlaying parses a STANDBY response with no art or time', async () => {
+    it('getNowPlaying parses a STANDBY response with no art or time', async () => {
       mock
         .onGet(`${BASE}/nowPlaying`)
         .reply(
@@ -181,7 +181,7 @@ describe('API', () => {
   });
 
   describe('sources / select', () => {
-    test('getSources parses the source list', async () => {
+    it('getSources parses the source list', async () => {
       mock
         .onGet(`${BASE}/sources`)
         .reply(
@@ -196,7 +196,7 @@ describe('API', () => {
       });
     });
 
-    test('selectSource posts a ContentItem and reports success', async () => {
+    it('selectSource posts a ContentItem and reports success', async () => {
       mock.onPost(`${BASE}/select`).reply(200, '<status>/select</status>');
       await expect(
         api.selectSource({ source: 'AUX', sourceAccount: '' })
@@ -206,7 +206,7 @@ describe('API', () => {
   });
 
   describe('zones', () => {
-    test('getZone parses master and members', async () => {
+    it('getZone parses master and members', async () => {
       mock
         .onGet(`${BASE}/getZone`)
         .reply(
@@ -219,7 +219,7 @@ describe('API', () => {
       });
     });
 
-    test('setZone posts the serialized zone', async () => {
+    it('setZone posts the serialized zone', async () => {
       mock.onPost(`${BASE}/setZone`).reply(200, '<status>/setZone</status>');
       const zone = {
         master: 'M1',
@@ -229,7 +229,7 @@ describe('API', () => {
       expect(mock.history.post[0].data).toContain('master="M1"');
     });
 
-    test('setZone includes senderIPAddress when provided', async () => {
+    it('setZone includes senderIPAddress when provided', async () => {
       mock.onPost(`${BASE}/setZone`).reply(200, '<status>/setZone</status>');
       const zone = {
         master: 'M1',
@@ -242,7 +242,7 @@ describe('API', () => {
   });
 
   describe('bass', () => {
-    test('getBassCapabilities parses the capabilities', async () => {
+    it('getBassCapabilities parses the capabilities', async () => {
       mock
         .onGet(`${BASE}/bassCapabilities`)
         .reply(
@@ -259,7 +259,7 @@ describe('API', () => {
       });
     });
 
-    test('getBass parses the current bass', async () => {
+    it('getBass parses the current bass', async () => {
       mock
         .onGet(`${BASE}/bass`)
         .reply(
@@ -273,7 +273,7 @@ describe('API', () => {
       });
     });
 
-    test('setBass posts the value', async () => {
+    it('setBass posts the value', async () => {
       mock.onPost(`${BASE}/bass`).reply(200, '<status>/bass</status>');
       await expect(api.setBass(-3)).resolves.toBe(true);
       expect(mock.history.post[0].data).toContain('<bass>-3</bass>');
@@ -281,7 +281,7 @@ describe('API', () => {
   });
 
   describe('presets', () => {
-    test('parses presets when present', async () => {
+    it('parses presets when present', async () => {
       mock
         .onGet(`${BASE}/presets`)
         .reply(
@@ -294,14 +294,14 @@ describe('API', () => {
       expect(presets?.[0]).toMatchObject({ id: 1 });
     });
 
-    test('returns undefined when there are no presets', async () => {
+    it('returns undefined when there are no presets', async () => {
       mock.onGet(`${BASE}/presets`).reply(200, '<presets></presets>');
       await expect(api.getPresets()).resolves.toBeUndefined();
     });
   });
 
   describe('group', () => {
-    test('parses the active group', async () => {
+    it('parses the active group', async () => {
       mock
         .onGet(`${BASE}/getGroup`)
         .reply(
@@ -321,7 +321,7 @@ describe('API', () => {
   });
 
   describe('keys', () => {
-    test('pressKey sends a press then a release', async () => {
+    it('pressKey sends a press then a release', async () => {
       mock.onPost(`${BASE}/key`).reply(200, '<status>/key</status>');
       await expect(api.pressKey(KeyValue.play)).resolves.toBe(true);
       expect(mock.history.post).toHaveLength(2);
@@ -330,7 +330,7 @@ describe('API', () => {
       expect(mock.history.post[0].data).toContain('PLAY');
     });
 
-    test('pressKey aborts before the release when the press fails', async () => {
+    it('pressKey aborts before the release when the press fails', async () => {
       mock.onPost(`${BASE}/key`).reply(200, '<nope/>');
       await expect(api.pressKey(KeyValue.play)).resolves.toBe(false);
       expect(mock.history.post).toHaveLength(1);
@@ -338,7 +338,7 @@ describe('API', () => {
   });
 
   describe('setName', () => {
-    test('posts the new name and returns the updated info', async () => {
+    it('posts the new name and returns the updated info', async () => {
       mock
         .onPost(`${BASE}/name`)
         .reply(

--- a/src/devices/SoundTouch/api/__tests__/art.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/art.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { artFromElement } from '../art.js';
 import { ArtStatus } from '../special-types.js';
 import { XMLElement } from '../utils/xml-element.js';
 
 describe('artFromElement', () => {
-  test('parses art url and status', () => {
+  it('parses art url and status', () => {
     const el = new XMLElement({
       $: { artImageStatus: 'IMAGE_PRESENT' },
       _: 'http://example.com/art.jpg',
@@ -15,12 +15,12 @@ describe('artFromElement', () => {
     });
   });
 
-  test('returns undefined when the status attribute is missing', () => {
+  it('returns undefined when the status attribute is missing', () => {
     const el = new XMLElement({ _: 'http://example.com/art.jpg' });
     expect(artFromElement(el)).toBeUndefined();
   });
 
-  test('returns undefined when there is no url text', () => {
+  it('returns undefined when there is no url text', () => {
     const el = new XMLElement({ $: { artImageStatus: 'IMAGE_PRESENT' } });
     expect(artFromElement(el)).toBeUndefined();
   });

--- a/src/devices/SoundTouch/api/__tests__/bass-capabilities.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/bass-capabilities.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { bassCapabilitiesFromElement } from '../bass-capabilities.js';
 import { XMLElement } from '../utils/xml-element.js';
 
 describe('bassCapabilitiesFromElement', () => {
-  test('parses availability and bass range', () => {
+  it('parses availability and bass range', () => {
     const el = new XMLElement({
       $: { deviceID: 'DEV1' },
       bassAvailable: ['true'],
@@ -20,7 +20,7 @@ describe('bassCapabilitiesFromElement', () => {
     });
   });
 
-  test('marks unavailable and leaves range undefined when absent', () => {
+  it('marks unavailable and leaves range undefined when absent', () => {
     const el = new XMLElement({
       $: { deviceID: 'DEV1' },
       bassAvailable: ['false'],
@@ -34,7 +34,7 @@ describe('bassCapabilitiesFromElement', () => {
     });
   });
 
-  test('returns undefined when the deviceID attribute is missing', () => {
+  it('returns undefined when the deviceID attribute is missing', () => {
     const el = new XMLElement({ bassAvailable: ['true'] });
     expect(bassCapabilitiesFromElement(el)).toBeUndefined();
   });

--- a/src/devices/SoundTouch/api/__tests__/bass.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/bass.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { bassFromElement } from '../bass.js';
 import { XMLElement } from '../utils/xml-element.js';
 
 describe('bassFromElement', () => {
-  test('parses target and actual bass', () => {
+  it('parses target and actual bass', () => {
     const el = new XMLElement({
       $: { deviceID: 'DEV1' },
       targetbass: ['-3'],
@@ -16,7 +16,7 @@ describe('bassFromElement', () => {
     });
   });
 
-  test('defaults target and actual to 0 when absent', () => {
+  it('defaults target and actual to 0 when absent', () => {
     const el = new XMLElement({ $: { deviceID: 'DEV1' } });
     expect(bassFromElement(el)).toEqual({
       deviceId: 'DEV1',
@@ -25,7 +25,7 @@ describe('bassFromElement', () => {
     });
   });
 
-  test('returns undefined when the deviceID attribute is missing', () => {
+  it('returns undefined when the deviceID attribute is missing', () => {
     const el = new XMLElement({ targetbass: ['0'], actualbass: ['0'] });
     expect(bassFromElement(el)).toBeUndefined();
   });

--- a/src/devices/SoundTouch/api/__tests__/component.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/component.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { componentFromElement } from '../component.js';
 import { XMLElement } from '../utils/xml-element.js';
 
 describe('componentFromElement', () => {
-  test('parses a component with software version and serial number', () => {
+  it('parses a component with software version and serial number', () => {
     const el = new XMLElement({
       softwareVersion: ['1.2.3'],
       serialNumber: ['SN-001'],
@@ -15,7 +15,7 @@ describe('componentFromElement', () => {
     });
   });
 
-  test('parses componentCategory when present', () => {
+  it('parses componentCategory when present', () => {
     const el = new XMLElement({
       componentCategory: ['DEVICE'],
       softwareVersion: ['1.2.3'],
@@ -28,12 +28,12 @@ describe('componentFromElement', () => {
     });
   });
 
-  test('returns undefined when children are missing', () => {
+  it('returns undefined when children are missing', () => {
     const el = new XMLElement({ softwareVersion: ['1.2.3'] });
     expect(componentFromElement(el)).toBeUndefined();
   });
 
-  test('returns undefined when a child is empty', () => {
+  it('returns undefined when a child is empty', () => {
     const el = new XMLElement({ softwareVersion: [], serialNumber: [] });
     expect(componentFromElement(el)).toBeUndefined();
   });

--- a/src/devices/SoundTouch/api/__tests__/connection-status-info.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/connection-status-info.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { connectionStatusInfoFromElement } from '../connection-status-info.js';
 import { XMLElement } from '../utils/xml-element.js';
 
 describe('connectionStatusInfoFromElement', () => {
-  test('parses status and device name attributes', () => {
+  it('parses status and device name attributes', () => {
     const el = new XMLElement({
       $: { status: 'CONNECTED', deviceName: 'Phone' },
     });
@@ -13,7 +13,7 @@ describe('connectionStatusInfoFromElement', () => {
     });
   });
 
-  test('returns undefined fields when attributes are absent', () => {
+  it('returns undefined fields when attributes are absent', () => {
     const el = new XMLElement({});
     expect(connectionStatusInfoFromElement(el)).toEqual({
       status: undefined,

--- a/src/devices/SoundTouch/api/__tests__/content-item.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/content-item.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import {
   contentItemFromElement,
   contentItemToElement,
@@ -6,7 +6,7 @@ import {
 import { XMLElement } from '../utils/xml-element.js';
 
 describe('contentItemFromElement', () => {
-  test('parses a full content item', () => {
+  it('parses a full content item', () => {
     const el = new XMLElement({
       $: {
         source: 'SPOTIFY',
@@ -27,7 +27,7 @@ describe('contentItemFromElement', () => {
     });
   });
 
-  test('defaults sourceAccount and isPresetable when absent', () => {
+  it('defaults sourceAccount and isPresetable when absent', () => {
     const el = new XMLElement({ $: { source: 'AUX' } });
     expect(contentItemFromElement(el)).toEqual({
       source: 'AUX',
@@ -39,20 +39,20 @@ describe('contentItemFromElement', () => {
     });
   });
 
-  test('returns undefined when the source attribute is missing', () => {
+  it('returns undefined when the source attribute is missing', () => {
     const el = new XMLElement({ $: { sourceAccount: 'x' } });
     expect(contentItemFromElement(el)).toBeUndefined();
   });
 });
 
 describe('contentItemToElement', () => {
-  test('serializes required attributes', () => {
+  it('serializes required attributes', () => {
     const el = contentItemToElement({ source: 'AUX', sourceAccount: '' });
     // toElement wraps the data in a <ContentItem> node.
     expect(el.data.ContentItem.$).toEqual({ source: 'AUX', sourceAccount: '' });
   });
 
-  test('serializes optional attributes and item name when present', () => {
+  it('serializes optional attributes and item name when present', () => {
     const el = contentItemToElement({
       source: 'SPOTIFY',
       sourceAccount: 'user',
@@ -71,7 +71,7 @@ describe('contentItemToElement', () => {
     expect(el.data.ContentItem.itemName).toBe('Name');
   });
 
-  test('round-trips through fromElement', () => {
+  it('round-trips through fromElement', () => {
     const el = contentItemToElement({
       source: 'SPOTIFY',
       sourceAccount: 'user',

--- a/src/devices/SoundTouch/api/__tests__/error.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/error.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { APIErrors, errorFromElement } from '../error.js';
 import { XMLElement } from '../utils/xml-element.js';
 
 describe('errorFromElement', () => {
-  test('parses value, name, severity and message', () => {
+  it('parses value, name, severity and message', () => {
     const el = new XMLElement({
       $: { value: '401', name: 'HTTP_ERROR', severity: 'High' },
       _: 'Unauthorized',
@@ -16,21 +16,21 @@ describe('errorFromElement', () => {
     });
   });
 
-  test('falls back to value 0 when the value is not numeric', () => {
+  it('falls back to value 0 when the value is not numeric', () => {
     const el = new XMLElement({
       $: { value: 'NaN', name: 'X', severity: 'Low' },
     });
     expect(errorFromElement(el)?.value).toBe(0);
   });
 
-  test('returns undefined when required attributes are missing', () => {
+  it('returns undefined when required attributes are missing', () => {
     const el = new XMLElement({ $: { value: '1', name: 'X' } });
     expect(errorFromElement(el)).toBeUndefined();
   });
 });
 
 describe('APIErrors', () => {
-  test('fromElement collects all errors and the device id', () => {
+  it('fromElement collects all errors and the device id', () => {
     const el = new XMLElement({
       $: { deviceID: 'DEV1' },
       error: [
@@ -43,7 +43,7 @@ describe('APIErrors', () => {
     expect(errors?.errors).toHaveLength(2);
   });
 
-  test('fromElement skips malformed error entries', () => {
+  it('fromElement skips malformed error entries', () => {
     const el = new XMLElement({
       $: { deviceID: 'DEV1' },
       error: [
@@ -54,7 +54,7 @@ describe('APIErrors', () => {
     expect(APIErrors.fromElement(el)?.errors).toHaveLength(1);
   });
 
-  test('is an Error carrying device id and a descriptive message', () => {
+  it('is an Error carrying device id and a descriptive message', () => {
     const errors = new APIErrors(
       [{ value: 1, name: 'A', severity: 'High' }],
       'DEV1'

--- a/src/devices/SoundTouch/api/__tests__/group.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/group.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { groupFromElement, roleFromElement } from '../group.js';
 import { GroupLocation } from '../special-types.js';
 import { XMLElement } from '../utils/xml-element.js';
 
 describe('roleFromElement', () => {
-  test('parses a role into device id, location and ip address', () => {
+  it('parses a role into device id, location and ip address', () => {
     const el = new XMLElement({
       deviceId: ['DEV-1'],
       role: ['LEFT'],
@@ -17,7 +17,7 @@ describe('roleFromElement', () => {
     });
   });
 
-  test('returns undefined when children are missing', () => {
+  it('returns undefined when children are missing', () => {
     const el = new XMLElement({ deviceId: ['DEV-1'] });
     expect(roleFromElement(el)).toBeUndefined();
   });
@@ -41,7 +41,7 @@ describe('groupFromElement', () => {
     };
   }
 
-  test('parses a full group with its roles', () => {
+  it('parses a full group with its roles', () => {
     const result = groupFromElement(new XMLElement(makeGroupData()));
     expect(result).toEqual({
       id: 'GROUP-1',
@@ -63,19 +63,19 @@ describe('groupFromElement', () => {
     });
   });
 
-  test('skips malformed roles', () => {
+  it('skips malformed roles', () => {
     const data = makeGroupData();
     data.roles[0].groupRole.push({ deviceId: ['DEV-3'] } as never);
     expect(groupFromElement(new XMLElement(data))?.roles).toHaveLength(2);
   });
 
-  test('returns undefined when the id attribute is missing', () => {
+  it('returns undefined when the id attribute is missing', () => {
     const data = makeGroupData();
     data.$ = {} as never;
     expect(groupFromElement(new XMLElement(data))).toBeUndefined();
   });
 
-  test('returns undefined when required children are missing', () => {
+  it('returns undefined when required children are missing', () => {
     const el = new XMLElement({ $: { id: 'GROUP-1' } });
     expect(groupFromElement(el)).toBeUndefined();
   });

--- a/src/devices/SoundTouch/api/__tests__/info.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/info.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { infoFromElement } from '../info.js';
 import { XMLElement } from '../utils/xml-element.js';
 
@@ -23,7 +23,7 @@ function makeInfoData() {
 }
 
 describe('infoFromElement', () => {
-  test('parses a full info element', () => {
+  it('parses a full info element', () => {
     const result = infoFromElement(new XMLElement(makeInfoData()));
     expect(result).toEqual({
       deviceId: 'DEV123',
@@ -40,7 +40,7 @@ describe('infoFromElement', () => {
     });
   });
 
-  test('skips malformed components and network info entries', () => {
+  it('skips malformed components and network info entries', () => {
     const data = makeInfoData();
     data.components[0].component.push({
       softwareVersion: ['3.0.0'],
@@ -51,13 +51,13 @@ describe('infoFromElement', () => {
     expect(result?.networkInfo).toHaveLength(2);
   });
 
-  test('returns undefined when the deviceID attribute is missing', () => {
+  it('returns undefined when the deviceID attribute is missing', () => {
     const data = makeInfoData();
     data.$ = {} as never;
     expect(infoFromElement(new XMLElement(data))).toBeUndefined();
   });
 
-  test('returns undefined when required children are missing', () => {
+  it('returns undefined when required children are missing', () => {
     const el = new XMLElement({ $: { deviceID: 'DEV123' } });
     expect(infoFromElement(el)).toBeUndefined();
   });

--- a/src/devices/SoundTouch/api/__tests__/member.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/member.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { memberFromElement } from '../member.js';
 import { XMLElement } from '../utils/xml-element.js';
 
 describe('memberFromElement', () => {
-  test('parses device id from text and ip from attribute', () => {
+  it('parses device id from text and ip from attribute', () => {
     const el = new XMLElement({ $: { ipaddress: '10.0.0.5' }, _: 'DEV-A' });
     expect(memberFromElement(el)).toEqual({
       deviceId: 'DEV-A',
@@ -11,12 +11,12 @@ describe('memberFromElement', () => {
     });
   });
 
-  test('returns undefined when the ipaddress attribute is missing', () => {
+  it('returns undefined when the ipaddress attribute is missing', () => {
     const el = new XMLElement({ _: 'DEV-A' });
     expect(memberFromElement(el)).toBeUndefined();
   });
 
-  test('returns undefined when the device id text is missing', () => {
+  it('returns undefined when the device id text is missing', () => {
     const el = new XMLElement({ $: { ipaddress: '10.0.0.5' } });
     expect(memberFromElement(el)).toBeUndefined();
   });

--- a/src/devices/SoundTouch/api/__tests__/network-info.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/network-info.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { networkInfoFromElement } from '../network-info.js';
 import { XMLElement } from '../utils/xml-element.js';
 
 describe('networkInfoFromElement', () => {
-  test('parses mac and ip addresses', () => {
+  it('parses mac and ip addresses', () => {
     const el = new XMLElement({
       macAddress: ['AA:BB:CC:DD:EE:FF'],
       ipAddress: ['192.168.1.50'],
@@ -14,12 +14,12 @@ describe('networkInfoFromElement', () => {
     });
   });
 
-  test('returns undefined when children are missing', () => {
+  it('returns undefined when children are missing', () => {
     const el = new XMLElement({ macAddress: ['AA:BB:CC:DD:EE:FF'] });
     expect(networkInfoFromElement(el)).toBeUndefined();
   });
 
-  test('returns undefined when a child is empty', () => {
+  it('returns undefined when a child is empty', () => {
     const el = new XMLElement({ macAddress: [], ipAddress: [] });
     expect(networkInfoFromElement(el)).toBeUndefined();
   });

--- a/src/devices/SoundTouch/api/__tests__/now-playing.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/now-playing.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { nowPlayingFromElement } from '../now-playing.js';
 import {
   PlayStatus,
@@ -38,7 +38,7 @@ function makeFullData() {
 }
 
 describe('nowPlayingFromElement', () => {
-  test('parses a fully populated now playing element', () => {
+  it('parses a fully populated now playing element', () => {
     const result = nowPlayingFromElement(new XMLElement(makeFullData()));
     expect(result).toMatchObject({
       deviceId: 'DEV1',
@@ -70,7 +70,7 @@ describe('nowPlayingFromElement', () => {
     });
   });
 
-  test('applies defaults for absent optional fields', () => {
+  it('applies defaults for absent optional fields', () => {
     const data = {
       $: { deviceID: 'DEV1', source: 'SPOTIFY' },
       ContentItem: [{ $: { source: 'SPOTIFY' } }],
@@ -94,18 +94,18 @@ describe('nowPlayingFromElement', () => {
     expect(result?.connectionStatusInfo).toBeUndefined();
   });
 
-  test('returns undefined when required attributes are missing', () => {
+  it('returns undefined when required attributes are missing', () => {
     const el = new XMLElement({ $: { deviceID: 'DEV1' } });
     expect(nowPlayingFromElement(el)).toBeUndefined();
   });
 
-  test('returns undefined when the ContentItem child is missing', () => {
+  it('returns undefined when the ContentItem child is missing', () => {
     const data = makeFullData();
     delete (data as Record<string, unknown>).ContentItem;
     expect(nowPlayingFromElement(new XMLElement(data))).toBeUndefined();
   });
 
-  test('parses successfully when art or time children are absent', () => {
+  it('parses successfully when art or time children are absent', () => {
     const data = makeFullData();
     delete (data as Record<string, unknown>).art;
     delete (data as Record<string, unknown>).time;
@@ -116,7 +116,7 @@ describe('nowPlayingFromElement', () => {
     expect(result?.source).toBe('SPOTIFY');
   });
 
-  test('returns undefined when the content item is malformed', () => {
+  it('returns undefined when the content item is malformed', () => {
     const data = makeFullData();
     data.ContentItem = [{ $: {} } as never];
     expect(nowPlayingFromElement(new XMLElement(data))).toBeUndefined();

--- a/src/devices/SoundTouch/api/__tests__/preset.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/preset.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { presetFromElement } from '../preset.js';
 import { XMLElement } from '../utils/xml-element.js';
 
 describe('presetFromElement', () => {
-  test('parses id, dates and content item', () => {
+  it('parses id, dates and content item', () => {
     const el = new XMLElement({
       $: { id: '3', createdOn: '1600000000', updateOn: '1600000500' },
       ContentItem: [
@@ -18,7 +18,7 @@ describe('presetFromElement', () => {
     expect(result?.contentItem.itemName).toBe('Mix');
   });
 
-  test('returns undefined when attributes are missing', () => {
+  it('returns undefined when attributes are missing', () => {
     const el = new XMLElement({
       $: { id: '3' },
       ContentItem: [{ $: { source: 'SPOTIFY' } }],
@@ -26,14 +26,14 @@ describe('presetFromElement', () => {
     expect(presetFromElement(el)).toBeUndefined();
   });
 
-  test('returns undefined when the ContentItem child is missing', () => {
+  it('returns undefined when the ContentItem child is missing', () => {
     const el = new XMLElement({
       $: { id: '3', createdOn: '1', updatedOn: '2' },
     });
     expect(presetFromElement(el)).toBeUndefined();
   });
 
-  test('returns undefined when the content item is malformed', () => {
+  it('returns undefined when the content item is malformed', () => {
     const el = new XMLElement({
       $: { id: '3', createdOn: '1', updatedOn: '2' },
       ContentItem: [{ $: {} }],

--- a/src/devices/SoundTouch/api/__tests__/source.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/source.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { sourceFromElement, sourcesFromElement } from '../source.js';
 import { SourceStatus } from '../special-types.js';
 import { XMLElement } from '../utils/xml-element.js';
 
 describe('sourceFromElement', () => {
-  test('parses a source item with all flags', () => {
+  it('parses a source item with all flags', () => {
     const el = new XMLElement({
       $: {
         source: 'AUX',
@@ -25,7 +25,7 @@ describe('sourceFromElement', () => {
     });
   });
 
-  test('defaults flags and account when absent', () => {
+  it('defaults flags and account when absent', () => {
     const el = new XMLElement({
       $: { source: 'BLUETOOTH', status: 'UNAVAILABLE' },
       _: 'Bluetooth',
@@ -40,19 +40,19 @@ describe('sourceFromElement', () => {
     });
   });
 
-  test('returns undefined when required attributes are missing', () => {
+  it('returns undefined when required attributes are missing', () => {
     const el = new XMLElement({ $: { source: 'AUX' }, _: 'AUX' });
     expect(sourceFromElement(el)).toBeUndefined();
   });
 
-  test('returns undefined when the name text is missing', () => {
+  it('returns undefined when the name text is missing', () => {
     const el = new XMLElement({ $: { source: 'AUX', status: 'READY' } });
     expect(sourceFromElement(el)).toBeUndefined();
   });
 });
 
 describe('sourcesFromElement', () => {
-  test('parses the device id and its source items', () => {
+  it('parses the device id and its source items', () => {
     const el = new XMLElement({
       $: { deviceID: 'DEV1' },
       sourceItem: [
@@ -66,7 +66,7 @@ describe('sourcesFromElement', () => {
     expect(result?.items[0].source).toBe('AUX');
   });
 
-  test('skips malformed source items', () => {
+  it('skips malformed source items', () => {
     const el = new XMLElement({
       $: { deviceID: 'DEV1' },
       sourceItem: [
@@ -77,7 +77,7 @@ describe('sourcesFromElement', () => {
     expect(sourcesFromElement(el)?.items).toHaveLength(1);
   });
 
-  test('returns undefined when the deviceID attribute is missing', () => {
+  it('returns undefined when the deviceID attribute is missing', () => {
     const el = new XMLElement({ sourceItem: [] });
     expect(sourcesFromElement(el)).toBeUndefined();
   });

--- a/src/devices/SoundTouch/api/__tests__/time.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/time.test.ts
@@ -1,14 +1,14 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { timeFromElement } from '../time.js';
 import { XMLElement } from '../utils/xml-element.js';
 
 describe('timeFromElement', () => {
-  test('parses current text and total attribute', () => {
+  it('parses current text and total attribute', () => {
     const el = new XMLElement({ $: { total: '240' }, _: '57' });
     expect(timeFromElement(el)).toEqual({ current: 57, total: 240 });
   });
 
-  test('defaults to zero when values are absent', () => {
+  it('defaults to zero when values are absent', () => {
     const el = new XMLElement({});
     expect(timeFromElement(el)).toEqual({ current: 0, total: 0 });
   });

--- a/src/devices/SoundTouch/api/__tests__/volume.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/volume.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { volumeFromElement } from '../volume.js';
 import { XMLElement } from '../utils/xml-element.js';
 
 describe('volumeFromElement', () => {
-  test('parses target, actual and mute state', () => {
+  it('parses target, actual and mute state', () => {
     const el = new XMLElement({
       $: { deviceID: 'DEV1' },
       targetvolume: ['40'],
@@ -18,7 +18,7 @@ describe('volumeFromElement', () => {
     });
   });
 
-  test('treats missing mute flag as not muted', () => {
+  it('treats missing mute flag as not muted', () => {
     const el = new XMLElement({
       $: { deviceID: 'DEV1' },
       targetvolume: ['40'],
@@ -27,12 +27,12 @@ describe('volumeFromElement', () => {
     expect(volumeFromElement(el)?.isMuted).toBe(false);
   });
 
-  test('returns undefined when volume values are missing', () => {
+  it('returns undefined when volume values are missing', () => {
     const el = new XMLElement({ $: { deviceID: 'DEV1' } });
     expect(volumeFromElement(el)).toBeUndefined();
   });
 
-  test('returns undefined when the deviceID attribute is missing', () => {
+  it('returns undefined when the deviceID attribute is missing', () => {
     const el = new XMLElement({ targetvolume: ['40'], actualvolume: ['38'] });
     expect(volumeFromElement(el)).toBeUndefined();
   });

--- a/src/devices/SoundTouch/api/__tests__/zone.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/zone.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { zoneFromElement, zoneToElement } from '../zone.js';
 import { XMLElement } from '../utils/xml-element.js';
 
 describe('zoneFromElement', () => {
-  test('parses master and members', () => {
+  it('parses master and members', () => {
     const el = new XMLElement({
       $: { master: 'MASTER-1' },
       member: [
@@ -20,7 +20,7 @@ describe('zoneFromElement', () => {
     });
   });
 
-  test('skips malformed members', () => {
+  it('skips malformed members', () => {
     const el = new XMLElement({
       $: { master: 'MASTER-1' },
       member: [{ $: { ipaddress: '10.0.0.1' }, _: 'DEV-1' }, { _: 'DEV-2' }],
@@ -30,19 +30,19 @@ describe('zoneFromElement', () => {
     ]);
   });
 
-  test('returns an empty member list when there are none', () => {
+  it('returns an empty member list when there are none', () => {
     const el = new XMLElement({ $: { master: 'MASTER-1' } });
     expect(zoneFromElement(el)).toEqual({ master: 'MASTER-1', members: [] });
   });
 
-  test('returns undefined when the master attribute is missing', () => {
+  it('returns undefined when the master attribute is missing', () => {
     const el = new XMLElement({ member: [] });
     expect(zoneFromElement(el)).toBeUndefined();
   });
 });
 
 describe('zoneToElement', () => {
-  test('serializes master and members and round-trips', () => {
+  it('serializes master and members and round-trips', () => {
     const zone = {
       master: 'MASTER-1',
       members: [

--- a/src/devices/SoundTouch/api/utils/__tests__/array-compact-map.test.ts
+++ b/src/devices/SoundTouch/api/utils/__tests__/array-compact-map.test.ts
@@ -1,30 +1,30 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { compactMap } from '../array-compact-map.js';
 
 describe('compactMap', () => {
-  test('maps values like Array.map when transform never returns undefined', () => {
+  it('maps values like Array.map when transform never returns undefined', () => {
     const result = compactMap([1, 2, 3], (n) => n * 2);
     expect(result).toEqual([2, 4, 6]);
   });
 
-  test('drops entries for which transform returns undefined', () => {
+  it('drops entries for which transform returns undefined', () => {
     const result = compactMap([1, 2, 3, 4], (n) =>
       n % 2 === 0 ? n : undefined
     );
     expect(result).toEqual([2, 4]);
   });
 
-  test('returns an empty array for an empty input', () => {
+  it('returns an empty array for an empty input', () => {
     const result = compactMap<number, number>([], (n) => n);
     expect(result).toEqual([]);
   });
 
-  test('returns an empty array when every entry maps to undefined', () => {
+  it('returns an empty array when every entry maps to undefined', () => {
     const result = compactMap([1, 2, 3], () => undefined);
     expect(result).toEqual([]);
   });
 
-  test('passes index and source array to the transform', () => {
+  it('passes index and source array to the transform', () => {
     const indexes: number[] = [];
     const arrays: number[][] = [];
     const source = [10, 20];
@@ -37,7 +37,7 @@ describe('compactMap', () => {
     expect(arrays).toEqual([source, source]);
   });
 
-  test('keeps falsy values other than undefined', () => {
+  it('keeps falsy values other than undefined', () => {
     const result = compactMap([0, null, '', false, undefined], (e) => e);
     expect(result).toEqual([0, null, '', false]);
   });

--- a/src/devices/SoundTouch/api/utils/__tests__/xml-element.test.ts
+++ b/src/devices/SoundTouch/api/utils/__tests__/xml-element.test.ts
@@ -1,143 +1,143 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { XMLElement } from '../xml-element.js';
 
 describe('XMLElement', () => {
   describe('getAttribute', () => {
-    test('returns the attribute value when present', () => {
+    it('returns the attribute value when present', () => {
       const el = new XMLElement({ $: { deviceID: 'abc' } });
       expect(el.getAttribute('deviceID')).toBe('abc');
     });
 
-    test('returns undefined when the attribute is missing', () => {
+    it('returns undefined when the attribute is missing', () => {
       const el = new XMLElement({ $: { deviceID: 'abc' } });
       expect(el.getAttribute('other')).toBeUndefined();
     });
 
-    test('returns undefined when there are no attributes', () => {
+    it('returns undefined when there are no attributes', () => {
       const el = new XMLElement({});
       expect(el.getAttribute('deviceID')).toBeUndefined();
     });
   });
 
   describe('getText', () => {
-    test('reads text from a child field stored as an array', () => {
+    it('reads text from a child field stored as an array', () => {
       const el = new XMLElement({ name: ['Kitchen'] });
       expect(el.getText('name')).toBe('Kitchen');
     });
 
-    test('reads text of the element itself when no field is given', () => {
+    it('reads text of the element itself when no field is given', () => {
       const el = new XMLElement({ $: { total: '5' }, _: 'hello' });
       expect(el.getText()).toBe('hello');
     });
 
-    test('reads text from a plain string field', () => {
+    it('reads text from a plain string field', () => {
       const el = new XMLElement({ name: 'Kitchen' });
       expect(el.getText('name')).toBe('Kitchen');
     });
 
-    test('reads text from an object field with a _ property', () => {
+    it('reads text from an object field with a _ property', () => {
       const el = new XMLElement({ name: [{ _: 'Kitchen', $: { a: '1' } }] });
       expect(el.getText('name')).toBe('Kitchen');
     });
 
-    test('returns undefined for an empty array field', () => {
+    it('returns undefined for an empty array field', () => {
       const el = new XMLElement({ name: [] });
       expect(el.getText('name')).toBeUndefined();
     });
 
-    test('returns undefined for a missing field', () => {
+    it('returns undefined for a missing field', () => {
       const el = new XMLElement({});
       expect(el.getText('name')).toBeUndefined();
     });
 
-    test('returns undefined when the element itself has no text', () => {
+    it('returns undefined when the element itself has no text', () => {
       const el = new XMLElement(42);
       expect(el.getText()).toBeUndefined();
     });
   });
 
   describe('hasAttribute', () => {
-    test('returns true when the attribute exists', () => {
+    it('returns true when the attribute exists', () => {
       const el = new XMLElement({ $: { source: 'AUX' } });
       expect(el.hasAttribute('source')).toBe(true);
     });
 
-    test('returns false when the attribute is missing', () => {
+    it('returns false when the attribute is missing', () => {
       const el = new XMLElement({ $: { source: 'AUX' } });
       expect(el.hasAttribute('status')).toBe(false);
     });
 
-    test('returns false when there are no attributes', () => {
+    it('returns false when there are no attributes', () => {
       const el = new XMLElement({});
       expect(el.hasAttribute('source')).toBe(false);
     });
   });
 
   describe('hasAttributes', () => {
-    test('returns true when all attributes exist', () => {
+    it('returns true when all attributes exist', () => {
       const el = new XMLElement({ $: { source: 'AUX', status: 'READY' } });
       expect(el.hasAttributes(['source', 'status'])).toBe(true);
     });
 
-    test('returns false when any attribute is missing', () => {
+    it('returns false when any attribute is missing', () => {
       const el = new XMLElement({ $: { source: 'AUX' } });
       expect(el.hasAttributes(['source', 'status'])).toBe(false);
     });
 
-    test('returns false when there are no attributes', () => {
+    it('returns false when there are no attributes', () => {
       const el = new XMLElement({});
       expect(el.hasAttributes(['source'])).toBe(false);
     });
   });
 
   describe('hasChild / hasChildren', () => {
-    test('hasChild returns true for an object/array child', () => {
+    it('hasChild returns true for an object/array child', () => {
       const el = new XMLElement({ ContentItem: [{ $: {} }] });
       expect(el.hasChild('ContentItem')).toBe(true);
     });
 
-    test('hasChild returns false for a missing child', () => {
+    it('hasChild returns false for a missing child', () => {
       const el = new XMLElement({});
       expect(el.hasChild('ContentItem')).toBe(false);
     });
 
-    test('hasChildren returns true when all children are present', () => {
+    it('hasChildren returns true when all children are present', () => {
       const el = new XMLElement({ name: ['x'], type: ['y'] });
       expect(el.hasChildren(['name', 'type'])).toBe(true);
     });
 
-    test('hasChildren returns false when any child is missing', () => {
+    it('hasChildren returns false when any child is missing', () => {
       const el = new XMLElement({ name: ['x'] });
       expect(el.hasChildren(['name', 'type'])).toBe(false);
     });
   });
 
   describe('getChild', () => {
-    test('returns a wrapped element for an array child', () => {
+    it('returns a wrapped element for an array child', () => {
       const el = new XMLElement({ ContentItem: [{ $: { source: 'AUX' } }] });
       const child = el.getChild('ContentItem');
       expect(child).toBeInstanceOf(XMLElement);
       expect(child?.getAttribute('source')).toBe('AUX');
     });
 
-    test('returns a wrapped element for a non-array child', () => {
+    it('returns a wrapped element for a non-array child', () => {
       const el = new XMLElement({ ContentItem: { $: { source: 'AUX' } } });
       expect(el.getChild('ContentItem')?.getAttribute('source')).toBe('AUX');
     });
 
-    test('returns undefined for a missing child', () => {
+    it('returns undefined for a missing child', () => {
       const el = new XMLElement({});
       expect(el.getChild('ContentItem')).toBeUndefined();
     });
 
-    test('returns undefined for an empty array child', () => {
+    it('returns undefined for an empty array child', () => {
       const el = new XMLElement({ ContentItem: [] });
       expect(el.getChild('ContentItem')).toBeUndefined();
     });
   });
 
   describe('getList', () => {
-    test('returns a wrapped element per array entry', () => {
+    it('returns a wrapped element per array entry', () => {
       const el = new XMLElement({
         member: [{ $: { ipaddress: '1' } }, { $: { ipaddress: '2' } }],
       });
@@ -147,12 +147,12 @@ describe('XMLElement', () => {
       expect(list[1].getAttribute('ipaddress')).toBe('2');
     });
 
-    test('returns an empty array when the field is not an array', () => {
+    it('returns an empty array when the field is not an array', () => {
       const el = new XMLElement({ member: { $: {} } });
       expect(el.getList('member')).toEqual([]);
     });
 
-    test('returns an empty array when the field is missing', () => {
+    it('returns an empty array when the field is missing', () => {
       const el = new XMLElement({});
       expect(el.getList('member')).toEqual([]);
     });

--- a/src/utils/__tests__/FormattedLogger.test.ts
+++ b/src/utils/__tests__/FormattedLogger.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, jest, test } from '@jest/globals';
+import { describe, expect, jest, it } from '@jest/globals';
 import { DeviceLogger, Logger } from '../FormattedLogger.js';
 import { LogLevel, type Logging } from 'homebridge';
 import { DeviceConfiguration } from '../../devices/SoundTouch/SoundTouchDeviceConfiguration.js';
@@ -55,7 +55,7 @@ describe('FormattedLogger', () => {
     ];
 
     testLevels.forEach((c) => {
-      test(`returns ${c.outcome} when log level is '${c.level}' and required level is '${c.requiredLevel}'`, () => {
+      it(`returns ${c.outcome} when log level is '${c.level}' and required level is '${c.requiredLevel}'`, () => {
         const result = Logger.excludeLog(c.level, c.requiredLevel);
         expect(result).toBe(c.outcome);
       });
@@ -63,7 +63,7 @@ describe('FormattedLogger', () => {
   });
 
   describe('Logger.log', () => {
-    test('passes message to homebridge logger when level meets threshold', () => {
+    it('passes message to homebridge logger when level meets threshold', () => {
       const homebridgeLogger = makeMockLogger();
       const logger = Logger.forHomebridgeLogger({
         logger: homebridgeLogger,
@@ -75,7 +75,7 @@ describe('FormattedLogger', () => {
       expect(homebridgeLogger.log).toHaveBeenCalledWith(LogLevel.INFO, 'hello');
     });
 
-    test('suppresses message when level is below threshold', () => {
+    it('suppresses message when level is below threshold', () => {
       const homebridgeLogger = makeMockLogger();
       const logger = Logger.forHomebridgeLogger({
         logger: homebridgeLogger,
@@ -87,7 +87,7 @@ describe('FormattedLogger', () => {
       expect(homebridgeLogger.log).not.toHaveBeenCalled();
     });
 
-    test('convenience methods delegate to log with correct level', () => {
+    it('convenience methods delegate to log with correct level', () => {
       const homebridgeLogger = makeMockLogger();
       const logger = Logger.forHomebridgeLogger({
         logger: homebridgeLogger,
@@ -124,7 +124,7 @@ describe('FormattedLogger', () => {
   });
 
   describe('DeviceLogger', () => {
-    test('prefixes messages with device name', () => {
+    it('prefixes messages with device name', () => {
       const homebridgeLogger = makeMockLogger();
       const logger = Logger.forHomebridgeLogger({
         logger: homebridgeLogger,
@@ -141,7 +141,7 @@ describe('FormattedLogger', () => {
       );
     });
 
-    test('inherits log level filtering from parent logger', () => {
+    it('inherits log level filtering from parent logger', () => {
       const homebridgeLogger = makeMockLogger();
       const logger = Logger.forHomebridgeLogger({
         logger: homebridgeLogger,


### PR DESCRIPTION
## What & why

Mechanical rename of `test()` → `it()` across the 21 test files that had not yet been converted. The three files already using `it()` were left untouched. Each file's `@jest/globals` import was updated in the same pass (`test` → `it`).

This aligns the whole suite with the project convention (coding-conventions skill: "prefer `it()` so descriptions complete the sentence 'it should …' naturally").

## Verification

```
npm run typecheck && npm run lint && npm test
```

All passed: 29 suites, 236 tests.