### PR TITLE
docs: housekeeping — fix CLAUDE.md branching and expand README config examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ git fetch origin dev
 git checkout -b <type>/<slug> origin/dev
 ```
 
-`main` is release-only and is never worked on directly.
+The release branches (`latest` and `beta`) are managed by semantic-release and are never worked on directly.
 
 ## Use the skills
 
@@ -29,7 +29,7 @@ skill **before** acting — don't rely on memory for these:
   and how it maps to `src/devices/SoundTouch/api/`.
 - **architect** (`/architect`) — plan and track a new feature; owns the
   branching/release flow (conventional commits, semantic-release
-  `latest`→`dev`→`beta`). See also `CONTRIBUTING.md`.
+  `dev`→`beta` and `dev`→`latest`). See also `CONTRIBUTING.md`.
 - **technical-lead** — surveys the roadmap and plans, identifies the next
   unblocked item, resolves/surfaces blockers, and produces engineering briefs.
   Can brief multiple engineers in parallel when work is independent.

--- a/README.md
+++ b/README.md
@@ -27,55 +27,66 @@ hb-service add homebridge-soundtouchspeaker
 hb-service add homebridge-soundtouchspeaker@beta
 ```
 ## Configuration
-Example `config.json` to discover all SoundTouch accessories
+
+Discover all SoundTouch speakers on the network automatically:
 
 ```json
 {
     "platform": "SoundTouchHomebridgePlugin",
-    "discoverAllAccessories": true
+    "discoverAllAccessories": true,
+    "global": {
+        "accessoryType": "lightbulb"
+    }
 }
 ```
 
-Example `config.json` to register a SoundTouch accessory using the speaker name from the Bose Soundtouch app:
+Register specific speakers by room name (as set in the Bose app):
 
 ```json
 {
     "platform": "SoundTouchHomebridgePlugin",
-    "discoverAllAccessories": false,
     "accessories": [
         {
             "name": "Kitchen Speaker",
-            "room": "Kitchen"
+            "room": "Kitchen",
+            "accessoryType": "lightbulb"
         }
     ]
 }
 ```
 
-Example `config.json` to register a SoundTouch accessory using the ip address of the speaker:
+Register speakers by IP address:
 
 ```json
 {
     "platform": "SoundTouchHomebridgePlugin",
-    "discoverAllAccessories": false,
     "accessories": [
         {
             "name": "Kitchen Speaker",
-            "ip": "<ip>"
+            "ip": "192.168.1.100",
+            "accessoryType": "lightbulb"
+        },
+        {
+            "name": "Living Room Speaker",
+            "ip": "192.168.1.101"
         }
     ]
 }
 ```
 
-Example `config.json` for multiple speakers:
+Mix of IP and room, with global defaults:
 
 ```json
 {
     "platform": "SoundTouchHomebridgePlugin",
-    "discoverAllAccessories": false,
+    "global": {
+        "accessoryType": "lightbulb",
+        "pollingInterval": 5000
+    },
     "accessories": [
         {
             "name": "Kitchen Speaker",
-            "ip": "<ip>"
+            "ip": "192.168.1.100"
         },
         {
             "name": "Living Room Speaker",


### PR DESCRIPTION
## What & why

Two housekeeping fixes caught during a docs review:

**CLAUDE.md** — removed the incorrect `main` branch reference (no such branch exists) and corrected the release flow from `latest→dev→beta` to the actual `dev→beta` / `dev→latest` promotion paths.

**README** — config examples were missing `accessoryType` and `global` block, both of which shipped in v0.3.0. Rewrote the four examples to show realistic configurations including `accessoryType: "lightbulb"`, `global` defaults, and `pollingInterval`. Replaced the placeholder `<ip>` with a realistic example address.

## Verification

- [x] `npm run typecheck && npm run lint && npm test` green (docs-only change, no code touched)