### PR TITLE
docs: plan structured error chaining, ContextError, and logLevel config

### DIFF
--- a/.claude/skills/architect/plans/2026-06-20-verror-structured-errors.md
+++ b/.claude/skills/architect/plans/2026-06-20-verror-structured-errors.md
@@ -1,49 +1,61 @@
 ---
-feature: Replace bare Error with structured, chained errors using native Error.cause
+feature: Structured error chaining, context fields, and fine-grained log-level control
 status: planned
 date: 2026-06-20
-branch: refactor/verror-structured-errors
-commit-type: refactor
+branch: feat/structured-errors-logging
+commit-type: feat
 ---
 
-# Replace bare Error with structured, chained errors using native Error.cause
+# Structured error chaining, context fields, and fine-grained log-level control
 
 ## Context
 
-Error messages today lose context as they propagate up the stack. A polling
-failure logs `'Polling refresh failed' <Error: ...>` with no trace of which
-device was involved or what the underlying API call was. A discovery failure
-logs the raw axios error with no device-name context. When errors cross
-boundaries (API → device → accessory → platform), each catch site re-logs
-without chaining — making it hard to correlate a user-visible failure back
-to its root cause.
+Two related problems in the current codebase:
 
-The fix uses two zero-dependency building blocks already available in this repo:
+**1. Errors lose context as they propagate.** A polling failure logs `'Polling
+refresh failed' <Error: ...>` with no trace of which device was involved or what
+the underlying API call was. A discovery failure logs the raw axios error with no
+device-name context. When errors cross boundaries (API → device → accessory →
+platform), each catch site re-logs without chaining — making it hard to correlate
+a user-visible failure back to its root cause.
+
+**2. Logging granularity is binary.** The only dial is `verbose: boolean` in
+config — `true` enables DEBUG, `false` enables INFO and above. Users can't say
+"show warnings and errors only" or "I want error output but not the debug noise."
+Additionally, when an error IS logged, the output is equally terse regardless of
+whether the user opted into verbose mode.
+
+This plan addresses both with zero new dependencies:
 
 - **Native `Error.cause`** (ES2022, Node 18+) — `new Error('doing X for Kitchen
-  Speaker', { cause: originalError })` chains errors without any library. The
-  repo's `tsconfig.json` targets ES2022 and `lib: ["ES2022"]`; Node 22+ at
-  runtime. Zero new dependencies.
-- **`homebridge-lib`'s `formatError()`** (already a runtime dep) — handles
-  system errors (ECONNREFUSED, etc.), axios errors, and plain Errors with
-  consistent human-readable output. Used per-node when traversing the `.cause`
-  chain in `FormattedLogger`.
-
-Together they give cause chaining and readable structured output without adding
-any package.
+  Speaker', { cause: originalError })` chains errors without any library.
+- **`ContextError` class** (new, ~10 lines) — extends `Error` with a typed
+  `context: Record<string, string>` bag for structured metadata (device name,
+  endpoint, room) that survives cause-chain traversal.
+- **`homebridge-lib`'s `formatError()`** (already a runtime dep) — used per-node
+  when traversing the `.cause` chain in `FormattedLogger`.
+- **`logLevel` config option** — replaces the binary `verbose` flag with a
+  four-value enum (`'debug' | 'info' | 'warn' | 'error'`). `verbose: true`
+  continues to work as a deprecated alias for `'debug'`.
+- **Level-aware error formatting in `FormattedLogger`** — at DEBUG, `error()` shows
+  the full cause chain and stack traces; at INFO/WARN/ERROR it shows the top-level
+  message and the immediate cause only.
 
 ## Decisions & findings
 
 | Date | Decision / finding | Rationale / evidence | Alternatives rejected |
 | --- | --- | --- | --- |
-| 2026-06-20 | Use `refactor:` commit type — no release | Error structure is internal; no user-facing API or behaviour changes | `fix:` (not a bug fix, no observable behaviour change for users) |
+| 2026-06-20 | **Drop `verror`** — use native `Error.cause` (ES2022) instead | `verror` is a third-party CJS dependency. Native `Error.cause` is available in ES2022 (this repo's TS target) and Node 18+ (runtime is Node 22). Zero new runtime or dev deps required. | `verror` (external dep, CJS interop complexity); `pino`/`winston` (heavy, wrong layer) |
 | 2026-06-20 | Keep `APIErrors extends Error` as-is | It carries structured SoundTouch API payload (`errors: APIError[]`, `deviceId`) that has no native-cause analogue. Wrap it at catch sites rather than rewriting the class. | Rewriting `APIErrors` (high churn, loses typed `.errors` array accessor) |
-| 2026-06-20 | **Drop `verror`** — use native `Error.cause` (ES2022) instead | `verror` is a third-party CJS dependency. Native `Error.cause` is available in ES2022 (this repo's TS target) and Node 18+ (runtime is Node 22). Zero new runtime or dev deps required. `{ cause }` option accepted by all `Error` subclasses natively. | `verror` (external dep, CJS interop complexity); `pino`/`winston` (heavy, wrong layer — logging not error chaining) |
-| 2026-06-20 | Use `homebridge-lib`'s `formatError()` per node in the cause chain | `homebridge-lib` is already a runtime dep (v8.1.1). Its `formatError(e, useChalk?)` handles ECONNREFUSED, axios errors, and plain errors better than `.message` alone. Calling it on each node in the `.cause` chain gives better output than either `.message` or `.stack` alone. | Reimplementing formatError ourselves (duplication); calling `.stack` raw (verbose, hard to read for ECONNREFUSED) |
-| 2026-06-20 | `FormattedLogger.error()` traverses the `.cause` chain centrally | Call sites already pass the raw error as the second arg. Upgrading the logger centralises the improvement without touching every call site. Output: `message: top-level message\n  caused by: cause message\n  caused by: root message`. | Updating every `logger.error(msg, e)` call site inline (repetitive, easy to miss new sites) |
-| 2026-06-20 | Context goes in the Error message string, not in structured metadata | `Error.cause` carries no structured `info` bag (unlike `verror`). Device name / endpoint are interpolated directly into the message string at throw time: `new Error(\`polling refresh for ${device.name}\`, { cause: e })`. Sufficient for log readability; metadata queries are not used anywhere in this codebase. | Adding a custom `ContextError extends Error` with an `info` map (over-engineering for current needs) |
 | 2026-06-20 | Do NOT add cause-wrapping to HAP characteristic throws | `HapStatusError` is a HAP protocol requirement and must remain unwrapped. Only the `logger.error` call *before* the `throw HapStatusError` gains the contextual Error. | Wrapping HapStatusError in a cause chain (breaks HAP) |
-| 2026-06-20 | `SoundTouchSpeakerOnCharacteristic.getOn()` has no catch — leave it | The method returns `false` on `deviceIsOn()` failure (silent catch inside `SoundTouchDevice`); there is no logged error to enrich. | Adding a wrapping catch (adds behaviour, out of scope for a refactor) |
+| 2026-06-20 | `SoundTouchSpeakerOnCharacteristic.getOn()` has no catch — leave it | The method returns `false` on `deviceIsOn()` failure (silent catch inside `SoundTouchDevice`); there is no logged error to enrich. | Adding a wrapping catch (adds behaviour, out of scope) |
+| 2026-06-21 | `logLevel: 'debug' \| 'info' \| 'warn' \| 'error'` replaces `verbose: boolean` | Four values cover all practical needs. `verbose: true` stays as a deprecated alias for `'debug'` so existing configs don't break. `LogLevel` from homebridge maps directly: `DEBUG / INFO / WARN / ERROR`. | Keeping `verbose` only (too coarse); per-channel toggles (over-engineered) |
+| 2026-06-21 | `logLevel` is a top-level `global` config option, threaded through `PlatformConfiguration` | Consistent with `pollingInterval`, `accessoryType`, and `verbose` — all live under `global`. `PlatformConfiguration.logLevel` replaces `verbose` internally; `verbose` is read only as an alias. | Per-accessory `logLevel` (log level is a platform concern, not per-device) |
+| 2026-06-21 | Level-aware error output in `Logger.error()`: DEBUG → full cause chain + stacks; others → top message + immediate cause | Users in verbose/debug mode need root-cause visibility; users in default INFO mode need a concise signal. Same call site, output determined by `requiredLogLevel`. | Separate `logger.verboseError()` method (leaks implementation detail into call sites); always-verbose (noisy for default users) |
+| 2026-06-21 | Introduce `ContextError extends Error` with `context: Record<string, string>` | Device name is already handled by `DeviceLogger` prefix. `ContextError` handles endpoint, room, operation — metadata that belongs with the error itself, not in the message string. `FormattedLogger` detects `instanceof ContextError` and renders context fields inline. | Interpolating everything into the message string (loses structure, can't filter/reformat); custom `info` map on all errors (requires touching more files) |
+| 2026-06-21 | `ContextError` lives in `src/errors.ts` alongside `apiNotFoundWithName` | One place for shared error primitives. | New file `src/utils/ContextError.ts` (unnecessary file for 10 lines) |
+| 2026-06-21 | commit-type is `feat:` — minor release | `logLevel` config option is user-visible and expands capability. | `refactor:` (wrong — user-facing config change) |
+| 2026-06-21 | Use `homebridge-lib`'s `formatError()` per node in the cause chain | Already a runtime dep. Handles ECONNREFUSED, axios errors, plain Errors consistently. | Reimplementing formatError (duplication); `.stack` raw (verbose, unreadable for ECONNREFUSED) |
 
 ## If cancelled
 
@@ -51,97 +63,195 @@ any package.
 
 ## Affected areas
 
-### No new dependencies
+### No new npm dependencies
 
-No `npm install` step. `Error.cause` is built into Node 22+ / ES2022.
-`formatError` is already exported from `homebridge-lib`.
+`Error.cause` and `ContextError` are zero-dep. `formatError` is from `homebridge-lib`
+(already installed). `logLevel` maps to homebridge's existing `LogLevel` enum.
 
-### Changed files
+### New / changed source files
 
-- `src/utils/FormattedLogger.ts` — enhance `error(msg, err?)`:
-  ```ts
-  import { formatError } from 'homebridge-lib';
+#### `src/errors.ts` — add `ContextError`
 
-  // In error():
-  if (err instanceof Error) {
-    let node: unknown = err;
+```ts
+export class ContextError extends Error {
+  readonly context: Record<string, string>;
+  constructor(
+    message: string,
+    context: Record<string, string>,
+    options?: ErrorOptions
+  ) {
+    super(message, options);
+    this.name = 'ContextError';
+    this.context = context;
+  }
+}
+
+export function apiNotFoundWithName(name: string): Error {
+  return new Error(`Can't find device using the name '${name}' on your network`);
+}
+```
+
+#### `src/ExternalPlatformConfig.ts` — add `logLevel`
+
+```ts
+interface BaseGlobalConfig {
+  readonly verbose?: boolean;  // deprecated alias for logLevel: 'debug'
+  readonly logLevel?: 'debug' | 'info' | 'warn' | 'error';
+}
+```
+
+#### `src/PlatformConfiguration.ts` — thread `logLevel`
+
+- Add `logLevel: LogLevel` property (internal, typed).
+- In `fromExternalConfiguration`: resolve `logLevel` from `props.global.logLevel`
+  first; fall back to `verbose: true → 'debug'`; default to `'info'`.
+- Map string → `LogLevel` enum: `'debug' → LogLevel.DEBUG`, etc.
+- Remove the `verbose` property (replaced internally by `logLevel`).
+
+#### `config.schema.json` — expose `logLevel`
+
+Add to `global` object:
+```json
+"logLevel": {
+  "type": "string",
+  "enum": ["debug", "info", "warn", "error"],
+  "default": "info",
+  "description": "Minimum log level written to the Homebridge console."
+}
+```
+
+#### `src/utils/FormattedLogger.ts` — level-aware error formatting
+
+```ts
+import { formatError } from 'homebridge-lib';
+import { ContextError } from '../errors.js';
+
+// Replace the existing error() body:
+error(message: string, err?: unknown): void {
+  if (!(err instanceof Error)) {
+    this.log(LogLevel.ERROR, message);
+    return;
+  }
+
+  const isDebug = !Logger.excludeLog(LogLevel.DEBUG, this.requiredLogLevel);
+
+  if (isDebug) {
+    // Full cause chain + context fields + stack at debug verbosity
     const lines: string[] = [];
+    let node: unknown = err;
     while (node instanceof Error) {
-      lines.push(formatError(node));
+      const ctx = node instanceof ContextError
+        ? ` [${Object.entries(node.context).map(([k, v]) => `${k}: ${v}`).join(', ')}]`
+        : '';
+      lines.push(`${formatError(node)}${ctx}`);
+      if (node.stack) lines.push(`  ${node.stack.split('\n').slice(1, 4).join('\n  ')}`);
       node = node.cause;
     }
-    this._log(LogLevel.ERROR, `${msg}: ${lines.join('\n  caused by: ')}`);
+    this.log(LogLevel.ERROR, `${message}:\n  ${lines.join('\n  caused by:\n  ')}`);
   } else {
-    this._log(LogLevel.ERROR, msg);
+    // Concise: top message + immediate cause
+    const ctx = err instanceof ContextError
+      ? ` [${Object.entries(err.context).map(([k, v]) => `${k}: ${v}`).join(', ')}]`
+      : '';
+    const cause = err.cause instanceof Error ? `\n  caused by: ${formatError(err.cause)}` : '';
+    this.log(LogLevel.ERROR, `${message}: ${formatError(err)}${ctx}${cause}`);
   }
-  ```
-- `src/errors.ts` — `apiNotFoundWithName`: `new Error(
-  \`Can't find device using the name '${name}' on your network\`)` stays
-  unchanged (no cause here — it is the root). No change needed.
+}
+```
+
+#### `src/platform.ts` — use `configuration.logLevel`
+
+Replace:
+```ts
+level: this.configuration.verbose ? LogLevel.DEBUG : LogLevel.INFO,
+```
+With:
+```ts
+level: this.configuration.logLevel,
+```
+
+#### Call sites — wrap errors with `Error.cause` and `ContextError`
+
 - `src/devices/SoundTouch/SoundTouchDevice.ts`
-  - `discoverAllAccessories` catch: `new Error(\`creating device ${device.ip ?? device.name}\`, { cause: e })` (log only, don't rethrow).
-  - `fromConfiguredAccessory` throws: `new Error(\`Could not find a device for room '${accessoryConfig.room}'\`)` and `new Error('Could not find device info', { cause: undefined })` — add room/name context to message.
+  - `discoverAllAccessories` catch: `new ContextError('creating device', { ip: device.ip ?? '', name: device.name ?? '' }, { cause: e })`
+  - `fromConfiguredAccessory` throws: add room/name to existing message strings.
 - `src/devices/SoundTouch/api/api.ts`
-  - `_req` catch (non-response network error): `throw new Error(\`network request to ${endpoint} failed\`, { cause: err })`.
+  - `_req` catch: `throw new ContextError('network request failed', { endpoint }, { cause: err })`.
 - `src/accessories/SoundTouchSpeakerPlatformAccessory.ts`
-  - Polling catch: log `new Error(\`polling refresh for ${this.accessory.displayName}\`, { cause: e as Error })`.
+  - Polling catch: `new ContextError('polling refresh', { device: this.accessory.displayName }, { cause: e as Error })`.
 - `src/platform.ts`
-  - `searchDevices` allSettled handler: `new Error(\`loading configured accessory ${name}\`, { cause: result.reason })`.
-  - `discoverDevices` two catch sites: wrap with device name context.
+  - `searchDevices` allSettled handler: `new ContextError('loading configured accessory', { name }, { cause: result.reason })`.
+  - `discoverDevices` catch sites: wrap with device name context.
 - `src/accessories/services/SoundTouchSpeakerBrightnessCharacteristic.ts`
   - Both catch blocks: log wrapped error before throwing `HapStatusError`.
 - `src/accessories/services/SoundTouchSpeakerOnCharacteristic.ts`
   - `setOn` catch: log wrapped error before throwing `HapStatusError`.
 - `src/accessories/services/SoundTouchSpeakerInformationCharacteristic.ts`
-  - `new Error('No information service found')` → add accessory name to message.
+  - Add accessory name to existing message string.
 
 ### Test files to add / update
 
-- `src/utils/__tests__/FormattedLogger.test.ts` — add cases:
-  - `error()` with a plain `Error` (no cause)
-  - `error()` with a two-level cause chain — assert "caused by:" appears
-  - `error()` with no error arg
-- `src/devices/SoundTouch/api/__tests__/error.test.ts` — `APIErrors` unchanged,
-  existing tests stay green as-is.
-- Integration tests: error-path branches in the existing integration suites
-  (`platform-lifecycle.integration.test.ts`) exercise the error paths through
-  the platform; verify they still pass with the new wrapping.
+- `src/utils/__tests__/FormattedLogger.test.ts`
+  - `error()` with plain `Error` (no cause) — concise path
+  - `error()` with `ContextError` — context fields appear in output
+  - `error()` with two-level cause chain at DEBUG level — full chain + "caused by:" appears
+  - `error()` with two-level cause chain at INFO level — only top + immediate cause
+  - `error()` with no error arg — message only
+- `src/__tests__/PlatformConfiguration.test.ts`
+  - `logLevel: 'warn'` maps to `LogLevel.WARN`
+  - `verbose: true` maps to `LogLevel.DEBUG` (backward compat)
+  - Default is `LogLevel.INFO`
+- `src/devices/SoundTouch/api/__tests__/error.test.ts` — `APIErrors` unchanged; existing tests stay green.
+- Integration tests: `platform-lifecycle.integration.test.ts` error paths pass unchanged (smoke check).
 
 ## Conventions for this change
 
-- **Commit type:** `refactor:` → no release.
-- **Config schema touched:** no.
-- **Tests to add/update:** `src/utils/__tests__/FormattedLogger.test.ts` (new
-  cause-chain cases); integration tests pass unchanged (smoke check).
-- **Target branch:** `dev` (squash-merged; PR title is the released commit
-  message).
+- **Commit type:** `feat:` → minor release.
+- **Config schema touched:** yes — `config.schema.json` (`logLevel`), `ExternalPlatformConfig`
+  (`logLevel`), `PlatformConfiguration` (`logLevel`, drop `verbose`), and their tests.
+- **Tests to add/update:** `FormattedLogger.test.ts`, `PlatformConfiguration.test.ts`.
+- **Target branch:** `dev` (squash-merged; PR title is the released commit message).
+- **ESM import rule:** `import { ContextError } from '../errors.js'` — don't omit `.js`.
+- **Domain skill to re-read before implementing:** `coding-conventions` (level-aware
+  logging, test structure).
 
 ## Implementation checklist
 
-- [ ] Update `src/utils/FormattedLogger.ts` — traverse `.cause` chain using
-      `homebridge-lib`'s `formatError()` in `error()`
-- [ ] Update `src/devices/SoundTouch/SoundTouchDevice.ts` — add context to
-      throws and catch site
-- [ ] Update `src/devices/SoundTouch/api/api.ts` — wrap network error in `_req`
-- [ ] Update `src/platform.ts` — wrap both catch sites with device-name context
+- [ ] Add `ContextError` class to `src/errors.ts`
+- [ ] Add `logLevel` to `ExternalPlatformConfig.ts` (keep `verbose` as deprecated alias)
+- [ ] Update `PlatformConfiguration.ts` — add `logLevel: LogLevel`, resolve from config,
+      remove `verbose` property
+- [ ] Update `config.schema.json` — add `logLevel` enum to `global`
+- [ ] Update `src/platform.ts` — use `configuration.logLevel` instead of
+      `configuration.verbose ? DEBUG : INFO`
+- [ ] Update `src/utils/FormattedLogger.ts` — level-aware `error()` with cause chain
+      traversal and `ContextError` context rendering
+- [ ] Update `src/devices/SoundTouch/SoundTouchDevice.ts` — wrap catch/throw sites
+- [ ] Update `src/devices/SoundTouch/api/api.ts` — wrap `_req` network error
+- [ ] Update `src/platform.ts` — wrap both catch sites with `ContextError`
 - [ ] Update `src/accessories/SoundTouchSpeakerPlatformAccessory.ts` — polling catch
 - [ ] Update `src/accessories/services/SoundTouchSpeakerBrightnessCharacteristic.ts`
 - [ ] Update `src/accessories/services/SoundTouchSpeakerOnCharacteristic.ts`
 - [ ] Update `src/accessories/services/SoundTouchSpeakerInformationCharacteristic.ts`
-- [ ] Add/update `FormattedLogger` tests for cause chain output
+- [ ] Add/update `FormattedLogger` tests (plain, ContextError, chain at DEBUG, chain at INFO)
+- [ ] Add `PlatformConfiguration` tests for `logLevel` resolution
 - [ ] `npm run typecheck && npm run lint && npm test`
+- [ ] `npm run knip` — confirm no unused exports
 
 ## Verification
 
 - [ ] `npm run lint`
 - [ ] `npm run build`
 - [ ] `npm test`
-- [ ] Confirm cause chain appears in logs during `npm run watch` — simulate
-      unreachable device (bad IP in config); expect `network request to /volume
-      failed\n  caused by: ECONNREFUSED …`
+- [ ] `npm run watch` with `logLevel: 'debug'` + bad IP — expect full chain:
+      `network request failed [endpoint: /volume]\n  caused by: ECONNREFUSED …`
+- [ ] `npm run watch` with `logLevel: 'info'` (default) — same scenario shows concise:
+      `polling refresh [device: Kitchen]: network request failed [endpoint: /volume]\n  caused by: ECONNREFUSED …`
+- [ ] `npm run watch` with `logLevel: 'warn'` — info messages suppressed, errors still appear
+- [ ] Confirm `verbose: true` still works (backward compat alias for `debug`)
 
 ## PR / release notes
 
 - **PR title (Conventional Commit, becomes the release commit):**
-  `refactor: chain errors with native Error.cause and log full cause chain`
+  `feat: add logLevel config and structured error chaining with cause context`
 - **Targets:** `dev`

--- a/.claude/skills/architect/plans/2026-06-20-verror-structured-errors.md
+++ b/.claude/skills/architect/plans/2026-06-20-verror-structured-errors.md
@@ -1,0 +1,127 @@
+---
+feature: Replace bare Error with VError for structured, chained errors
+status: planned
+date: 2026-06-20
+branch: refactor/verror-structured-errors
+commit-type: refactor
+---
+
+# Replace bare Error with VError for structured, chained errors
+
+## Context
+
+Error messages today lose context as they propagate up the stack. A polling
+failure logs `'Polling refresh failed' <Error: ...>` with no trace of which
+device was involved or what the underlying API call was. A discovery failure
+logs the raw axios error with no device-name context. When errors cross
+boundaries (API → device → accessory → platform), each catch site re-logs
+without chaining — making it hard to correlate a user-visible failure back
+to its root cause.
+
+[`verror`](https://github.com/oven-sh/verror) (Joyent/Node.js community
+standard) adds three primitives we need:
+
+- **Cause chaining** — `new VError(cause, 'doing X for device %s', name)`
+  preserves the original error and its stack as `.cause`.
+- **Structured info** — `new VError({ cause, info: { deviceId, ip } }, '…')`
+  attaches arbitrary metadata retrievable via `VError.info(err)`.
+- **Full stack** — `VError.fullStack(err)` emits the complete causal chain in
+  one string, making logs immediately actionable.
+
+## Decisions & findings
+
+| Date | Decision / finding | Rationale / evidence | Alternatives rejected |
+| --- | --- | --- | --- |
+| 2026-06-20 | Use `refactor:` commit type — no release | Error structure is internal; no user-facing API or behaviour changes | `fix:` (not a bug fix, no observable behaviour change for users) |
+| 2026-06-20 | Keep `APIErrors extends Error` as-is | It carries structured SoundTouch API payload (`errors: APIError[]`, `deviceId`) that has no VError analogue. Wrap it at catch sites with VError rather than extending VError. | Rewriting `APIErrors` to extend `VError` (high churn, loses typed `.errors` array accessor) |
+| 2026-06-20 | Import as `import VError from 'verror'` (default import) | `verror` is CommonJS; `esModuleInterop: true` + `allowSyntheticDefaultImports: true` in `tsconfig.json` enable this in the NodeNext module resolution already used by the repo. | Named import `import { VError } from 'verror'` (not exported that way from the CJS module) |
+| 2026-06-20 | Add `@types/verror` as devDependency | `verror` ships no built-in types; `@types/verror` provides them. | Inline `declare module` shim (fragile, not maintained) |
+| 2026-06-20 | Improve `FormattedLogger.error` to emit `VError.fullStack()` when available | The call sites already pass the raw error object as the second arg; upgrading the logger centralises the improvement without touching every call site individually. | Updating every `logger.error(msg, e)` call site to call `VError.fullStack(e)` inline (repetitive, easy to miss new sites) |
+| 2026-06-20 | Do NOT add VError to HAP characteristic throws | `HapStatusError` is a HAP protocol requirement and must remain unwrapped — HomeKit depends on its exact shape. Only the `logger.error` call before the throw gains context. | Wrapping HapStatusError in VError (breaks HAP) |
+| 2026-06-20 | `SoundTouchSpeakerOnCharacteristic.getOn()` has no catch — leave it | The method returns `false` on `deviceIsOn()` failure (silent catch inside `SoundTouchDevice`); there is no logged error to enrich. | Adding a wrapping catch (adds behaviour, out of scope for a refactor) |
+
+## If cancelled
+
+> Only fill this in when `status: cancelled`. Leave empty otherwise.
+
+## Affected areas
+
+### New dependency
+
+- `package.json` — add `"verror": "^1.10.1"` to `dependencies` and
+  `"@types/verror": "^1.10.6"` to `devDependencies`.
+
+### Changed files
+
+- `src/errors.ts` — `apiNotFoundWithName` returns `new VError({ info: { name } }, "Can't find device using the name '%s' on your network", name)`.
+- `src/utils/FormattedLogger.ts` — `error(msg, err?)`: when `err` is an
+  `Error`, emit `VError.fullStack(err)` (falls back gracefully for non-VError
+  instances since `VError.fullStack` handles plain `Error` too).
+- `src/devices/SoundTouch/SoundTouchDevice.ts`
+  - `discoverAllAccessories` catch: wrap with `new VError(e, 'creating device %s', device.ip ?? device.name)`.
+  - `fromConfiguredAccessory` throws: replace `new Error('Could not find a device')` / `new Error('Could not find device info')` with `VError` with `{ info: { name, room, ip } }`.
+- `src/devices/SoundTouch/api/api.ts`
+  - `_req` catch: wrap non-response network errors — `throw new VError(err, 'network request to %s failed', endpoint)`.
+- `src/accessories/SoundTouchSpeakerPlatformAccessory.ts`
+  - Polling catch: `new VError(e as Error, 'polling refresh for %s', this.accessory.displayName)` (log, don't rethrow).
+- `src/platform.ts`
+  - `searchDevices` catch in `allSettled` handler: `new VError(result.reason, 'loading configured accessory %s', name)`.
+  - `discoverDevices` two catch sites: wrap with device name context.
+- `src/accessories/services/SoundTouchSpeakerBrightnessCharacteristic.ts`
+  - Both catch blocks: log `new VError(e as Error, 'brightness %s for %s', action, deviceName)` before throwing `HapStatusError`.
+- `src/accessories/services/SoundTouchSpeakerOnCharacteristic.ts`
+  - `setOn` catch: log `new VError(e as Error, 'setOn for %s', deviceName)` before throwing `HapStatusError`.
+- `src/accessories/services/SoundTouchSpeakerInformationCharacteristic.ts`
+  - `new Error('No information service found')` → `new VError('no HAP information service registered for %s', accessoryName)`.
+
+### Test files to add / update
+
+- `src/utils/__tests__/FormattedLogger.test.ts` — add cases: `error()` with a
+  plain `Error`, a `VError` chain, and no error arg; assert the full-stack
+  output appears.
+- `src/devices/SoundTouch/__tests__/SoundTouchDeviceConfiguration.test.ts` —
+  no change needed (config, not errors).
+- `src/devices/SoundTouch/api/__tests__/error.test.ts` — `APIErrors` unchanged,
+  existing tests stay green as-is.
+- Integration tests: error-path branches in the existing integration suites
+  (`platform-lifecycle.integration.test.ts`) exercise the error paths through
+  the platform; verify they still pass with the new wrapping.
+
+## Conventions for this change
+
+- **Commit type:** `refactor:` → no release.
+- **Config schema touched:** no.
+- **Tests to add/update:** `src/utils/__tests__/FormattedLogger.test.ts` (new
+  VError cases); integration tests pass unchanged (smoke check).
+- **Target branch:** `dev` (squash-merged; PR title is the released commit
+  message).
+
+## Implementation checklist
+
+- [ ] `npm install verror && npm install --save-dev @types/verror`
+- [ ] Update `src/utils/FormattedLogger.ts` — emit `VError.fullStack()` in `error()`
+- [ ] Update `src/errors.ts` — `apiNotFoundWithName` → `VError` with `info: { name }`
+- [ ] Update `src/devices/SoundTouch/SoundTouchDevice.ts` — wrap throws and catch sites
+- [ ] Update `src/devices/SoundTouch/api/api.ts` — wrap network error in `_req`
+- [ ] Update `src/platform.ts` — wrap both catch sites with device-name context
+- [ ] Update `src/accessories/SoundTouchSpeakerPlatformAccessory.ts` — polling catch
+- [ ] Update `src/accessories/services/SoundTouchSpeakerBrightnessCharacteristic.ts`
+- [ ] Update `src/accessories/services/SoundTouchSpeakerOnCharacteristic.ts`
+- [ ] Update `src/accessories/services/SoundTouchSpeakerInformationCharacteristic.ts`
+- [ ] Add/update `FormattedLogger` tests for VError chain output
+- [ ] Run `npm run knip` — confirm `verror` is not flagged as unused
+- [ ] `npm run typecheck && npm run lint && npm test`
+
+## Verification
+
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] `npm test`
+- [ ] Confirm `VError.fullStack()` output appears in logs during `npm run watch`
+  (e.g. simulate a device unreachable by pointing config at a bad IP)
+
+## PR / release notes
+
+- **PR title (Conventional Commit, becomes the release commit):**
+  `refactor: replace bare Error with VError for structured, chained errors`
+- **Targets:** `dev`

--- a/.claude/skills/architect/plans/2026-06-20-verror-structured-errors.md
+++ b/.claude/skills/architect/plans/2026-06-20-verror-structured-errors.md
@@ -1,12 +1,12 @@
 ---
-feature: Replace bare Error with VError for structured, chained errors
+feature: Replace bare Error with structured, chained errors using native Error.cause
 status: planned
 date: 2026-06-20
 branch: refactor/verror-structured-errors
 commit-type: refactor
 ---
 
-# Replace bare Error with VError for structured, chained errors
+# Replace bare Error with structured, chained errors using native Error.cause
 
 ## Context
 
@@ -18,26 +18,31 @@ boundaries (API → device → accessory → platform), each catch site re-logs
 without chaining — making it hard to correlate a user-visible failure back
 to its root cause.
 
-[`verror`](https://github.com/oven-sh/verror) (Joyent/Node.js community
-standard) adds three primitives we need:
+The fix uses two zero-dependency building blocks already available in this repo:
 
-- **Cause chaining** — `new VError(cause, 'doing X for device %s', name)`
-  preserves the original error and its stack as `.cause`.
-- **Structured info** — `new VError({ cause, info: { deviceId, ip } }, '…')`
-  attaches arbitrary metadata retrievable via `VError.info(err)`.
-- **Full stack** — `VError.fullStack(err)` emits the complete causal chain in
-  one string, making logs immediately actionable.
+- **Native `Error.cause`** (ES2022, Node 18+) — `new Error('doing X for Kitchen
+  Speaker', { cause: originalError })` chains errors without any library. The
+  repo's `tsconfig.json` targets ES2022 and `lib: ["ES2022"]`; Node 22+ at
+  runtime. Zero new dependencies.
+- **`homebridge-lib`'s `formatError()`** (already a runtime dep) — handles
+  system errors (ECONNREFUSED, etc.), axios errors, and plain Errors with
+  consistent human-readable output. Used per-node when traversing the `.cause`
+  chain in `FormattedLogger`.
+
+Together they give cause chaining and readable structured output without adding
+any package.
 
 ## Decisions & findings
 
 | Date | Decision / finding | Rationale / evidence | Alternatives rejected |
 | --- | --- | --- | --- |
 | 2026-06-20 | Use `refactor:` commit type — no release | Error structure is internal; no user-facing API or behaviour changes | `fix:` (not a bug fix, no observable behaviour change for users) |
-| 2026-06-20 | Keep `APIErrors extends Error` as-is | It carries structured SoundTouch API payload (`errors: APIError[]`, `deviceId`) that has no VError analogue. Wrap it at catch sites with VError rather than extending VError. | Rewriting `APIErrors` to extend `VError` (high churn, loses typed `.errors` array accessor) |
-| 2026-06-20 | Import as `import VError from 'verror'` (default import) | `verror` is CommonJS; `esModuleInterop: true` + `allowSyntheticDefaultImports: true` in `tsconfig.json` enable this in the NodeNext module resolution already used by the repo. | Named import `import { VError } from 'verror'` (not exported that way from the CJS module) |
-| 2026-06-20 | Add `@types/verror` as devDependency | `verror` ships no built-in types; `@types/verror` provides them. | Inline `declare module` shim (fragile, not maintained) |
-| 2026-06-20 | Improve `FormattedLogger.error` to emit `VError.fullStack()` when available | The call sites already pass the raw error object as the second arg; upgrading the logger centralises the improvement without touching every call site individually. | Updating every `logger.error(msg, e)` call site to call `VError.fullStack(e)` inline (repetitive, easy to miss new sites) |
-| 2026-06-20 | Do NOT add VError to HAP characteristic throws | `HapStatusError` is a HAP protocol requirement and must remain unwrapped — HomeKit depends on its exact shape. Only the `logger.error` call before the throw gains context. | Wrapping HapStatusError in VError (breaks HAP) |
+| 2026-06-20 | Keep `APIErrors extends Error` as-is | It carries structured SoundTouch API payload (`errors: APIError[]`, `deviceId`) that has no native-cause analogue. Wrap it at catch sites rather than rewriting the class. | Rewriting `APIErrors` (high churn, loses typed `.errors` array accessor) |
+| 2026-06-20 | **Drop `verror`** — use native `Error.cause` (ES2022) instead | `verror` is a third-party CJS dependency. Native `Error.cause` is available in ES2022 (this repo's TS target) and Node 18+ (runtime is Node 22). Zero new runtime or dev deps required. `{ cause }` option accepted by all `Error` subclasses natively. | `verror` (external dep, CJS interop complexity); `pino`/`winston` (heavy, wrong layer — logging not error chaining) |
+| 2026-06-20 | Use `homebridge-lib`'s `formatError()` per node in the cause chain | `homebridge-lib` is already a runtime dep (v8.1.1). Its `formatError(e, useChalk?)` handles ECONNREFUSED, axios errors, and plain errors better than `.message` alone. Calling it on each node in the `.cause` chain gives better output than either `.message` or `.stack` alone. | Reimplementing formatError ourselves (duplication); calling `.stack` raw (verbose, hard to read for ECONNREFUSED) |
+| 2026-06-20 | `FormattedLogger.error()` traverses the `.cause` chain centrally | Call sites already pass the raw error as the second arg. Upgrading the logger centralises the improvement without touching every call site. Output: `message: top-level message\n  caused by: cause message\n  caused by: root message`. | Updating every `logger.error(msg, e)` call site inline (repetitive, easy to miss new sites) |
+| 2026-06-20 | Context goes in the Error message string, not in structured metadata | `Error.cause` carries no structured `info` bag (unlike `verror`). Device name / endpoint are interpolated directly into the message string at throw time: `new Error(\`polling refresh for ${device.name}\`, { cause: e })`. Sufficient for log readability; metadata queries are not used anywhere in this codebase. | Adding a custom `ContextError extends Error` with an `info` map (over-engineering for current needs) |
+| 2026-06-20 | Do NOT add cause-wrapping to HAP characteristic throws | `HapStatusError` is a HAP protocol requirement and must remain unwrapped. Only the `logger.error` call *before* the `throw HapStatusError` gains the contextual Error. | Wrapping HapStatusError in a cause chain (breaks HAP) |
 | 2026-06-20 | `SoundTouchSpeakerOnCharacteristic.getOn()` has no catch — leave it | The method returns `false` on `deviceIsOn()` failure (silent catch inside `SoundTouchDevice`); there is no logged error to enrich. | Adding a wrapping catch (adds behaviour, out of scope for a refactor) |
 
 ## If cancelled
@@ -46,41 +51,56 @@ standard) adds three primitives we need:
 
 ## Affected areas
 
-### New dependency
+### No new dependencies
 
-- `package.json` — add `"verror": "^1.10.1"` to `dependencies` and
-  `"@types/verror": "^1.10.6"` to `devDependencies`.
+No `npm install` step. `Error.cause` is built into Node 22+ / ES2022.
+`formatError` is already exported from `homebridge-lib`.
 
 ### Changed files
 
-- `src/errors.ts` — `apiNotFoundWithName` returns `new VError({ info: { name } }, "Can't find device using the name '%s' on your network", name)`.
-- `src/utils/FormattedLogger.ts` — `error(msg, err?)`: when `err` is an
-  `Error`, emit `VError.fullStack(err)` (falls back gracefully for non-VError
-  instances since `VError.fullStack` handles plain `Error` too).
+- `src/utils/FormattedLogger.ts` — enhance `error(msg, err?)`:
+  ```ts
+  import { formatError } from 'homebridge-lib';
+
+  // In error():
+  if (err instanceof Error) {
+    let node: unknown = err;
+    const lines: string[] = [];
+    while (node instanceof Error) {
+      lines.push(formatError(node));
+      node = node.cause;
+    }
+    this._log(LogLevel.ERROR, `${msg}: ${lines.join('\n  caused by: ')}`);
+  } else {
+    this._log(LogLevel.ERROR, msg);
+  }
+  ```
+- `src/errors.ts` — `apiNotFoundWithName`: `new Error(
+  \`Can't find device using the name '${name}' on your network\`)` stays
+  unchanged (no cause here — it is the root). No change needed.
 - `src/devices/SoundTouch/SoundTouchDevice.ts`
-  - `discoverAllAccessories` catch: wrap with `new VError(e, 'creating device %s', device.ip ?? device.name)`.
-  - `fromConfiguredAccessory` throws: replace `new Error('Could not find a device')` / `new Error('Could not find device info')` with `VError` with `{ info: { name, room, ip } }`.
+  - `discoverAllAccessories` catch: `new Error(\`creating device ${device.ip ?? device.name}\`, { cause: e })` (log only, don't rethrow).
+  - `fromConfiguredAccessory` throws: `new Error(\`Could not find a device for room '${accessoryConfig.room}'\`)` and `new Error('Could not find device info', { cause: undefined })` — add room/name context to message.
 - `src/devices/SoundTouch/api/api.ts`
-  - `_req` catch: wrap non-response network errors — `throw new VError(err, 'network request to %s failed', endpoint)`.
+  - `_req` catch (non-response network error): `throw new Error(\`network request to ${endpoint} failed\`, { cause: err })`.
 - `src/accessories/SoundTouchSpeakerPlatformAccessory.ts`
-  - Polling catch: `new VError(e as Error, 'polling refresh for %s', this.accessory.displayName)` (log, don't rethrow).
+  - Polling catch: log `new Error(\`polling refresh for ${this.accessory.displayName}\`, { cause: e as Error })`.
 - `src/platform.ts`
-  - `searchDevices` catch in `allSettled` handler: `new VError(result.reason, 'loading configured accessory %s', name)`.
+  - `searchDevices` allSettled handler: `new Error(\`loading configured accessory ${name}\`, { cause: result.reason })`.
   - `discoverDevices` two catch sites: wrap with device name context.
 - `src/accessories/services/SoundTouchSpeakerBrightnessCharacteristic.ts`
-  - Both catch blocks: log `new VError(e as Error, 'brightness %s for %s', action, deviceName)` before throwing `HapStatusError`.
+  - Both catch blocks: log wrapped error before throwing `HapStatusError`.
 - `src/accessories/services/SoundTouchSpeakerOnCharacteristic.ts`
-  - `setOn` catch: log `new VError(e as Error, 'setOn for %s', deviceName)` before throwing `HapStatusError`.
+  - `setOn` catch: log wrapped error before throwing `HapStatusError`.
 - `src/accessories/services/SoundTouchSpeakerInformationCharacteristic.ts`
-  - `new Error('No information service found')` → `new VError('no HAP information service registered for %s', accessoryName)`.
+  - `new Error('No information service found')` → add accessory name to message.
 
 ### Test files to add / update
 
-- `src/utils/__tests__/FormattedLogger.test.ts` — add cases: `error()` with a
-  plain `Error`, a `VError` chain, and no error arg; assert the full-stack
-  output appears.
-- `src/devices/SoundTouch/__tests__/SoundTouchDeviceConfiguration.test.ts` —
-  no change needed (config, not errors).
+- `src/utils/__tests__/FormattedLogger.test.ts` — add cases:
+  - `error()` with a plain `Error` (no cause)
+  - `error()` with a two-level cause chain — assert "caused by:" appears
+  - `error()` with no error arg
 - `src/devices/SoundTouch/api/__tests__/error.test.ts` — `APIErrors` unchanged,
   existing tests stay green as-is.
 - Integration tests: error-path branches in the existing integration suites
@@ -92,24 +112,23 @@ standard) adds three primitives we need:
 - **Commit type:** `refactor:` → no release.
 - **Config schema touched:** no.
 - **Tests to add/update:** `src/utils/__tests__/FormattedLogger.test.ts` (new
-  VError cases); integration tests pass unchanged (smoke check).
+  cause-chain cases); integration tests pass unchanged (smoke check).
 - **Target branch:** `dev` (squash-merged; PR title is the released commit
   message).
 
 ## Implementation checklist
 
-- [ ] `npm install verror && npm install --save-dev @types/verror`
-- [ ] Update `src/utils/FormattedLogger.ts` — emit `VError.fullStack()` in `error()`
-- [ ] Update `src/errors.ts` — `apiNotFoundWithName` → `VError` with `info: { name }`
-- [ ] Update `src/devices/SoundTouch/SoundTouchDevice.ts` — wrap throws and catch sites
+- [ ] Update `src/utils/FormattedLogger.ts` — traverse `.cause` chain using
+      `homebridge-lib`'s `formatError()` in `error()`
+- [ ] Update `src/devices/SoundTouch/SoundTouchDevice.ts` — add context to
+      throws and catch site
 - [ ] Update `src/devices/SoundTouch/api/api.ts` — wrap network error in `_req`
 - [ ] Update `src/platform.ts` — wrap both catch sites with device-name context
 - [ ] Update `src/accessories/SoundTouchSpeakerPlatformAccessory.ts` — polling catch
 - [ ] Update `src/accessories/services/SoundTouchSpeakerBrightnessCharacteristic.ts`
 - [ ] Update `src/accessories/services/SoundTouchSpeakerOnCharacteristic.ts`
 - [ ] Update `src/accessories/services/SoundTouchSpeakerInformationCharacteristic.ts`
-- [ ] Add/update `FormattedLogger` tests for VError chain output
-- [ ] Run `npm run knip` — confirm `verror` is not flagged as unused
+- [ ] Add/update `FormattedLogger` tests for cause chain output
 - [ ] `npm run typecheck && npm run lint && npm test`
 
 ## Verification
@@ -117,11 +136,12 @@ standard) adds three primitives we need:
 - [ ] `npm run lint`
 - [ ] `npm run build`
 - [ ] `npm test`
-- [ ] Confirm `VError.fullStack()` output appears in logs during `npm run watch`
-  (e.g. simulate a device unreachable by pointing config at a bad IP)
+- [ ] Confirm cause chain appears in logs during `npm run watch` — simulate
+      unreachable device (bad IP in config); expect `network request to /volume
+      failed\n  caused by: ECONNREFUSED …`
 
 ## PR / release notes
 
 - **PR title (Conventional Commit, becomes the release commit):**
-  `refactor: replace bare Error with VError for structured, chained errors`
+  `refactor: chain errors with native Error.cause and log full cause chain`
 - **Targets:** `dev`

--- a/.claude/skills/architect/plans/2026-06-20-verror-structured-errors.md
+++ b/.claude/skills/architect/plans/2026-06-20-verror-structured-errors.md
@@ -54,6 +54,7 @@ This plan addresses both with zero new dependencies:
 | 2026-06-21 | Level-aware error output in `Logger.error()`: DEBUG → full cause chain + stacks; others → top message + immediate cause | Users in verbose/debug mode need root-cause visibility; users in default INFO mode need a concise signal. Same call site, output determined by `requiredLogLevel`. | Separate `logger.verboseError()` method (leaks implementation detail into call sites); always-verbose (noisy for default users) |
 | 2026-06-21 | Introduce `ContextError extends Error` with `context: Record<string, string>` | Device name is already handled by `DeviceLogger` prefix. `ContextError` handles endpoint, room, operation — metadata that belongs with the error itself, not in the message string. `FormattedLogger` detects `instanceof ContextError` and renders context fields inline. | Interpolating everything into the message string (loses structure, can't filter/reformat); custom `info` map on all errors (requires touching more files) |
 | 2026-06-21 | `ContextError` lives in `src/errors.ts` alongside `apiNotFoundWithName` | One place for shared error primitives. | New file `src/utils/ContextError.ts` (unnecessary file for 10 lines) |
+| 2026-06-21 | `ContextError` constructor is `private`; exposes `static wrap(message, context, cause)` | Follows the repo-wide static factory convention (coding-conventions skill). `wrap()` eliminates the `{ cause: err }` options bag at every catch site and is the idiomatic creation path. `throw new ContextError(...)` remains acceptable only inside the class itself. | `new ContextError(...)` at all call sites (violates factory convention for complex-arg Error subclasses) |
 | 2026-06-21 | commit-type is `feat:` — minor release | `logLevel` config option is user-visible and expands capability. | `refactor:` (wrong — user-facing config change) |
 | 2026-06-21 | Use `homebridge-lib`'s `formatError()` per node in the cause chain | Already a runtime dep. Handles ECONNREFUSED, axios errors, plain Errors consistently. | Reimplementing formatError (duplication); `.stack` raw (verbose, unreadable for ECONNREFUSED) |
 
@@ -75,7 +76,8 @@ This plan addresses both with zero new dependencies:
 ```ts
 export class ContextError extends Error {
   readonly context: Record<string, string>;
-  constructor(
+
+  private constructor(
     message: string,
     context: Record<string, string>,
     options?: ErrorOptions
@@ -83,6 +85,14 @@ export class ContextError extends Error {
     super(message, options);
     this.name = 'ContextError';
     this.context = context;
+  }
+
+  static wrap(
+    message: string,
+    context: Record<string, string>,
+    cause: unknown
+  ): ContextError {
+    return new ContextError(message, context, { cause });
   }
 }
 
@@ -170,17 +180,20 @@ With:
 level: this.configuration.logLevel,
 ```
 
-#### Call sites — wrap errors with `Error.cause` and `ContextError`
+#### Call sites — wrap errors with `ContextError.wrap()`
+
+All catch sites use `ContextError.wrap(message, context, cause)` — never
+`new ContextError(...)` directly (that is private to the class).
 
 - `src/devices/SoundTouch/SoundTouchDevice.ts`
-  - `discoverAllAccessories` catch: `new ContextError('creating device', { ip: device.ip ?? '', name: device.name ?? '' }, { cause: e })`
-  - `fromConfiguredAccessory` throws: add room/name to existing message strings.
+  - `discoverAllAccessories` catch: `ContextError.wrap('creating device', { ip: device.ip ?? '', name: device.name ?? '' }, e)`
+  - `fromConfiguredAccessory` throws: add room/name to existing message strings (plain `Error`, no cause here).
 - `src/devices/SoundTouch/api/api.ts`
-  - `_req` catch: `throw new ContextError('network request failed', { endpoint }, { cause: err })`.
+  - `_req` catch: `throw ContextError.wrap('network request failed', { endpoint }, err)`.
 - `src/accessories/SoundTouchSpeakerPlatformAccessory.ts`
-  - Polling catch: `new ContextError('polling refresh', { device: this.accessory.displayName }, { cause: e as Error })`.
+  - Polling catch: `ContextError.wrap('polling refresh', { device: this.accessory.displayName }, e)`.
 - `src/platform.ts`
-  - `searchDevices` allSettled handler: `new ContextError('loading configured accessory', { name }, { cause: result.reason })`.
+  - `searchDevices` allSettled handler: `ContextError.wrap('loading configured accessory', { name }, result.reason)`.
   - `discoverDevices` catch sites: wrap with device name context.
 - `src/accessories/services/SoundTouchSpeakerBrightnessCharacteristic.ts`
   - Both catch blocks: log wrapped error before throwing `HapStatusError`.


### PR DESCRIPTION
## What & why

Architect plan for structured error chaining with fine-grained log control. See `.claude/skills/architect/plans/2026-06-20-verror-structured-errors.md`.

Two problems addressed together:

**Errors lose context** — polling failures log no device name, API failures lose the underlying cause. Fixed with `Error.cause` chaining and a new `ContextError` class (private constructor, `static wrap(message, context, cause)` factory) that carries typed context fields (`device`, `endpoint`, etc.) alongside the error.

**Logging is binary** — `verbose: boolean` only toggles DEBUG vs INFO. Fixed with a new `logLevel: 'debug' | 'info' | 'warn' | 'error'` config option under `global`. `verbose: true` stays as a deprecated alias.

**Level-aware error output** — at `debug`, `FormattedLogger.error()` shows the full cause chain, context fields, and abbreviated stacks. At `info`/`warn`/`error`, it shows the top message + immediate cause only. Same call site, verbosity follows `logLevel`.

Zero new dependencies. `ContextError.wrap()` follows the repo's static factory convention (see PR #102).

This is a `feat:` (minor release) because `logLevel` is a new user-visible config option.

## Verification

Docs-only change — no code or tests.