### PR TITLE
docs: update roadmap after merging PRs #100–103

### DIFF
--- a/.claude/skills/technical-lead/ROADMAP.md
+++ b/.claude/skills/technical-lead/ROADMAP.md
@@ -1,6 +1,6 @@
 # Technical Roadmap
 
-Last updated: 2026-06-20
+Last updated: 2026-06-21
 
 This file gives the delivery order and dependency chain across all planned
 features. The individual plan files contain the detail; this file answers
@@ -35,7 +35,7 @@ flowchart TD
     PWA1Node --> PWA3Node
 ```
 
-## Current state (2026-06-20)
+## Current state (2026-06-21)
 
 - **Beta (v0.3.0-beta.1):** [05] Integration test harness — **#58**. Fake HTTP server + HAP stub; polling neutralised with fake timers.
 - **Beta (v0.3.0-beta.1):** [06] Polling lifecycle — **#65**. Polling stoppable on unregister/shutdown; `pollingInterval` config field.
@@ -44,7 +44,10 @@ flowchart TD
 - **Beta (v0.3.0-beta.1):** [01] Accessory type — **#72**. `accessoryType: 'switch' | 'lightbulb'` threaded through config → accessory; orphan-service pruning on type change.
 - **Beta (v0.3.0-beta.1):** [02] Volume — Lightbulb path — **#86** (feat), **#91** (race fix). Brightness 0–100 maps to volume; 0 = power off; non-blocking settle.
 - **Cancelled:** [02] Volume — Switch path. **PR #62 was merged then reverted (#70)** — binary `On` only; volume requires 0–100 range.
-- **Next (unblocked):** `prefer-it-over-test` sweep — mechanical `test()` → `it()` rename across ~21 test files. Small, no production code.
+- **Dev:** `prefer-it-over-test` sweep — **#98**. Mechanical `test()` → `it()` rename across all remaining test files. No production code, no release.
+- **Dev (planned):** Static factory enforcement — **#103 (plan)**. Private constructors on all classes + `API.create()` factory. `refactor:` → no release.
+- **Dev (planned):** Structured errors + logLevel — **#100 (plan)**. `ContextError`, native `Error.cause`, `logLevel` config, level-aware `FormattedLogger.error()`. `feat:` → minor.
+- **Dev (planned):** Speaker zones — **#101 (plan)**. `zones` config array, `SoundTouchZoneAccessory`, zone API activation. `feat:` → minor.
 - **Next (unblocked):** Spike C Part 2 — real hardware capture session. Unblocks [07] WebSocket push (plan 06 ✅, Spike C Part 1 ✅).
 - **Blocked:** [03] Source selection (TV-vs-Switch spike), [04] PWA all phases (spikes A/B).
 
@@ -58,7 +61,10 @@ flowchart TD
 | 2.6 | **FirmwareRevision characteristic** | `test/firmware-revision-coverage` | ✅ beta v0.3.0-beta.1 (#83, #85) | SCM `softwareVersion` component correctly sourced and published. |
 | 3 | **[01] Accessory type** | `feat/accessory-type` | ✅ beta v0.3.0-beta.1 (#72) | `accessoryType: 'switch' \| 'lightbulb'` threaded through config → accessory; orphan-service pruning on type change. `feat:` → minor. |
 | 4 | **[02] Volume — Lightbulb path** | `feat/volume-control` | ✅ beta v0.3.0-beta.1 (#86, #91) | Brightness 0–100 maps to volume; 0 = power off; non-blocking settle for the `On`/`Brightness` race. |
-| 4.5 | **prefer-it-over-test sweep** | `test/prefer-it-over-test` | 🟢 Next (unblocked) | Mechanical `test()` → `it()` rename across ~21 test files. Small, no production code, no release. |
+| 4.5 | **prefer-it-over-test sweep** | `test/prefer-it-over-test` | ✅ dev (#98) | Mechanical `test()` → `it()` rename across all remaining test files. No production code, no release. |
+| 4.6 | **Static factory enforcement** | `refactor/static-factory-enforcement` | 🟢 Next (unblocked) | Private constructors on all ten classes + `API.create()` factory. `refactor:` → no release. Small, purely mechanical, no new tests. |
+| 4.7 | **Structured errors + logLevel** | `feat/structured-errors-logging` | 🟢 Next (unblocked) | `ContextError` + native `Error.cause` chaining; `logLevel` config replaces `verbose: boolean`; level-aware `FormattedLogger.error()`. `feat:` → minor. No new deps. |
+| 4.8 | **Speaker zones** | `feat/speaker-zones` | 🟢 Next (unblocked) | `zones` config array; `SoundTouchZoneAccessory`; zone API activation at startup sync. `feat:` → minor. Zone API already implemented in `api/zone.ts`. |
 | 5 | **[07] WebSocket push (gabbo)** | `feat/websocket-push` | 🟡 Spike C Part 2 needed | Event-driven refresh via the gabbo channel (port 8080), **augmenting** polling. Spike C Part 2 needs real hardware (device available). Phased: P1 connection+lifecycle, P2 per-event mapping, P3 tune polling + edges. |
 | 6 | **[03] Source selection** | `feat/source-selection` | 🔴 Blocked (spike) | Independent of 01/02. Blocked on a **spike** (verify Television+InputSource on a real device; choose TV path vs per-source Switch fallback). Cannot be committed until the spike resolves the architecture choice. |
 | 7 | **[04] PWA — Phase 1** | `feat/pwa` | 🔴 Blocked (spike A) | Architecturally separate (new `web/` workspace + embedded HTTP server). Blocked on **spike A** (reverse-engineer the hotspot provisioning HTTP API at `http://192.0.2.1`). Phase 1 must ship before phases 2 and 3 (it creates the web scaffold and embedded server). |
@@ -80,7 +86,10 @@ below.
 | **[06] Polling lifecycle** | Small–Medium | Modifies existing platform + accessory lifecycle (retain wrappers, stop on unregister/shutdown) and threads two config fields; async lifecycle reasoning + a couple of tests | ✅ beta v0.3.0-beta.1 |
 | **[01] Accessory type** | Heavy | Config threading through `DeviceConfiguration`, branching the hardcoded Switch in `createAccessory`, and orphan-service pruning on type change | ✅ beta v0.3.0-beta.1 |
 | **[02] Volume — Lightbulb path** | Small–Medium | `SoundTouchSpeakerBrightnessCharacteristic` + power/volume race fix; `On`/`Brightness` ordering needs careful handling | ✅ beta v0.3.0-beta.1 |
-| **prefer-it-over-test sweep** | Small | Pure mechanical rename, no production code, no iteration risk | 🟢 Next. |
+| **prefer-it-over-test sweep** | Small | Pure mechanical rename, no production code, no iteration risk | ✅ dev (#98) |
+| **Static factory enforcement** | Small | Mechanical: add `private` to 10 constructors, add `API.create()`, update 3 test files. Typecheck is the gate — either it compiles or it doesn't. | 🟢 Next. One sitting, likely half a session. |
+| **Structured errors + logLevel** | Medium | New `ContextError` class + `logLevel` config option threaded through `ExternalPlatformConfig` → `PlatformConfiguration` → `platform.ts`; `FormattedLogger.error()` rewrite for cause-chain traversal. TDD on `ContextError` and the formatter is the main loop. | 🟢 Next. Fits one session. |
+| **Speaker zones** | Heavy | New `ZoneConfig` type + config schema update; `zones` threaded through `PlatformConfiguration`; `SoundTouchZoneAccessory` + `SoundTouchZoneOnCharacteristic`; startup `getZone()` sync per primary; zone set/dissolve via `setZone`/`removeZoneSlave`. Multiple new classes + config schema + integration path. | 🟢 Next. Plan a full session. |
 | **[07] WebSocket push — Phase 1** | Heavy (est.) | New stateful per-device connection (connect/parse/reconnect/teardown), a new `ws`-backed fake-gabbo harness, and async lifecycle threaded through `platform.ts`/accessory; async timing + reconnect is high iteration risk | Plan a full session. Re-estimate after Spike C. Phases 2–3 are Medium. |
 | **[03] Source selection** | TBD (blocked) | Estimate after the TV-vs-Switch spike resolves the architecture | Re-estimate once unblocked. |
 | **[04] PWA — Phase 1–3** | TBD (blocked) | New `web/` workspace + embedded `src/server/`; estimate after spike A | Each phase is its own session at minimum. |
@@ -99,6 +108,7 @@ When a unit ships, record actual-vs-estimate here so future estimates sharpen.
 | 2026-06-20 | [05] Integration test harness | Medium | Medium–Heavy | HTTP fake server was trivial as predicted, but two unforeseen drivers pushed it up: the manual homebridge mock provides no Service/Characteristic (HAP stub written from scratch), and polling is hardcoded on (neutralised with fake timers). Lesson: when a test exercises framework wiring, budget for stubbing the framework surface, not just the protocol. |
 | 2026-06-20 | [01] Accessory type | Heavy | Heavy | Full session as estimated. Config threading + orphan pruning touched many files; pruning logic needed extra iteration. |
 | 2026-06-20 | [02] Volume — Lightbulb path | Small–Medium | Small–Medium | Landed as estimated. Race fix was the main loop as predicted; the `On`/`Brightness` ordering required a follow-up fix PR (#91). |
+| 2026-06-21 | prefer-it-over-test sweep | Small | Small | Landed as estimated. Pure mechanical rename, no iteration needed. |
 
 ## Spikes (blockers)
 


### PR DESCRIPTION
## What & why

Roadmap update after merging PRs #100–103:

- Mark `prefer-it-over-test` done (#98)
- Slot the three new implementation plans into the delivery order:
  - 4.6 Static factory enforcement (`refactor:`, Small) — private constructors + `API.create()`
  - 4.7 Structured errors + logLevel (`feat:`, Medium) — `ContextError`, cause chaining, `logLevel` config
  - 4.8 Speaker zones (`feat:`, Heavy) — `zones` config array, `SoundTouchZoneAccessory`
- Add session cost estimates and calibration row for the new plans

## Verification

Docs-only change — no code or tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_011pHXd7DtLXVpEQrAT2kMPE)_