### PR TITLE
docs: update release flow — dev → beta and dev → latest are both valid promotion paths

### DIFF
--- a/.claude/skills/release-manager/SKILL.md
+++ b/.claude/skills/release-manager/SKILL.md
@@ -2,7 +2,7 @@
 name: release-manager
 description: >-
   Pre-release gate for the homebridge-soundtouchspeaker plugin. Use before
-  promoting dev→beta or beta→latest, when asked to "check if we're ready to
+  promoting dev→beta or dev→latest, when asked to "check if we're ready to
   release", "run release checks", or "is the branch releasable". Also use when
   the user asks whether the README, config schema, or docs are accurate and
   up to date. Runs the full checklist — tests, build, lint, README/schema
@@ -22,10 +22,13 @@ takes over.
 ## Release flow recap
 
 ```
-feature → dev (squash merge) → beta (regular merge, @beta on npm) → latest (regular merge, @latest on npm)
+feature → dev (squash merge) → beta (regular merge, @beta on npm)
+feature → dev (squash merge) → latest (regular merge, @latest on npm)
 ```
 
-You run this skill before the `dev → beta` or `beta → latest` promotion PR.
+Feature work lands in `dev`. From `dev` you promote to `beta` for pre-release
+testing, or directly to `latest` for a stable release. Run this skill before
+either `dev → beta` or `dev → latest` promotion PR.
 
 ---
 
@@ -102,7 +105,7 @@ To find what's implemented, check:
 ### 7. Conventional commits on the branch
 
 Identify the merge base between the current branch and its target
-(`dev`→`beta` target is `beta`; `beta`→`latest` target is `latest`):
+(`dev`→`beta` target is `beta`; `dev`→`latest` target is `latest`):
 
 ```bash
 git log --oneline $(git merge-base HEAD origin/<target>)..HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,8 @@ npm run watch    # build, npm link, and reload on change for live testing
 
 ## Branching model
 
-The release pipeline flows **`latest` → `dev` → `beta` → `latest`**.
+Feature work lands in `dev`. From `dev` you promote to `beta` for pre-release
+testing or directly to `latest` for a stable release.
 
 | Branch           | Purpose                              | On push                                  |
 | ---------------- | ------------------------------------ | ---------------------------------------- |
@@ -31,11 +32,13 @@ Typical cycle:
 1. `dev` is cut from `latest` and tracks the next release.
 2. Branch feature work off `dev` and open a pull request **into `dev`**. CI
    lints, builds, and tests it.
-3. Promote `dev` → `beta`. Merging publishes a pre-release to npm `@beta`.
-4. Once the pre-release is proven, promote `beta` → `latest`. Merging
-   publishes the stable release to npm `@latest`.
+3. **Promote `dev` → `beta`** — merging publishes a pre-release to npm `@beta`
+   so the change can be verified on a real device before going stable.
+4. **Promote `dev` → `latest`** — merging publishes the stable release to npm
+   `@latest`. Run this after beta has been verified (or for doc/CI-only changes
+   that don't need beta testing).
 
-> Use a regular merge (not squash) for the `dev → beta` and `beta → latest`
+> Use a regular merge (not squash) for `dev → beta` and `dev → latest`
 > promotions so release tags stay reachable. Feature PRs into `dev` are
 > squash-merged.
 


### PR DESCRIPTION
## Summary

- Updates CONTRIBUTING.md to document that `dev` promotes to either `beta` (pre-release testing) or `latest` (stable) directly — not the previous linear `dev → beta → latest` flow
- Updates the release-manager skill to match: description and flow recap now say `dev → beta` and `dev → latest`; the conventional-commits check target references are corrected

## Test plan

- [ ] Review the updated CONTRIBUTING.md branching model section
- [ ] Review the updated release-manager SKILL.md