### PR TITLE
fix: escape XML special chars in fake-soundtouch-server error response

### DIFF
--- a/src/__integration__/helpers/fake-soundtouch-server.ts
+++ b/src/__integration__/helpers/fake-soundtouch-server.ts
@@ -93,7 +93,7 @@ export class FakeSoundTouchServer {
       if (xml === undefined) {
         res.writeHead(404, { 'content-type': 'application/xml' });
         res.end(
-          `<errors><error value="404">no canned response for ${path}</error></errors>`
+          `<errors><error value="404">no canned response for ${path.replace(/[<>&"]/g, (c) => `&#${c.charCodeAt(0)};`)}</error></errors>`
         );
         return;
       }


### PR DESCRIPTION
## Summary

- Escapes `< > & "` in the 404 error body of `FakeSoundTouchServer` to silence a CodeQL reflected-XSS alert flagged on PR #109
- The server is test-only (in-process, bound to `127.0.0.1:0`) so there is no real attack surface, but the fix is a one-liner and keeps the code technically correct

## Test plan

- [ ] Integration tests pass (`npm test`)
- [ ] CodeQL alert resolves on next scan