### PR TITLE
docs: document static factory method convention for class instantiation

### DIFF
--- a/.claude/skills/coding-conventions/SKILL.md
+++ b/.claude/skills/coding-conventions/SKILL.md
@@ -18,6 +18,53 @@ The canonical, language/tooling-level conventions for this repo. Domain skills
 (`homebridge-developer`, `soundtouch-api-expert`) and `architect` link here
 rather than restating this — keep style/build/test rules in this one place.
 
+## Class instantiation — static factory methods
+
+All new classes expose their creation through **named static factory methods**,
+not through direct `new ClassName(...)` at call sites. This is already the
+universal pattern in the codebase:
+
+| Class | Factory method(s) |
+| --- | --- |
+| `PlatformConfiguration` | `fromExternalConfiguration()` |
+| `DeviceConfiguration` | `fromAccessoryConfiguration()`, `create()`, `createForRoom()`, `createForIp()` |
+| `Logger` | `forHomebridgeLogger()` |
+| `DeviceLogger` | `fromLogger()` |
+| `SoundTouchDevice` | `fromConfiguredAccessory()`, `fromDiscoveredAccessory()` |
+| `SoundTouchSpeakerPlatformAccessory` | `createAccessory()` |
+
+**Rules:**
+
+- Every new class **must** expose at least one named static factory.
+- The constructor is **`private`** (or `protected` for classes designed to be
+  subclassed). Direct `new ClassName(...)` may only appear *inside* the class
+  itself — never at external call sites.
+- Factory names follow the existing vocabulary:
+  - `static fromX(x: X): ClassName` — when creating from a source object
+  - `static create(...): ClassName` — for general construction
+  - `static forX(...): ClassName` — for context-specific construction
+- **`Error` subclasses are a partial exception** — `throw new MyError(...)` is
+  idiomatic JS and acceptable at throw sites. Still provide a `static wrap()`
+  or `static create()` when the construction arguments are complex or repeated.
+
+**Example:**
+
+```ts
+export class SoundTouchZoneAccessory {
+  private constructor(
+    private readonly device: SoundTouchDevice,
+    private readonly slaves: SoundTouchDevice[],
+  ) {}
+
+  static create(props: {
+    device: SoundTouchDevice;
+    slaves: SoundTouchDevice[];
+  }): SoundTouchZoneAccessory {
+    return new SoundTouchZoneAccessory(props.device, props.slaves);
+  }
+}
+```
+
 ## TypeScript & ESM (do not skip)
 
 - `package.json` has `"type": "module"`; TypeScript emits ESM.

--- a/.claude/skills/coding-conventions/SKILL.md
+++ b/.claude/skills/coding-conventions/SKILL.md
@@ -30,6 +30,8 @@ rather than restating this — keep style/build/test rules in this one place.
   - [BDD test structure](#bdd-test-structure)
 - [Logging](#logging)
 - [Dependency management](#dependency-management)
+  - [Adding new packages](#adding-new-packages)
+  - [Updating existing packages](#updating-existing-packages)
 - [Definition of done](#definition-of-done)
 - [Pull requests](#pull-requests)
   - [Title](#title)
@@ -199,6 +201,35 @@ Log through the formatted logger (`src/utils/FormattedLogger.ts`) — `.debug`,
 ---
 
 ## Dependency management
+
+### Adding new packages
+
+**Do not `npm install` any new package without prior discussion.** This applies
+to both runtime and dev dependencies.
+
+Before suggesting a package:
+
+1. **Exhaust zero-dep alternatives first** — Node built-ins, packages already
+   installed, or a small custom implementation. The existing dep list covers a
+   lot: `homebridge-lib` (formatError, platform utilities), `axios` (HTTP),
+   `xml2js` (XML), `ws` (WebSocket), `homebridge` types. Reach for these before
+   reaching for npm.
+2. **Check transitive dependencies** — run `npm info <pkg> dependencies` and
+   `npm pack --dry-run <pkg>` to count what comes with it. A package that pulls
+   in ten transitive deps is ten packages to audit, maintain, and trust.
+3. **Flag it explicitly** — any package suggestion must state:
+   - The number of direct + transitive dependencies
+   - Whether those dependencies are themselves external (vs. bundled/native)
+   - Why no existing dep or built-in can serve the need
+4. **Prefer lean packages** — if a package is genuinely needed, a package with
+   zero or one dependency is strongly preferred over a feature-rich one with a
+   deep tree. A package with >5 transitive deps requires strong justification.
+
+The plans in `.claude/skills/architect/plans/` record dependency decisions in
+their **Decisions & findings** table — if a package was considered and rejected,
+note it there so it isn't re-investigated.
+
+### Updating existing packages
 
 Run `npm outdated` to check for stale packages. The "Wanted" column shows what
 satisfies the current semver range; "Latest" shows the newest release (may be a

--- a/.claude/skills/coding-conventions/SKILL.md
+++ b/.claude/skills/coding-conventions/SKILL.md
@@ -18,11 +18,49 @@ The canonical, language/tooling-level conventions for this repo. Domain skills
 (`homebridge-developer`, `soundtouch-api-expert`) and `architect` link here
 rather than restating this — keep style/build/test rules in this one place.
 
-## Class instantiation — static factory methods
+## Contents
+
+- [TypeScript code style](#typescript-code-style)
+  - [ESM & imports](#esm--imports)
+  - [Class instantiation — static factory methods](#class-instantiation--static-factory-methods)
+- [Toolchain](#toolchain)
+- [Testing](#testing)
+  - [Setup](#setup)
+  - [TDD workflow](#tdd-workflow)
+  - [BDD test structure](#bdd-test-structure)
+- [Logging](#logging)
+- [Dependency management](#dependency-management)
+- [Definition of done](#definition-of-done)
+- [Pull requests](#pull-requests)
+  - [Title](#title)
+  - [Description](#description)
+  - [No AI attribution](#no-ai-attribution)
+- [Scope](#scope)
+
+---
+
+## TypeScript code style
+
+### ESM & imports
+
+> **Do not skip — the most common footgun in this repo.**
+
+- `package.json` has `"type": "module"`; TypeScript emits ESM.
+- **Relative imports must include the `.js` extension**, even though the source
+  is `.ts`:
+  ```ts
+  import { SoundTouchDevice } from './devices/SoundTouch/SoundTouchDevice.js';
+  ```
+  Omitting `.js` compiles but **fails at runtime under Homebridge**.
+- Import package types/values **without** an extension:
+  `import { API, Service, Characteristic } from 'homebridge';`
+- Source lives in `src/`, compiles to `dist/`. Never edit `dist/`.
+
+### Class instantiation — static factory methods
 
 All new classes expose their creation through **named static factory methods**,
-not through direct `new ClassName(...)` at call sites. This is already the
-universal pattern in the codebase:
+not through direct `new ClassName(...)` at call sites. This is the universal
+pattern in the codebase:
 
 | Class | Factory method(s) |
 | --- | --- |
@@ -36,18 +74,15 @@ universal pattern in the codebase:
 **Rules:**
 
 - Every new class **must** expose at least one named static factory.
-- The constructor is **`private`** (or `protected` for classes designed to be
-  subclassed). Direct `new ClassName(...)` may only appear *inside* the class
-  itself — never at external call sites.
+- The constructor is **`private`** (or `protected` for abstract base classes).
+  Direct `new ClassName(...)` may only appear *inside* the class itself.
 - Factory names follow the existing vocabulary:
   - `static fromX(x: X): ClassName` — when creating from a source object
   - `static create(...): ClassName` — for general construction
   - `static forX(...): ClassName` — for context-specific construction
 - **`Error` subclasses are a partial exception** — `throw new MyError(...)` is
-  idiomatic JS and acceptable at throw sites. Still provide a `static wrap()`
-  or `static create()` when the construction arguments are complex or repeated.
-
-**Example:**
+  idiomatic JS and acceptable at throw sites. Still provide `static wrap()` or
+  `static create()` when construction arguments are complex or repeated.
 
 ```ts
 export class SoundTouchZoneAccessory {
@@ -65,19 +100,7 @@ export class SoundTouchZoneAccessory {
 }
 ```
 
-## TypeScript & ESM (do not skip)
-
-- `package.json` has `"type": "module"`; TypeScript emits ESM.
-- **Relative imports must include the `.js` extension**, even though the source
-  is `.ts`:
-  ```ts
-  import { SoundTouchDevice } from './devices/SoundTouch/SoundTouchDevice.js';
-  ```
-  Omitting `.js` compiles but **fails at runtime under Homebridge**. This is the
-  most common footgun in this repo.
-- Import package types/values **without** an extension:
-  `import { API, Service, Characteristic } from 'homebridge';`
-- Source lives in `src/`, compiles to `dist/`. Never edit `dist/`.
+---
 
 ## Toolchain
 
@@ -96,13 +119,17 @@ owns formatting — run `npm run format` to auto-write; don't hand-format agains
 it. Run `npm run knip` after deleting or moving code to catch newly unused
 exports, files, or dependencies.
 
+---
+
 ## Testing
+
+### Setup
 
 - Runner: **Jest + `@swc/jest`** (not ts-jest). Config: `jest.config.ts`.
 - Tests live in `__tests__/` directories **beside the code they cover** and match
   `*.test.ts` / `*.spec.ts`. `roots` is `<rootDir>/src`.
 - `moduleNameMapper` rewrites `^(\.{1,2}/.*)\.js$` → `$1` so the `.js` import
-  extensions (above) resolve in tests.
+  extensions resolve in tests.
 - Coverage is collected by default (`collectCoverage: true`).
 - Favor testing pure logic (config transforms, payload parsing) over framework
   wiring.
@@ -110,7 +137,7 @@ exports, files, or dependencies.
   `const enum` gotcha) is Homebridge-specific — see the **homebridge-developer**
   skill.
 
-## TDD workflow (red → green → refactor)
+### TDD workflow
 
 Write tests **before** the implementation for any new behaviour or bug fix:
 
@@ -124,7 +151,7 @@ Write tests **before** the implementation for any new behaviour or bug fix:
 For bug fixes, start by writing a test that reproduces the bug before touching
 production code.
 
-## BDD test structure
+### BDD test structure
 
 Structure tests so they read as a living specification. Use Jest's
 `describe`/`it` to express **what** the unit does, not how it does it.
@@ -136,15 +163,13 @@ describe('ClassName or function name')
     it('throws when Z')
 ```
 
-Rules:
 - `describe` labels name the **subject** (`'NowPlayingParser'`, `'#parsePreset'`).
 - `it` labels name **observable behaviour** in plain English: `'returns null when
-  the content item is missing'`, not `'handles missing content item'` or
-  `'test 3'`.
-- Nest a second `describe` for distinct scenarios or preconditions
-  (`'when the device is in standby'`).
+  the content item is missing'`, not `'handles missing content item'`.
+- Nest a second `describe` for distinct scenarios (`'when the device is in standby'`).
 - Structure each test as **Arrange → Act → Assert** with a blank line between
-  phases. Skip the "Arrange" block when setup is trivial (one-liner).
+  phases. Skip "Arrange" when setup is trivial (one-liner).
+- Use `it('...')`, never `test('...')`.
 
 ```ts
 describe('VolumeParser', () => {
@@ -164,31 +189,36 @@ describe('VolumeParser', () => {
 });
 ```
 
-Avoid `test('...')` — prefer `it('...')` so descriptions complete the sentence
-"it should …" naturally.
+---
 
 ## Logging
 
 Log through the formatted logger (`src/utils/FormattedLogger.ts`) — `.debug`,
-`.success`, `.error`. Never use `console.*`.
+`.info`, `.success`, `.warn`, `.error`. Never use `console.*`.
 
-## Dependency maintenance
+---
 
-Run `npm outdated` to check for stale packages. The "Wanted" column shows what satisfies the current semver range; "Latest" shows the newest release (may be a major bump).
+## Dependency management
+
+Run `npm outdated` to check for stale packages. The "Wanted" column shows what
+satisfies the current semver range; "Latest" shows the newest release (may be a
+major bump).
 
 **Safe updates (within semver range):**
 ```sh
 npm update          # brings all deps to their "Wanted" version
 ```
 
-**Major version bumps** require manually editing the version range in `package.json`, then running `npm install`. Always verify the toolchain passes (`npm run typecheck && npm run lint && npm test`) after any major bump.
+**Major version bumps** require manually editing the version range in
+`package.json`, then running `npm install`. Always verify the toolchain passes
+(`npm run typecheck && npm run lint && npm test`) after any major bump.
 
 **Known config update requirements after major bumps:**
 
 | Package | What to check |
 | --- | --- |
-| `knip` (v5→v6) | Update `"$schema"` in `knip.json` to `knip@6`. Knip v6 auto-discovers most deps/binaries that previously needed `ignoreDependencies`/`ignoreBinaries` entries — run `npm run knip` and remove any entries flagged as redundant hints. |
-| `typescript-eslint` (major) | If ESLint reports "multiple candidate TSConfigRootDirs", add `parserOptions: { tsconfigRootDir: import.meta.dirname }` to `eslint.config.js`. Also ensure `.claude/**` is in the `ignores` array so git worktrees under `.claude/worktrees/` are never linted. |
+| `knip` (v5→v6) | Update `"$schema"` in `knip.json` to `knip@6`. Knip v6 auto-discovers most deps/binaries — run `npm run knip` and remove any entries flagged as redundant hints. |
+| `typescript-eslint` (major) | If ESLint reports "multiple candidate TSConfigRootDirs", add `parserOptions: { tsconfigRootDir: import.meta.dirname }` to `eslint.config.js`. Also ensure `.claude/**` is in the `ignores` array. |
 | `eslint-config-prettier` (v9→v10) | No config changes required; drop-in replacement. |
 | `lint-staged` (major) | Check `engines.node` in `npm info lint-staged@<new>` matches runtime before installing. |
 
@@ -196,7 +226,10 @@ npm update          # brings all deps to their "Wanted" version
 ```sh
 npm audit
 ```
-A vulnerability scoped to `node_modules/npm/node_modules/...` is inside the npm CLI itself, not this package — it is not actionable here.
+A vulnerability scoped to `node_modules/npm/node_modules/...` is inside the npm
+CLI itself — not actionable here.
+
+---
 
 ## Definition of done
 
@@ -206,67 +239,55 @@ Before considering a code change complete, all three must be green:
 npm run typecheck && npm run lint && npm test
 ```
 
-## Pull requests
+---
 
-Feature PRs target `dev` and are **squash-merged**, so the **PR title becomes the
-released commit message**. A required "PR Title" check (commitlint) rejects a
-title that isn't a valid Conventional Commit. The branch/PR flow and which
-commit type to pick are owned by **architect**; the full release model lives in
-`CONTRIBUTING.md`. This skill covers how to *write* the title and description.
+## Pull requests
 
 ### Title
 
-- Format: `<type>: <imperative summary>` — same Conventional Commit grammar as
-  commit messages (`feat`, `fix`, `feat!` / `BREAKING CHANGE:`, and the
-  no-release types `chore`/`docs`/`ci`/`test`/`refactor`). The type drives the
-  release: `feat:` → minor, `fix:` → patch, `feat!:` → major, the rest → none.
-- **Concise and imperative.** Lower-case after the colon, no trailing period,
-  one line (~50–72 chars). Describe the change, not the files touched:
-  `feat: add volume control`, not `Added volume control to the speaker.`
+Feature PRs target `dev` and are **squash-merged** — the **PR title becomes the
+released commit message**. A required "PR Title" check (commitlint) rejects
+anything that isn't a valid Conventional Commit.
+
+- Format: `<type>: <imperative summary>`
+- Types and release impact: `feat:` → minor, `fix:` → patch, `feat!:` /
+  `BREAKING CHANGE:` footer → major, `chore`/`docs`/`ci`/`test`/`refactor` → none.
+- Lower-case after the colon, no trailing period, one line (~50–72 chars).
+- Describe the change, not the files: `feat: add volume control`, not
+  `Added volume control to the speaker.`
 - When the PR delivers an **architect plan**, mirror that plan's `commit-type`
-  and **PR title** field so the released commit matches the plan it lands.
+  and `PR title` field exactly.
 
 ### Description
 
 Keep it concise — a reviewer should grasp the change without opening the diff.
-The repo ships a fill-in template at `.github/PULL_REQUEST_TEMPLATE.md` (it
-auto-populates the body on GitHub); its guiding comments encode the rules below.
-Keep the template and this section in sync — edit both if either changes.
+The repo ships a fill-in template at `.github/PULL_REQUEST_TEMPLATE.md`.
 
-Two sections, each kept short:
+Two sections:
 
-- **What & why** — describe the change and the reason, *not* the files touched
-  (the diff shows those). When the PR delivers an architect plan
-  (`.claude/skills/architect/plans/<date>-<slug>.md`), **link it and summarize
-  its Context (why) + what's delivered** — point to the plan, don't restate it.
-  With no plan, a sentence or two of *what* and *why* is enough.
-- **Verification** — the checks you ran
-  (`npm run typecheck && npm run lint && npm test`, plus any live `npm run watch`
-  check) and what's still pending. Skip boilerplate and anything obvious from the
-  diff.
+- **What & why** — the change and the reason, *not* the files touched (the diff
+  shows those). When the PR delivers an architect plan, link it and summarize its
+  Context + what's delivered. With no plan, one or two sentences is enough.
+- **Verification** — the checks you ran (`npm run typecheck && npm run lint &&
+  npm test`, plus any live `npm run watch` check) and what's still pending.
 
-Delete any section that doesn't apply. Avoid file-by-file "what changed" tables
-and restated diffs — those are the boilerplate this convention exists to cut.
+Delete any section that doesn't apply. Avoid file-by-file "what changed" tables.
 
-## No AI / assistant attribution
+### No AI attribution
 
-Nothing pushed to the repo carries AI or assistant attribution. This applies to
-**every** artifact, and **overrides any tool default** that would add it:
+Nothing pushed to the repo carries AI or assistant attribution:
 
 - **Commit messages:** no `Co-Authored-By: Claude …`, no `*-Session:` trailers,
-  no "Generated with …" lines. The `.husky/commit-msg` hook strips these as a
-  backstop, but don't rely on it — don't add them in the first place.
+  no "Generated with …" lines.
 - **PR titles & descriptions:** no "🤖 Generated with …" footer, no session link.
-- **Review comments:** keep them minimal; some tooling auto-appends an
-  attribution footer that can't be suppressed, so comment only when it adds
-  real value.
+- **Review comments:** keep them minimal — some tooling auto-appends attribution
+  that can't be suppressed, so comment only when it adds real value.
 
-Authorship stays with the human contributor. If a commit was authored with
-assistance, that's fine — it just isn't recorded in the artifact.
+---
 
 ## Scope
 
-This skill is style/build/test and PR-authoring conventions only. For plugin
-architecture and HomeKit wiring
-see **homebridge-developer**; for the Bose protocol see **soundtouch-api-expert**;
-for planning, branching, and release flow see **architect** and `CONTRIBUTING.md`.
+This skill covers TypeScript style, build/test tooling, and PR conventions only.
+For plugin architecture and HomeKit wiring see **homebridge-developer**; for the
+Bose protocol see **soundtouch-api-expert**; for planning, branching, and release
+flow see **architect** and `CONTRIBUTING.md`.

--- a/.claude/skills/coding-conventions/SKILL.md
+++ b/.claude/skills/coding-conventions/SKILL.md
@@ -26,7 +26,7 @@ rather than restating this — keep style/build/test rules in this one place.
 - [Toolchain](#toolchain)
 - [Testing](#testing)
   - [Setup](#setup)
-  - [TDD workflow](#tdd-workflow)
+  - [TDD workflow — red → green → refactor](#tdd-workflow--red--green--refactor)
   - [BDD test structure](#bdd-test-structure)
 - [Logging](#logging)
 - [Dependency management](#dependency-management)
@@ -139,7 +139,7 @@ exports, files, or dependencies.
   `const enum` gotcha) is Homebridge-specific — see the **homebridge-developer**
   skill.
 
-### TDD workflow
+### TDD workflow — red → green → refactor
 
 Write tests **before** the implementation for any new behaviour or bug fix:
 


### PR DESCRIPTION
## What & why

Documents the static factory method convention in the `coding-conventions` skill, plus adds a dependency-management convention (no new packages without discussion) and reorganizes the skill with a table of contents and logical section groupings.

The static factory pattern is already universally applied across the codebase but was undocumented. This makes it explicit so new classes follow the same shape without having to infer it from existing code. Key rules:
- All new classes expose at least one named static factory; constructor is `private` (or `protected` for subclasses)
- Direct `new ClassName(...)` only appears inside the class itself
- Error subclasses: `throw new MyError(...)` acceptable, but provide `static wrap()` when construction args are complex or repeated
- No new packages without prior discussion; prefer zero-dep alternatives; flag transitive dep count when a package is genuinely needed

## Verification

Docs-only change — no code or tests.