### PR TITLE
test: spike gabbo WebSocket volume tickle → Brightness characteristic

### DIFF
--- a/.claude/skills/architect/plans/2026-06-21-changelog.md
+++ b/.claude/skills/architect/plans/2026-06-21-changelog.md
@@ -1,0 +1,84 @@
+---
+feature: Introduce and backfill CHANGELOG.md
+status: in-progress
+date: 2026-06-21
+branch: docs/changelog
+commit-type: docs
+---
+
+# Introduce and backfill CHANGELOG.md
+
+## Context
+
+The repo has no `CHANGELOG.md`. Consumers who want to understand what changed
+between versions have to read GitHub Releases or raw git log. A hand-maintained
+(but automation-friendly) `CHANGELOG.md` checked in at the repo root gives a
+durable, offline-readable history and is the conventional expectation for an npm
+package.
+
+Going forward, `semantic-release` does **not** currently write a changelog file
+— the `.releaserc.json` uses only the `commit-analyzer`, `release-notes-generator`,
+`npm`, and `github` plugins. The generator plugin writes notes to GitHub Releases
+but never touches the filesystem. We need to decide whether to:
+
+1. **Keep the status quo** (GitHub Releases = source of truth) and add a
+   static, hand-curated backfill that is updated manually on each release, or
+2. **Add `@semantic-release/changelog`** to `.releaserc.json` so that
+   `semantic-release` auto-writes and commits `CHANGELOG.md` on every future
+   release.
+
+Option 2 is the right call: it keeps the file accurate without manual discipline.
+
+## Decisions & findings
+
+| Date | Decision / finding | Rationale / evidence | Alternatives rejected |
+| --- | --- | --- | --- |
+| 2026-06-21 | Use `@semantic-release/changelog` + `@semantic-release/git` to auto-write CHANGELOG.md on release | Eliminates manual discipline; consistent with semantic-release's own docs | Hand-curating after every release — too easy to forget |
+| 2026-06-21 | Plugin order: changelog → npm → git → github | `@semantic-release/git` must come after `npm` so the version bump is already in `package.json` before the commit; `changelog` must come before `git` so the file exists to commit | Other orderings leave files untracked or the commit malformed |
+| 2026-06-21 | Backfill covers all tagged releases: v0.2.3, v0.2.4, v0.3.0-beta.1, v0.3.0-beta.2, and the unreleased `dev` changes | Tags are `v0.2.3` (2025-04-27), `v0.2.4` (after #45), `v0.2.4-beta.*` (ci experiments), `v0.3.0-beta.1`, `v0.3.0-beta.2` | Skipping pre-releases would lose meaningful feat/fix context |
+| 2026-06-21 | Backfill is written by hand (not generated) | Only user-facing feat/fix/perf entries belong; no chore/docs/ci noise; generated output would need the same pruning anyway | `conventional-changelog` CLI — still requires post-editing |
+| 2026-06-21 | `commit-type: docs` → no release triggered | This is purely an infra/docs change; no version bump warranted | `chore:` — equivalent, but docs is more accurate |
+| 2026-06-21 | `@semantic-release/git` assets: `["CHANGELOG.md", "package.json"]` | Commits both the updated changelog and the version bump together; matches semantic-release convention | Committing only CHANGELOG.md — leaves package.json bump out of the commit |
+| 2026-06-21 | Branch type: planning branch (`docs/changelog`) | No production code changes; CHANGELOG.md and .releaserc.json are both documentation/tooling | Implementation branch — wrong because there is no feature code to deliver |
+
+## If cancelled
+
+> Only fill this in when `status: cancelled`. Leave empty otherwise.
+
+## Affected areas
+
+- `CHANGELOG.md` — new file at repo root (backfilled, then auto-maintained)
+- `.releaserc.json` — add `@semantic-release/changelog` and `@semantic-release/git` plugins
+- `package.json` — add `@semantic-release/changelog` and `@semantic-release/git` as devDependencies
+
+## Conventions for this change
+
+- **Commit type:** `docs:` → no release
+- **Config schema touched:** no
+- **Tests to add/update:** none (tooling-only change)
+- **Target branch:** `dev` (squash-merged; PR title is the released commit message)
+
+## Implementation checklist
+
+- [x] Install `@semantic-release/changelog` and `@semantic-release/git` as devDependencies
+- [x] Update `.releaserc.json`: add plugins in order — `changelog`, then `git` (after `npm`)
+- [x] Write backfilled `CHANGELOG.md` covering all tagged releases (user-facing entries only)
+  - [x] `## [Unreleased]` — dev commits since v0.3.0-beta.2 (feat/fix only)
+  - [x] `## [0.3.0-beta.2]`
+  - [x] `## [0.3.0-beta.1]`
+  - [x] `## [0.2.4]`
+  - [x] `## [0.2.3]` — initial stable release (no prior public changelog)
+- [ ] Verify `.releaserc.json` is valid JSON and semantic-release dry-run passes locally (or trust CI)
+
+## Verification
+
+- [x] `npm run lint`
+- [x] `npm run build`
+- [x] `npm test`
+- [ ] Confirm `npx semantic-release --dry-run` does not error on the new plugin config (requires `GITHUB_TOKEN` + `NPM_TOKEN` in env, so CI verification is acceptable)
+
+## PR / release notes
+
+- **PR title (Conventional Commit, becomes the released commit message):**
+  `docs: introduce CHANGELOG.md and wire semantic-release to maintain it`
+- **Targets:** `dev`

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -23,7 +23,15 @@
         }
       }
     ],
+    "@semantic-release/changelog",
     "@semantic-release/npm",
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md", "package.json"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
     [
       "@semantic-release/github",
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+Going forward this file is maintained automatically by
+[`@semantic-release/changelog`](https://github.com/semantic-release/changelog).
+Entries below were backfilled by hand from the git history.
+
+---
+
+## [Unreleased]
+
+### Fixes
+
+- Escape XML special characters in fake SoundTouch server error responses (#110)
+
+---
+
+## [0.3.0-beta.2] — 2026-06-20
+
+### Fixes
+
+- Pin `undici` >=6.27.0 to address security advisories (Dependabot #62, #64, #65) (#95)
+
+---
+
+## [0.3.0-beta.1] — 2026-06-20
+
+### New Features
+
+- Add volume control via Lightbulb brightness (Lightbulb accessory type) (#86)
+- Let each speaker be configured as a Switch or a Lightbulb accessory (`accessoryType`) (#72)
+- Add volume control via Speaker service on the Switch accessory (#62)
+
+### Fixes
+
+- Prevent brightness-zero/setOn race that bounced volume back to its previous level (#91)
+- Use `softwareVersion` from SCM component for the FirmwareRevision characteristic (#85)
+- Stop device polling on accessory removal/shutdown; honour `pollingInterval` config (#65)
+- Correct SoundTouch API spec mismatches (response shapes, field names) (#52)
+
+---
+
+## [0.2.4] — 2026-06-19
+
+### Fixes
+
+- Correct config schema: `name` is optional, `port` is configurable (#43)
+- Resolve npm deprecation warnings and address security vulnerabilities (#35)
+- Fix critical bugs in polling loop, logger, and power control (#21)
+- Fix error handling resilience and ESM import consistency (#22)
+
+---
+
+## [0.2.3] — 2025-04-27
+
+Initial public release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,7 @@ Entries below were backfilled by hand from the git history.
 
 ---
 
-## [Unreleased]
-
-### Fixes
-
-- Escape XML special characters in fake SoundTouch server error responses (#110)
-
----
-
-## [0.3.0-beta.2] — 2026-06-20
-
-### Fixes
-
-- Pin `undici` >=6.27.0 to address security advisories (Dependabot #62, #64, #65) (#95)
-
----
-
-## [0.3.0-beta.1] — 2026-06-20
+## [0.3.0] — 2026-06-21
 
 ### New Features
 
@@ -34,6 +18,8 @@ Entries below were backfilled by hand from the git history.
 
 ### Fixes
 
+- Escape XML special characters in fake SoundTouch server error responses (#110)
+- Pin `undici` >=6.27.0 to address security advisories (Dependabot #62, #64, #65) (#95)
 - Prevent brightness-zero/setOn race that bounced volume back to its previous level (#91)
 - Use `softwareVersion` from SCM component for the FirmwareRevision characteristic (#85)
 - Stop device polling on accessory removal/shutdown; honour `pollingInterval` config (#65)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,43 +1,35 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-
-Going forward this file is maintained automatically by
-[`@semantic-release/changelog`](https://github.com/semantic-release/changelog).
-Entries below were backfilled by hand from the git history.
-
----
-
-## [0.3.0] — 2026-06-21
+## [0.3.0](https://github.com/forktrucka/homebridge-soundtouch-speaker/compare/v0.2.4...v0.3.0) (2026-06-21)
 
 ### New Features
 
-- Add volume control via Lightbulb brightness (Lightbulb accessory type) (#86)
-- Let each speaker be configured as a Switch or a Lightbulb accessory (`accessoryType`) (#72)
-- Add volume control via Speaker service on the Switch accessory (#62)
+* let each speaker be configured as a Switch or a Lightbulb accessory (`accessoryType`) ([#72](https://github.com/forktrucka/homebridge-soundtouch-speaker/issues/72))
+* add volume control via Speaker service on the Switch accessory ([#62](https://github.com/forktrucka/homebridge-soundtouch-speaker/issues/62))
+* add volume control via Lightbulb brightness ([#86](https://github.com/forktrucka/homebridge-soundtouch-speaker/issues/86))
 
 ### Fixes
 
-- Escape XML special characters in fake SoundTouch server error responses (#110)
-- Pin `undici` >=6.27.0 to address security advisories (Dependabot #62, #64, #65) (#95)
-- Prevent brightness-zero/setOn race that bounced volume back to its previous level (#91)
-- Use `softwareVersion` from SCM component for the FirmwareRevision characteristic (#85)
-- Stop device polling on accessory removal/shutdown; honour `pollingInterval` config (#65)
-- Correct SoundTouch API spec mismatches (response shapes, field names) (#52)
+* correct SoundTouch API spec mismatches (response shapes, field names) ([#52](https://github.com/forktrucka/homebridge-soundtouch-speaker/issues/52))
+* stop device polling on accessory removal/shutdown; honour `pollingInterval` config ([#65](https://github.com/forktrucka/homebridge-soundtouch-speaker/issues/65))
+* use `softwareVersion` from SCM component for the FirmwareRevision characteristic ([#85](https://github.com/forktrucka/homebridge-soundtouch-speaker/issues/85))
+* prevent brightness-zero/setOn race that bounced volume back to its previous level ([#91](https://github.com/forktrucka/homebridge-soundtouch-speaker/issues/91))
+* pin `undici` >=6.27.0 to address security advisories ([#95](https://github.com/forktrucka/homebridge-soundtouch-speaker/issues/95))
+* escape XML special characters in fake SoundTouch server error responses ([#110](https://github.com/forktrucka/homebridge-soundtouch-speaker/issues/110))
 
 ---
 
-## [0.2.4] — 2026-06-19
+## [0.2.4](https://github.com/forktrucka/homebridge-soundtouch-speaker/compare/v0.2.3...v0.2.4) (2026-06-19)
 
 ### Fixes
 
-- Correct config schema: `name` is optional, `port` is configurable (#43)
-- Resolve npm deprecation warnings and address security vulnerabilities (#35)
-- Fix critical bugs in polling loop, logger, and power control (#21)
-- Fix error handling resilience and ESM import consistency (#22)
+* correct config schema: `name` is optional, `port` is configurable ([#43](https://github.com/forktrucka/homebridge-soundtouch-speaker/issues/43))
+* fix critical bugs in polling loop, logger, and power control ([#21](https://github.com/forktrucka/homebridge-soundtouch-speaker/issues/21))
+* fix error handling resilience and ESM import consistency ([#22](https://github.com/forktrucka/homebridge-soundtouch-speaker/issues/22))
+* resolve npm deprecation warnings and address security vulnerabilities ([#35](https://github.com/forktrucka/homebridge-soundtouch-speaker/issues/35))
 
 ---
 
-## [0.2.3] — 2025-04-27
+## 0.2.3 (2025-04-27)
 
 Initial public release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ git fetch origin dev
 git checkout -b <type>/<slug> origin/dev
 ```
 
-`main` is release-only and is never worked on directly.
+The release branches (`latest` and `beta`) are managed by semantic-release and are never worked on directly.
 
 ## Use the skills
 
@@ -29,7 +29,7 @@ skill **before** acting — don't rely on memory for these:
   and how it maps to `src/devices/SoundTouch/api/`.
 - **architect** (`/architect`) — plan and track a new feature; owns the
   branching/release flow (conventional commits, semantic-release
-  `latest`→`dev`→`beta`). See also `CONTRIBUTING.md`.
+  `dev`→`beta` and `dev`→`latest`). See also `CONTRIBUTING.md`.
 - **technical-lead** — surveys the roadmap and plans, identifies the next
   unblocked item, resolves/surfaces blockers, and produces engineering briefs.
   Can brief multiple engineers in parallel when work is independent.

--- a/README.md
+++ b/README.md
@@ -27,55 +27,66 @@ hb-service add homebridge-soundtouchspeaker
 hb-service add homebridge-soundtouchspeaker@beta
 ```
 ## Configuration
-Example `config.json` to discover all SoundTouch accessories
+
+Discover all SoundTouch speakers on the network automatically:
 
 ```json
 {
     "platform": "SoundTouchHomebridgePlugin",
-    "discoverAllAccessories": true
+    "discoverAllAccessories": true,
+    "global": {
+        "accessoryType": "lightbulb"
+    }
 }
 ```
 
-Example `config.json` to register a SoundTouch accessory using the speaker name from the Bose Soundtouch app:
+Register specific speakers by room name (as set in the Bose app):
 
 ```json
 {
     "platform": "SoundTouchHomebridgePlugin",
-    "discoverAllAccessories": false,
     "accessories": [
         {
             "name": "Kitchen Speaker",
-            "room": "Kitchen"
+            "room": "Kitchen",
+            "accessoryType": "lightbulb"
         }
     ]
 }
 ```
 
-Example `config.json` to register a SoundTouch accessory using the ip address of the speaker:
+Register speakers by IP address:
 
 ```json
 {
     "platform": "SoundTouchHomebridgePlugin",
-    "discoverAllAccessories": false,
     "accessories": [
         {
             "name": "Kitchen Speaker",
-            "ip": "<ip>"
+            "ip": "192.168.1.100",
+            "accessoryType": "lightbulb"
+        },
+        {
+            "name": "Living Room Speaker",
+            "ip": "192.168.1.101"
         }
     ]
 }
 ```
 
-Example `config.json` for multiple speakers:
+Mix of IP and room, with global defaults:
 
 ```json
 {
     "platform": "SoundTouchHomebridgePlugin",
-    "discoverAllAccessories": false,
+    "global": {
+        "accessoryType": "lightbulb",
+        "pollingInterval": 5000
+    },
     "accessories": [
         {
             "name": "Kitchen Speaker",
-            "ip": "<ip>"
+            "ip": "192.168.1.100"
         },
         {
             "name": "Living Room Speaker",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-soundtouchspeaker",
-  "version": "0.0.0-development",
+  "version": "0.2.4-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-soundtouchspeaker",
-      "version": "0.0.0-development",
+      "version": "0.2.4-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.17.0",
@@ -21,6 +21,8 @@
         "@commitlint/config-conventional": "21.0.2",
         "@eslint/js": "^10.0.1",
         "@jest/globals": "^30.4.1",
+        "@semantic-release/changelog": "^6.0.3",
+        "@semantic-release/git": "^10.0.1",
         "@swc/core": "^1.15.41",
         "@swc/jest": "^0.2.39",
         "@types/bonjour": "^3.5.10",
@@ -2729,6 +2731,69 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@semantic-release/changelog": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
+      "integrity": "sha512-dZuR5qByyfe3Y03TpmCvAxCyTnp7r5XwtHRf/8vD9EAn4ZWbavUX8adMtXYzE86EVh0gyLA7lm5yW4IV30XUag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "fs-extra": "^11.0.0",
+        "lodash": "^4.17.4"
+      },
+      "engines": {
+        "node": ">=14.17"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=18.0.0"
+      }
+    },
+    "node_modules/@semantic-release/changelog/node_modules/@semantic-release/error": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@semantic-release/changelog/node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@semantic-release/changelog/node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@semantic-release/changelog/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@semantic-release/commit-analyzer": {
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-13.0.1.tgz",
@@ -2760,6 +2825,83 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/git": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-10.0.1.tgz",
+      "integrity": "sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "dir-glob": "^3.0.0",
+        "execa": "^5.0.0",
+        "lodash": "^4.17.4",
+        "micromatch": "^4.0.0",
+        "p-reduce": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.17"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=18.0.0"
+      }
+    },
+    "node_modules/@semantic-release/git/node_modules/@semantic-release/error": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@semantic-release/git/node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@semantic-release/git/node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@semantic-release/git/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@semantic-release/git/node_modules/p-reduce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@semantic-release/github": {
@@ -8765,6 +8907,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash-es": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
@@ -9568,8 +9717,6 @@
     },
     "node_modules/npm/node_modules/@gar/promise-retry": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
-      "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9579,8 +9726,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9593,16 +9738,12 @@
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
-      "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.2.tgz",
-      "integrity": "sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9619,8 +9760,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
       "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-9.8.0.tgz",
-      "integrity": "sha512-bqjei/1+uait6wA30G7IElMs5VCyGpuVPFQYsvzqhTEEAVmDMsHBCFstcT2lLfeQDvi8MeUQHStfHSArvdTQuw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9669,8 +9808,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/config": {
       "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/config/-/config-10.11.0.tgz",
-      "integrity": "sha512-YeRrOREeF9rYlwQfqbjJc8bjplzdzz2dapOVfV3gl3kSMFn0wEI9+QZQADmAvdd+MKTeOr/ISgNmdxJj6layAA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9690,8 +9827,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
-      "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9704,8 +9839,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/git": {
       "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.2.tgz",
-      "integrity": "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9725,8 +9858,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
-      "integrity": "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9743,8 +9874,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-5.0.3.tgz",
-      "integrity": "sha512-o2grssXo1e774E5OtEwwrgoszYRh0lqkJH+Pb9r78UcqdGJRDRfhpM8DvZPjzNLLNYeD/rNbjOKM3Ss5UABROw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9760,8 +9889,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@npmcli/metavuln-calculator/-/metavuln-calculator-9.0.3.tgz",
-      "integrity": "sha512-94GLSYhLXF2t2LAC7pDwLaM4uCARzxShyAQKsirmlNcpidH89VA4/+K1LbJmRMgz5gy65E/QBBWQdUvGLe2Frg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9778,8 +9905,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-4.0.0.tgz",
-      "integrity": "sha512-qfrhVlOSqmKM8i6rkNdZzABj8MKEITGFAY+4teqBziksCQAOLutiAxM1wY2BKEd8KjUSpWmWCYxvXr0y4VTlPg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9789,8 +9914,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-5.0.0.tgz",
-      "integrity": "sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9800,8 +9923,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
       "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.5.tgz",
-      "integrity": "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9820,8 +9941,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
-      "integrity": "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9834,8 +9953,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/query": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/query/-/query-5.0.0.tgz",
-      "integrity": "sha512-8TZWfTQOsODpLqo9SVhVjHovmKXNpevHU0gO9e+y4V4fRIOneiXy0u0sMP9LmS71XivrEWfZWg50ReH4WRT4aQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9848,8 +9965,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/redact": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
-      "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9859,8 +9974,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
       "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-10.0.4.tgz",
-      "integrity": "sha512-mGUWr1uMnf0le2TwfOZY4SFxZGXGfm4Jtay/nwAa2FLNAKXUoUwaGwBMNH36UHPtinWfTSJ3nqFQr0091CxVGg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9877,8 +9990,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/bundle": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
-      "integrity": "sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -9891,8 +10002,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/core": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-3.2.1.tgz",
-      "integrity": "sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -9902,8 +10011,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.5.1.tgz",
-      "integrity": "sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -9913,8 +10020,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.1.1.tgz",
-      "integrity": "sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -9932,8 +10037,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.2.tgz",
-      "integrity": "sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -9947,8 +10050,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-3.1.1.tgz",
-      "integrity": "sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -9963,8 +10064,6 @@
     },
     "node_modules/npm/node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
-      "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9974,8 +10073,6 @@
     },
     "node_modules/npm/node_modules/@tufjs/models": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-4.1.0.tgz",
-      "integrity": "sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9989,8 +10086,6 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
-      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10000,8 +10095,6 @@
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10011,24 +10104,18 @@
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
-      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10038,8 +10125,6 @@
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.2.tgz",
-      "integrity": "sha512-frE1t78WOwJ45PKV2cF2tNPjTcs9L1J9s6VkrV59wanRP4GlaomuxYPVma7BwthMg8WnfSory4w5PTE6FZZ81w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10056,8 +10141,6 @@
     },
     "node_modules/npm/node_modules/binary-extensions": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-3.1.0.tgz",
-      "integrity": "sha512-Jvvd9hy1w+xUad8+ckQsWA/V1AoyubOvqn0aygjMOVM4BfIaRav1NFS3LsTSDaV4n4FtcCtQXvzep1E6MboqwQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10070,8 +10153,6 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10084,8 +10165,6 @@
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "20.0.4",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
-      "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10107,8 +10186,6 @@
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10121,8 +10198,6 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -10132,8 +10207,6 @@
     },
     "node_modules/npm/node_modules/ci-info": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
-      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
       "dev": true,
       "funding": [
         {
@@ -10149,8 +10222,6 @@
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-5.0.5.tgz",
-      "integrity": "sha512-59tdLZcC+BJXa4C5rOmVSuJTy/UneqfJJtCraqwdx5BDHTkGrBtKCUl3u2uiCFvXu+wk0kVuX8axX7yHCZOI9w==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -10160,8 +10231,6 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
-      "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10171,8 +10240,6 @@
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
-      "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -10182,8 +10249,6 @@
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10196,8 +10261,6 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10215,8 +10278,6 @@
     },
     "node_modules/npm/node_modules/diff": {
       "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -10226,8 +10287,6 @@
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10237,16 +10296,12 @@
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
-      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10256,8 +10311,6 @@
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
-      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10270,8 +10323,6 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -10289,16 +10340,12 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
-      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10311,16 +10358,12 @@
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10334,8 +10377,6 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10349,8 +10390,6 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10368,8 +10407,6 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
-      "integrity": "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10382,8 +10419,6 @@
     },
     "node_modules/npm/node_modules/ini": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
-      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10393,8 +10428,6 @@
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-8.2.5.tgz",
-      "integrity": "sha512-IknQ+upLuJU6t3p0uo9wS3GjFD/1GtxIwcIGYOWR8zL2HxQeJwvxYTgZr9brJ8pyZ4kvpkebM8ZKcyqOeLOHSg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10412,8 +10445,6 @@
     },
     "node_modules/npm/node_modules/ip-address": {
       "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10423,8 +10454,6 @@
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-6.0.4.tgz",
-      "integrity": "sha512-tOIBU3QiXy0W4LvHbcKWAWSuQfGwDiEILphFCAZtDqj7C57uv3ClO6K8aNEGV4VTA7bWJlpQ0suKQkUe6Rd6ag==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -10437,8 +10466,6 @@
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
-      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -10448,8 +10475,6 @@
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
-      "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10459,8 +10484,6 @@
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz",
-      "integrity": "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10470,8 +10493,6 @@
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
       "dev": true,
       "engines": [
         "node >= 0.2.0"
@@ -10481,24 +10502,18 @@
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/just-diff/-/just-diff-6.0.2.tgz",
-      "integrity": "sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/just-diff-apply/-/just-diff-apply-5.5.0.tgz",
-      "integrity": "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-10.0.3.tgz",
-      "integrity": "sha512-JPHTfWJxIK+NVPdNMNGnkz4XGX56iijPbe0qFWbdt68HL+kIvSzh+euBL8npLZvl2fpaxo+1eZSdoG15f5YdIQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10512,8 +10527,6 @@
     },
     "node_modules/npm/node_modules/libnpmdiff": {
       "version": "8.1.10",
-      "resolved": "https://registry.npmjs.org/libnpmdiff/-/libnpmdiff-8.1.10.tgz",
-      "integrity": "sha512-UWZPUjkaCuE6+b5kgFrfeIjCR/4IWdU1QRu6jAGgUrk4sKMgnrHKdZ5JzNM4SnPfzLC51+Ts/woEKG7JMEJsPw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10533,8 +10546,6 @@
     },
     "node_modules/npm/node_modules/libnpmexec": {
       "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/libnpmexec/-/libnpmexec-10.3.0.tgz",
-      "integrity": "sha512-JzRj0fVmvBpqrQJ+3Cv0VGPjiDvJbnBu+nbUXKJ/5BUISoSYd0KShyjZsZaIiMZLlDjzFgvDXMZZP2bhVhhVdQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10558,8 +10569,6 @@
     },
     "node_modules/npm/node_modules/libnpmfund": {
       "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/libnpmfund/-/libnpmfund-7.0.24.tgz",
-      "integrity": "sha512-ubiggibzvG9TQr8KO0Jf6hLQbvfJHr+I4Lo740qV+/03e0SLSRjnHArqgffubEFtmtvrHfeNX/YYFfZaeaiE7A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10572,8 +10581,6 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/libnpmorg/-/libnpmorg-8.0.1.tgz",
-      "integrity": "sha512-/QeyXXg4hqMw0ESM7pERjIT2wbR29qtFOWIOug/xO4fRjS3jJJhoAPQNsnHtdwnCqgBdFpGQ45aIdFFZx2YhTA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10587,8 +10594,6 @@
     },
     "node_modules/npm/node_modules/libnpmpack": {
       "version": "9.1.10",
-      "resolved": "https://registry.npmjs.org/libnpmpack/-/libnpmpack-9.1.10.tgz",
-      "integrity": "sha512-J8V8wUBkqRRVtAn43zTMcw3vFyODlOGkS9jq4esolBLCwxuMDjNarWn5Og+DeZLocsHYtlqc963a1hUFOrKIHQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10604,8 +10609,6 @@
     },
     "node_modules/npm/node_modules/libnpmpublish": {
       "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-11.2.0.tgz",
-      "integrity": "sha512-fAEts7UCM2r1xhI82Dv9PK4gFGZoyD7Z5sfIwBQKoO/f67VNVDC0DeH3uH1Yi+T4kwt5iBuCKkZ5XcpxfvsGHQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10625,8 +10628,6 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-9.0.1.tgz",
-      "integrity": "sha512-oKw58X415ERY/BOGV3jQPVMcep8YeMRWMzuuqB0BAIM5VxicOU1tQt19ExCu4SV77SiTOEoziHxGEgJGw3FBYQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10639,8 +10640,6 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/libnpmteam/-/libnpmteam-8.0.2.tgz",
-      "integrity": "sha512-ypLrDUQoi8EhG+gzx5ENMcYq23YjPV17Mfvx4nOnQiHOi8vp47+4GvZBrMsEM4yeHPwxguF/HZoXH4rJfHdH/w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10654,8 +10653,6 @@
     },
     "node_modules/npm/node_modules/libnpmversion": {
       "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/libnpmversion/-/libnpmversion-8.0.4.tgz",
-      "integrity": "sha512-5NiNpLxXkNeLHCYVTLxX/qRgdAoRAjiR0arFdVpQ5kZOJ2b0pHdXS9G3qC7uiqVsLa/gfQQIbQIEPdmSMKXF2A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10672,8 +10669,6 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -10683,8 +10678,6 @@
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "15.0.6",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.6.tgz",
-      "integrity": "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10708,8 +10701,6 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -10725,8 +10716,6 @@
     },
     "node_modules/npm/node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -10736,8 +10725,6 @@
     },
     "node_modules/npm/node_modules/minipass-collect": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
-      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10750,8 +10737,6 @@
     },
     "node_modules/npm/node_modules/minipass-fetch": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
-      "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10781,8 +10766,6 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10795,8 +10778,6 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10809,16 +10790,12 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
-      "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10831,8 +10808,6 @@
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10845,16 +10820,12 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
-      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10864,8 +10835,6 @@
     },
     "node_modules/npm/node_modules/negotiator": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10875,8 +10844,6 @@
     },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
-      "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10901,8 +10868,6 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
-      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10918,8 +10883,6 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-7.0.0.tgz",
-      "integrity": "sha512-bluLL4xwGr/3PERYz50h2Upco0TJMDcLcymuFnfDWeGO99NqH724MNzhWi5sXXuXf2jbytFF0LyR8W+w1jTI6A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10929,8 +10892,6 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-5.0.0.tgz",
-      "integrity": "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10943,8 +10904,6 @@
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-8.0.0.tgz",
-      "integrity": "sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -10957,8 +10916,6 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
-      "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10968,8 +10925,6 @@
     },
     "node_modules/npm/node_modules/npm-package-arg": {
       "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
-      "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10985,8 +10940,6 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.4.tgz",
-      "integrity": "sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11000,8 +10953,6 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
-      "integrity": "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11030,8 +10981,6 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-19.1.1.tgz",
-      "integrity": "sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11051,8 +11000,6 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-4.0.0.tgz",
-      "integrity": "sha512-TP+Ziq/qPi/JRdhaEhnaiMkqfMGjhDLoh/oRfW+t5aCuIfJxIUxvwk6Sg/6ZJ069N/Be6gs00r+aZeJTfS9uHQ==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -11062,8 +11009,6 @@
     },
     "node_modules/npm/node_modules/p-map": {
       "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11076,8 +11021,6 @@
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "21.5.1",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.1.tgz",
-      "integrity": "sha512-KvcJ9iy3crysCsgqc4+PknH/w6jkrp8JN36mpZBPwNaDRwTfMZD37YzRazNstiZUOhuF5pno9f78n9mEJBavwg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11109,8 +11052,6 @@
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/parse-conflict-json/-/parse-conflict-json-5.0.1.tgz",
-      "integrity": "sha512-ZHEmNKMq1wyJXNwLxyHnluPfRAFSIliBvbK/UiOceROt4Xh9Pz0fq49NytIaeaCUf5VR86hwQ/34FCcNU5/LKQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11125,8 +11066,6 @@
     },
     "node_modules/npm/node_modules/path-scurry": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -11143,8 +11082,6 @@
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
       "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11158,8 +11095,6 @@
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11169,8 +11104,6 @@
     },
     "node_modules/npm/node_modules/proggy": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/proggy/-/proggy-4.0.0.tgz",
-      "integrity": "sha512-MbA4R+WQT76ZBm/5JUpV9yqcJt92175+Y0Bodg3HgiXzrmKu7Ggq+bpn6y6wHH+gN9NcyKn3yg1+d47VaKwNAQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11180,8 +11113,6 @@
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
-      "integrity": "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11191,8 +11122,6 @@
     },
     "node_modules/npm/node_modules/promise-call-limit": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/promise-call-limit/-/promise-call-limit-3.0.2.tgz",
-      "integrity": "sha512-mRPQO2T1QQVw11E7+UdCJu7S61eJVWknzml9sC1heAdj1jxl0fWMBypIt9ZOcLFf8FkG995ZD7RnVk7HH72fZw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11202,8 +11131,6 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/promzard/-/promzard-3.0.1.tgz",
-      "integrity": "sha512-M5mHhWh+Adz0BIxgSrqcc6GTCSconR7zWQV9vnOSptNtr6cSFlApLc28GbQhuN6oOWBQeV2C0bNE47JCY/zu3Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11216,8 +11143,6 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
-      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
       "dev": true,
       "inBundle": true,
       "bin": {
@@ -11226,8 +11151,6 @@
     },
     "node_modules/npm/node_modules/read": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/read/-/read-5.0.1.tgz",
-      "integrity": "sha512-+nsqpqYkkpet2UVPG8ZiuE8d113DK4vHYEoEhcrXBAlPiq6di7QRTuNiKQAbaRYegobuX2BpZ6QjanKOXnJdTA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11240,8 +11163,6 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
-      "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11251,8 +11172,6 @@
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11272,8 +11191,6 @@
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11286,8 +11203,6 @@
     },
     "node_modules/npm/node_modules/sigstore": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-4.1.1.tgz",
-      "integrity": "sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -11305,8 +11220,6 @@
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11317,8 +11230,6 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
-      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11333,8 +11244,6 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11349,16 +11258,12 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
-      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
       "dev": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
-      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11369,16 +11274,12 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
-      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
-      "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11391,8 +11292,6 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11405,8 +11304,6 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -11423,24 +11320,18 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-2.0.2.tgz",
-      "integrity": "sha512-rGxAbeL9z3J4pI2GtBEoFaavHdO4RKAU54hEuOef5kfx5aPqiQtbhYktMOTL5OA33db8BjsDcLXuNp+/v19PHw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11457,8 +11348,6 @@
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11476,8 +11365,6 @@
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11490,8 +11377,6 @@
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-3.0.0.tgz",
-      "integrity": "sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11501,8 +11386,6 @@
     },
     "node_modules/npm/node_modules/tuf-js": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-4.1.0.tgz",
-      "integrity": "sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11526,16 +11409,12 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
-      "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11545,8 +11424,6 @@
     },
     "node_modules/npm/node_modules/walk-up-path": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
-      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11556,8 +11433,6 @@
     },
     "node_modules/npm/node_modules/which": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
-      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11573,8 +11448,6 @@
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
-      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11587,8 +11460,6 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "@commitlint/config-conventional": "21.0.2",
     "@eslint/js": "^10.0.1",
     "@jest/globals": "^30.4.1",
+    "@semantic-release/changelog": "^6.0.3",
+    "@semantic-release/git": "^10.0.1",
     "@swc/core": "^1.15.41",
     "@swc/jest": "^0.2.39",
     "@types/bonjour": "^3.5.10",

--- a/src/ExternalPlatformConfig.ts
+++ b/src/ExternalPlatformConfig.ts
@@ -18,6 +18,8 @@ export interface AccessoryConfig extends GlobalConfig {
   readonly room?: string;
   readonly ip?: string;
   readonly port?: number;
+  /** Override the gabbo WebSocket port (default 8080). For tests only. */
+  readonly gabboPort?: number;
 }
 
 export interface ExternalPlatformConfig extends BasePlatformConfig {

--- a/src/__integration__/gabbo-volume-brightness.integration.test.ts
+++ b/src/__integration__/gabbo-volume-brightness.integration.test.ts
@@ -1,0 +1,145 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import type { ExternalPlatformConfig } from '../ExternalPlatformConfig.js';
+import { SoundTouchHomebridgePlatform } from '../platform.js';
+import {
+  FakeSoundTouchServer,
+  infoXml,
+  nowPlayingXml,
+} from './helpers/fake-soundtouch-server.js';
+import { FakeGabboServer } from './helpers/fake-gabbo-server.js';
+import { HomebridgeApiStub } from './helpers/homebridge-stub.js';
+
+const DEVICE_ID = 'DEV-GABBO-1';
+
+function volumeXml(options: {
+  actual: number;
+  target: number;
+  deviceId?: string;
+}): string {
+  const { actual, target, deviceId = DEVICE_ID } = options;
+  return (
+    `<volume deviceID="${deviceId}">` +
+    `<targetvolume>${target}</targetvolume>` +
+    `<actualvolume>${actual}</actualvolume>` +
+    `<muteenabled>false</muteenabled>` +
+    '</volume>'
+  );
+}
+
+/**
+ * Spike: end-to-end volume tickle → Brightness characteristic update.
+ *
+ * Spins up both FakeSoundTouchServer (HTTP) and FakeGabboServer (WebSocket),
+ * configures the platform with a `lightbulb` accessory, then pushes a
+ * `volumeUpdated` tickle and asserts that the Brightness characteristic
+ * reflects the re-fetched volume.
+ */
+describe('gabbo volumeUpdated tickle → Brightness characteristic', () => {
+  let httpServer: FakeSoundTouchServer;
+  let gabboServer: FakeGabboServer;
+  let httpPort: number;
+  let gabboPort: number;
+  let api: HomebridgeApiStub;
+
+  beforeEach(async () => {
+    httpServer = new FakeSoundTouchServer();
+    gabboServer = new FakeGabboServer();
+
+    httpPort = await httpServer.start();
+    gabboPort = await gabboServer.start();
+
+    httpServer.setResponse(
+      '/info',
+      infoXml({ deviceId: DEVICE_ID, name: 'Gabbo Test Speaker' })
+    );
+    httpServer.setResponse('/nowPlaying', nowPlayingXml('SPOTIFY', DEVICE_ID));
+    httpServer.setResponse('/volume', volumeXml({ actual: 20, target: 20 }));
+
+    // Fake timers keep the polling loop parked while real I/O (HTTP + WS) runs.
+    jest.useFakeTimers({
+      doNotFake: ['nextTick', 'setImmediate', 'queueMicrotask'],
+    });
+
+    api = new HomebridgeApiStub();
+  });
+
+  afterEach(async () => {
+    jest.useRealTimers();
+    await httpServer.stop();
+    await gabboServer.stop();
+  });
+
+  function createPlatform(): SoundTouchHomebridgePlatform {
+    const config = {
+      platform: 'SoundTouchSpeaker',
+      global: { accessoryType: 'lightbulb' },
+      accessories: [{ ip: '127.0.0.1', port: httpPort, gabboPort }],
+    } as ExternalPlatformConfig;
+
+    return new SoundTouchHomebridgePlatform(
+      api.logger,
+      config,
+      api.asHomebridgeApi()
+    );
+  }
+
+  /**
+   * Poll `condition` using setImmediate (not faked by jest.useFakeTimers here)
+   * until it's true or `timeoutMs` real-clock milliseconds elapse.
+   */
+  function waitFor(
+    condition: () => boolean,
+    timeoutMs = 3000
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const deadline = Date.now() + timeoutMs;
+
+      const tick = (): void => {
+        if (condition()) {
+          resolve();
+          return;
+        }
+        if (Date.now() >= deadline) {
+          reject(new Error(`waitFor: condition not met within ${timeoutMs}ms`));
+          return;
+        }
+        setImmediate(tick);
+      };
+
+      setImmediate(tick);
+    });
+  }
+
+  it('updates the Brightness characteristic when a volumeUpdated tickle arrives', async () => {
+    createPlatform();
+    await api.emitDidFinishLaunching();
+
+    // Initial Brightness should be the volume from the fake HTTP server (20).
+    expect(api.getCharacteristicValue('Lightbulb', 'Brightness')).toBe(20);
+
+    // Update the HTTP server so the re-fetch returns 55.
+    httpServer.setResponse('/volume', volumeXml({ actual: 55, target: 55 }));
+
+    // Wait for the GabboClient to connect to the fake gabbo server.
+    await waitFor(() => gabboServer.connectionCount > 0);
+
+    // Push the volumeUpdated tickle to all connected clients.
+    gabboServer.push(
+      `<updates deviceID="${DEVICE_ID}"><volumeUpdated/></updates>`
+    );
+
+    // Wait for the Brightness characteristic to reflect the new volume (55).
+    await waitFor(
+      () => api.getCharacteristicValue('Lightbulb', 'Brightness') === 55
+    );
+
+    expect(api.getCharacteristicValue('Lightbulb', 'Brightness')).toBe(55);
+  });
+});

--- a/src/accessories/services/SoundTouchSpeakerBrightnessCharacteristic.ts
+++ b/src/accessories/services/SoundTouchSpeakerBrightnessCharacteristic.ts
@@ -7,10 +7,12 @@ import {
 import { SoundTouchDevice } from '../../devices/SoundTouch/SoundTouchDevice.js';
 import { SoundTouchHomebridgePlatform } from '../../platform.js';
 import { SoundTouchSpeakerCharacteristic } from './SoundTouchSpeakerCharacteristic.js';
+import { GabboClient } from '../../devices/SoundTouch/GabboClient.js';
 
 export class SoundTouchSpeakerBrightnessCharacteristic extends SoundTouchSpeakerCharacteristic {
   private readonly service: Service;
   private characteristic: Characteristic;
+  private readonly gabbo: GabboClient;
 
   constructor({
     service,
@@ -29,11 +31,25 @@ export class SoundTouchSpeakerBrightnessCharacteristic extends SoundTouchSpeaker
     this.characteristic
       .onSet(this.setBrightness.bind(this))
       .onGet(this.getBrightness.bind(this));
+
+    this.gabbo = new GabboClient({
+      host: this.device.api.host,
+      log: this.log,
+      port: this.device.configuration.gabboPort,
+    });
+    this.gabbo.onVolume(() => {
+      this.refresh().catch((err: unknown) => {
+        this.log.error('gabbo volume refresh failed', err);
+      });
+    });
   }
 
   async init(): Promise<void> {
     this.log.debug('initialising brightness characteristic');
     await this.refresh();
+    this.gabbo.connect().catch((err: unknown) => {
+      this.log.error('gabbo connect failed', err);
+    });
   }
 
   async refresh(): Promise<void> {
@@ -76,6 +92,10 @@ export class SoundTouchSpeakerBrightnessCharacteristic extends SoundTouchSpeaker
         this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE
       );
     }
+  }
+
+  stopGabbo(): void {
+    this.gabbo.close();
   }
 
   static async create(props: {

--- a/src/devices/SoundTouch/GabboClient.ts
+++ b/src/devices/SoundTouch/GabboClient.ts
@@ -1,0 +1,82 @@
+import { parseGabboFrame } from './api/notifications/gabbo-notification.js';
+import { Logger } from '../../utils/FormattedLogger.js';
+
+const GABBO_DEFAULT_PORT = 8080;
+const GABBO_PROTOCOL = 'gabbo';
+
+type VolumeTickleCallback = () => void;
+
+/**
+ * Minimal WebSocket client for the SoundTouch `gabbo` notification channel
+ * (port 8080). Spike scope: only dispatches `volumeUpdated` tickles to a
+ * single registered callback. No reconnect logic — connect once, close on
+ * teardown.
+ *
+ * The global `WebSocket` class (undici) is available in Node 22+.  No runtime
+ * dependency is added; `ws` remains a devDependency for the fake server only.
+ */
+export class GabboClient {
+  private readonly url: string;
+  private readonly log: Logger;
+  private socket?: WebSocket;
+  private onVolumeUpdated?: VolumeTickleCallback;
+
+  constructor({
+    host,
+    log,
+    port = GABBO_DEFAULT_PORT,
+  }: {
+    host: string;
+    log: Logger;
+    port?: number;
+  }) {
+    this.url = `ws://${host}:${port}`;
+    this.log = log;
+  }
+
+  /** Register a callback that fires on every `volumeUpdated` tickle. */
+  onVolume(callback: VolumeTickleCallback): void {
+    this.onVolumeUpdated = callback;
+  }
+
+  /** Open the WebSocket connection. Resolves once the connection is open. */
+  connect(): Promise<void> {
+    const ws = new WebSocket(this.url, GABBO_PROTOCOL);
+    this.socket = ws;
+
+    ws.addEventListener('message', (event: MessageEvent) => {
+      this._handleFrame(String(event.data)).catch((err: unknown) => {
+        this.log.error('gabbo frame error', err);
+      });
+    });
+
+    ws.addEventListener('error', () => {
+      this.log.error('gabbo WebSocket error');
+    });
+
+    ws.addEventListener('close', () => {
+      this.log.debug('gabbo WebSocket closed');
+    });
+
+    return new Promise((resolve, reject) => {
+      ws.addEventListener('open', () => resolve(), { once: true });
+      ws.addEventListener('error', () => reject(new Error('gabbo connection failed')), { once: true });
+    });
+  }
+
+  /** Close the WebSocket — call on teardown. */
+  close(): void {
+    this.socket?.close();
+    this.socket = undefined;
+  }
+
+  private async _handleFrame(xml: string): Promise<void> {
+    const notifications = await parseGabboFrame(xml);
+    for (const notification of notifications) {
+      if (notification.type === 'volume') {
+        this.log.debug('gabbo: volumeUpdated tickle received');
+        this.onVolumeUpdated?.();
+      }
+    }
+  }
+}

--- a/src/devices/SoundTouch/SoundTouchDeviceConfiguration.ts
+++ b/src/devices/SoundTouch/SoundTouchDeviceConfiguration.ts
@@ -20,6 +20,8 @@ interface DeviceViaRoomConfigurationProps extends BaseDeviceConfiguration {
 interface DeviceViaIpConfigurationProps extends BaseDeviceConfiguration {
   ip?: string;
   port?: number;
+  /** Override the gabbo WebSocket port (default 8080). For tests only. */
+  gabboPort?: number;
 }
 
 export class DeviceConfiguration {
@@ -29,6 +31,8 @@ export class DeviceConfiguration {
   readonly room?: string;
   readonly ip?: string;
   readonly port?: number;
+  /** Override the gabbo WebSocket port (default 8080). For tests only. */
+  readonly gabboPort?: number;
 
   readonly pollingInterval: number;
   readonly verboseLogging: boolean;
@@ -40,6 +44,7 @@ export class DeviceConfiguration {
     room?: string;
     ip?: string;
     port?: number;
+    gabboPort?: number;
     pollingInterval?: number;
     verboseLogging?: boolean;
     accessoryType?: AccessoryType;
@@ -56,6 +61,7 @@ export class DeviceConfiguration {
     if (props.type === 'ip') {
       this.ip = props.ip;
       this.port = props.port;
+      this.gabboPort = props.gabboPort;
     }
   }
 
@@ -68,7 +74,7 @@ export class DeviceConfiguration {
   }
 
   static createForIp(props: DeviceViaIpConfigurationProps) {
-    return new DeviceConfiguration({ ...props, type: 'ip' });
+    return new DeviceConfiguration({ ...props, type: 'ip', gabboPort: props.gabboPort });
   }
 
   static fromAccessoryConfiguration(props: {
@@ -80,6 +86,7 @@ export class DeviceConfiguration {
         name: props?.name || props.accessoryConfig.name || '',
         ip: props.accessoryConfig.ip,
         port: props.accessoryConfig.port,
+        gabboPort: props.accessoryConfig.gabboPort,
         pollingInterval: props.accessoryConfig.pollingInterval,
         accessoryType: props.accessoryConfig.accessoryType,
       });

--- a/src/devices/SoundTouch/api/api.ts
+++ b/src/devices/SoundTouch/api/api.ts
@@ -38,7 +38,7 @@ const parseXML = promisify(
 );
 
 export class API {
-  private readonly host: string;
+  readonly host: string;
   private readonly port: number;
   private readonly builder: XMLBuilder;
   private readonly axiosInstance: AxiosInstance;


### PR DESCRIPTION
## What & why

Proves the end-to-end gabbo WebSocket → Brightness characteristic path before building the full [07] plan.

`GabboClient` opens `ws://<ip>:8080` with the `gabbo` sub-protocol and dispatches `volumeUpdated` tickles. `SoundTouchSpeakerBrightnessCharacteristic` subscribes: on tickle, it re-fetches volume over HTTP and calls `characteristic.updateValue` via the existing `refresh()` path. The global `WebSocket` class (Node 22+/undici) is used — no new runtime dependency.

## Status

**Blocked** — not merging until the following land first (see [#113](https://github.com/forktrucka/homebridge-soundtouch-speaker/pull/113) for the updated roadmap):

1. `feat/disabled-flag` — per-accessory `disabled: true` to cleanly remove a speaker from HomeKit during testing
2. `feat/structured-errors-logging` — better logs to read during the Spike C Part 2 real-device capture session

Once those are in and Spike C Part 2 is complete, this spike's findings feed directly into the [07] WebSocket push implementation.

## Verification

`npm run typecheck && npm run lint && npm test` — 237 tests pass, 0 failures.

New integration test (`gabbo-volume-brightness.integration.test.ts`) spins up `FakeSoundTouchServer` (HTTP) and `FakeGabboServer` (WebSocket) in-process, pushes a `volumeUpdated` tickle, and asserts the Brightness characteristic reflects the re-fetched value.