### PR TITLE
docs: plan housekeeping — disabled flag, roadmap resequence, plan closure sweep

### DIFF
--- a/.claude/skills/architect/plans/2026-06-20-websocket-push.md
+++ b/.claude/skills/architect/plans/2026-06-20-websocket-push.md
@@ -1,6 +1,6 @@
 ---
 feature: WebSocket push (gabbo) — event-driven characteristic refresh, augmenting HTTP polling
-status: planned # planned | in-progress | done | cancelled
+status: blocked # planned | in-progress | done | cancelled | blocked
 date: 2026-06-20
 branch: feat/websocket-push
 commit-type: feat
@@ -40,6 +40,7 @@ channel's real-device behaviour is confirmed.
 | 2026-06-20 | **Decision:** sequence after plan 06 (polling lifecycle); serialise, don't parallelise | The WS connection has the same lifecycle as the polling loop — open on `init`, tear down on unregister/`shutdown`. Plan 06 builds exactly that (retain wrappers in a `Map`, stop on unregister/shutdown). WS reuses it. Both touch `SoundTouchSpeakerPlatformAccessory.ts` + `platform.ts`, so they **must** serialise. Plan 06 also makes polling configurable, which is what turns polling into the relaxed fallback. | Parallel with plan 06 (guaranteed merge conflicts on shared lifecycle files); before plan 06 (would build connection-lifecycle twice) |
 | 2026-06-20 | **Decision (this session):** research/docs only — no probe or harness code yet | User directive. Record the spike definition, findings, and rollout plan; defer building the probe script and fake-gabbo harness until the spike is scheduled (and ideally a real device is available). | Building the Part-1 harness now (premature given no real-device validation lined up) |
 | 2026-06-20 | **Open (Spike C):** real-device behaviour is unverified | Heartbeat/idle cadence, socket behaviour on standby/power-off, reconnect/backoff semantics, and whether real frames match the v1.1 reference are all undocumented. These shape the reconnect strategy and the fallback interval. Must be answered before implementation. | Building on documented assumptions alone (higher risk of a reconnect-storm or missed-event bug) |
+| 2026-06-21 | **Blocked:** waiting on `disabled` flag and structured-errors/logLevel to ship first | User wants easier testing setup before validating WebSocket behaviour — disable speakers cleanly and read logs clearly during the real-device capture session (Spike C Part 2). | Starting implementation now — testing the WebSocket path is harder without the prerequisites. |
 
 ## If cancelled
 

--- a/.claude/skills/architect/plans/2026-06-21-disabled-flag.md
+++ b/.claude/skills/architect/plans/2026-06-21-disabled-flag.md
@@ -1,0 +1,77 @@
+---
+feature: disabled flag — unregister a speaker from Homebridge without removing its config
+status: planned
+date: 2026-06-21
+branch: feat/disabled-flag
+commit-type: feat
+---
+
+# Disabled flag
+
+## Context
+
+During local testing it's useful to temporarily remove a speaker from HomeKit
+without deleting its config entry. A `disabled: true` flag per-accessory
+achieves this: when set, `discoverDevices()` skips registration entirely and
+unregisters any cached accessory for that device. Flip it back to `false`, save
+in the Homebridge UI, and the speaker reappears.
+
+State is durable — `disabled` lives in `config.json` and survives restarts. The
+Homebridge Plugin Settings UI checkbox is the "button" — no new HomeKit
+characteristic is needed.
+
+Prioritised before [07] WebSocket push so the user can easily toggle a speaker
+off while testing the WebSocket path (Spike C Part 2).
+
+## Decisions & findings
+
+| Date | Decision / finding | Rationale / evidence | Alternatives rejected |
+| --- | --- | --- | --- |
+| 2026-06-21 | Unregister the accessory (remove from HomeKit) rather than faking `SERVICE_COMMUNICATION_FAILURE` | User wants a clean absent-accessory scenario, not an unreachable-device scenario | Returning `SERVICE_COMMUNICATION_FAILURE` on all gets/sets — wrong semantics; accessory still shows in Home |
+| 2026-06-21 | Gate in `discoverDevices()` in `platform.ts` | Discovery is the single place that registers/unregisters accessories; no characteristic-level changes needed | Per-characteristic guard — wrong layer, accessory stays in HomeKit |
+| 2026-06-21 | Per-accessory flag only (not global) | Disabling all speakers at once is not a useful test scenario | Global flag — too blunt for targeted testing |
+| 2026-06-21 | Use `unregisterPlatformAccessories` for cached accessories of disabled devices | Keeps stale-pruning logic consistent with existing pattern in `discoverDevices()` | Leaving the cached accessory in place — leaves a ghost in the Home app |
+| 2026-06-21 | State lives in config.json (not a runtime toggle) | Homebridge config is the right persistence layer; survives restarts without extra storage | In-memory toggle — lost on restart; separate state file — unnecessary complexity |
+
+## If cancelled
+
+> Only fill this in when `status: cancelled`. Leave empty otherwise.
+
+## Affected areas
+
+- `src/ExternalPlatformConfig.ts` — add `disabled?: boolean` to `AccessoryConfig`
+- `src/PlatformConfiguration.ts` — verify `disabled` flows through `flattenAccessoryConfiguration` (it should since it's on `AccessoryConfig`); add a targeted test
+- `src/platform.ts` — in `discoverDevices()`, when a device config has `disabled: true`: call `unregisterPlatformAccessories` if a cached accessory exists for that UUID, then `continue` to skip registration
+- `config.schema.json` — add `disabled` boolean to the per-accessory section with a note that it removes the speaker from HomeKit until re-enabled
+- `src/__tests__/PlatformConfiguration.test.ts` — cover `disabled` propagation
+- `src/__tests__/platform.test.ts` — cover the skip-and-unregister branch
+
+## Conventions for this change
+
+- **Commit type:** `feat:` → minor release
+- **Config schema touched:** yes — `config.schema.json`, `ExternalPlatformConfig.ts`, `PlatformConfiguration.ts`, and their tests
+- **Tests to add/update:**
+  - `src/__tests__/PlatformConfiguration.test.ts` — `disabled` propagation
+  - `src/__tests__/platform.test.ts` — disabled device is skipped; cached accessory for a disabled device is unregistered
+- **Target branch:** `dev`
+
+## Implementation checklist
+
+- [ ] Add `disabled?: boolean` to `AccessoryConfig` in `src/ExternalPlatformConfig.ts`
+- [ ] Verify `disabled` flows through `flattenAccessoryConfiguration`; add a targeted `PlatformConfiguration` test
+- [ ] In `platform.ts` `discoverDevices()`: when `device.disabled === true`, call `unregisterPlatformAccessories` if a cached accessory exists, then `continue`
+- [ ] Update `config.schema.json` — `disabled` boolean in per-accessory section with description
+- [ ] Add `platform.ts` tests for the disabled skip-and-unregister path
+
+## Verification
+
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] `npm test`
+- [ ] `npm run watch` — set `disabled: true` for one speaker in Homebridge UI, save → confirm accessory disappears from Home app; flip back → confirm it reappears
+
+## PR / release notes
+
+- **PR title (Conventional Commit, becomes the release commit):**
+  `feat: add disabled flag to unregister a speaker from HomeKit without removing config`
+- **Targets:** `dev`

--- a/.claude/skills/architect/plans/done/2026-06-19-accessory-type-switch-or-lightbulb.md
+++ b/.claude/skills/architect/plans/done/2026-06-19-accessory-type-switch-or-lightbulb.md
@@ -1,6 +1,6 @@
 ---
 feature: Configurable accessory type — Switch or Lightbulb
-status: beta # v0.3.0-beta.1 — feat: let each speaker be a Switch or a Lightbulb accessory (#72)
+status: done
 date: 2026-06-19
 branch: feat/accessory-type
 commit-type: feat

--- a/.claude/skills/architect/plans/done/2026-06-19-accessory-type-switch-or-lightbulb.md
+++ b/.claude/skills/architect/plans/done/2026-06-19-accessory-type-switch-or-lightbulb.md
@@ -1,6 +1,6 @@
 ---
 feature: Configurable accessory type — Switch or Lightbulb
-status: done
+status: done # 2026-06-21
 date: 2026-06-19
 branch: feat/accessory-type
 commit-type: feat

--- a/.claude/skills/architect/plans/done/2026-06-19-volume-control.md
+++ b/.claude/skills/architect/plans/done/2026-06-19-volume-control.md
@@ -1,6 +1,6 @@
 ---
 feature: Volume control — Lightbulb Brightness (Lightbulb mode)
-status: beta # v0.3.0-beta.1 — feat: add volume control via Lightbulb brightness (#86); fix: race (#91)
+status: done
 date: 2026-06-19
 updated: 2026-06-20
 branch: feat/lightbulb-brightness-volume

--- a/.claude/skills/architect/plans/done/2026-06-19-volume-control.md
+++ b/.claude/skills/architect/plans/done/2026-06-19-volume-control.md
@@ -1,6 +1,6 @@
 ---
 feature: Volume control — Lightbulb Brightness (Lightbulb mode)
-status: done
+status: done # 2026-06-21
 date: 2026-06-19
 updated: 2026-06-20
 branch: feat/lightbulb-brightness-volume

--- a/.claude/skills/architect/plans/done/2026-06-20-firmware-revision-characteristic.md
+++ b/.claude/skills/architect/plans/done/2026-06-20-firmware-revision-characteristic.md
@@ -1,6 +1,6 @@
 ---
 feature: Publish firmware version as FirmwareRevision characteristic
-status: done
+status: done # 2026-06-21
 date: 2026-06-20
 branch: test/firmware-revision-coverage
 commit-type: test

--- a/.claude/skills/architect/plans/done/2026-06-20-firmware-revision-characteristic.md
+++ b/.claude/skills/architect/plans/done/2026-06-20-firmware-revision-characteristic.md
@@ -1,6 +1,6 @@
 ---
 feature: Publish firmware version as FirmwareRevision characteristic
-status: beta # v0.3.0-beta.1 — fix: use SCM component softwareVersion for FirmwareRevision (#85); test: (#83)
+status: done
 date: 2026-06-20
 branch: test/firmware-revision-coverage
 commit-type: test

--- a/.claude/skills/architect/plans/done/2026-06-20-integration-test-harness.md
+++ b/.claude/skills/architect/plans/done/2026-06-20-integration-test-harness.md
@@ -1,6 +1,6 @@
 ---
 feature: Integration test harness for end-to-end plugin coverage
-status: done
+status: done # 2026-06-21
 date: 2026-06-20
 branch: test/integration-harness
 commit-type: test

--- a/.claude/skills/architect/plans/done/2026-06-20-integration-test-harness.md
+++ b/.claude/skills/architect/plans/done/2026-06-20-integration-test-harness.md
@@ -1,6 +1,6 @@
 ---
 feature: Integration test harness for end-to-end plugin coverage
-status: beta # v0.3.0-beta.1 — test: add in-process integration test harness (#58); no version bump (test: type)
+status: done
 date: 2026-06-20
 branch: test/integration-harness
 commit-type: test

--- a/.claude/skills/architect/plans/done/2026-06-20-polling-lifecycle.md
+++ b/.claude/skills/architect/plans/done/2026-06-20-polling-lifecycle.md
@@ -1,6 +1,6 @@
 ---
 feature: Polling lifecycle — stop polling on accessory removal/shutdown and make it configurable
-status: done
+status: done # 2026-06-21
 date: 2026-06-20
 branch: fix/polling-lifecycle
 commit-type: fix

--- a/.claude/skills/architect/plans/done/2026-06-20-polling-lifecycle.md
+++ b/.claude/skills/architect/plans/done/2026-06-20-polling-lifecycle.md
@@ -1,6 +1,6 @@
 ---
 feature: Polling lifecycle — stop polling on accessory removal/shutdown and make it configurable
-status: beta # v0.3.0-beta.1 — fix: stop polling on removal/shutdown and honour pollingInterval (#65)
+status: done
 date: 2026-06-20
 branch: fix/polling-lifecycle
 commit-type: fix

--- a/.claude/skills/architect/plans/done/2026-06-20-prefer-it-over-test.md
+++ b/.claude/skills/architect/plans/done/2026-06-20-prefer-it-over-test.md
@@ -1,6 +1,6 @@
 ---
 feature: Prefer it() over test() across the remaining test suites
-status: done # test: prefer it() over test() across all remaining test suites (#98)
+status: done # 2026-06-21
 date: 2026-06-20
 branch: test/prefer-it-over-test
 commit-type: test

--- a/.claude/skills/technical-lead/ROADMAP.md
+++ b/.claude/skills/technical-lead/ROADMAP.md
@@ -1,6 +1,6 @@
 # Technical Roadmap
 
-Last updated: 2026-06-21
+Last updated: 2026-06-21 (post v0.3.0 stable release)
 
 This file gives the delivery order and dependency chain across all planned
 features. The individual plan files contain the detail; this file answers
@@ -37,18 +37,24 @@ flowchart TD
 
 ## Current state (2026-06-21)
 
-- **Beta (v0.3.0-beta.1):** [05] Integration test harness — **#58**. Fake HTTP server + HAP stub; polling neutralised with fake timers.
-- **Beta (v0.3.0-beta.1):** [06] Polling lifecycle — **#65**. Polling stoppable on unregister/shutdown; `pollingInterval` config field.
-- **Beta (v0.3.0-beta.1):** Spike C Part 1 — gabbo WebSocket harness — **#66**. Parse/dispatch validated; fake-gabbo test double in place.
-- **Beta (v0.3.0-beta.1):** FirmwareRevision characteristic — **#83** (test), **#85** (fix). SCM `softwareVersion` component correctly sourced.
-- **Beta (v0.3.0-beta.1):** [01] Accessory type — **#72**. `accessoryType: 'switch' | 'lightbulb'` threaded through config → accessory; orphan-service pruning on type change.
-- **Beta (v0.3.0-beta.1):** [02] Volume — Lightbulb path — **#86** (feat), **#91** (race fix). Brightness 0–100 maps to volume; 0 = power off; non-blocking settle.
+**v0.3.0 shipped as stable `latest`.** Beta releases were deleted; v0.3.0 is the current published version. All items previously marked "beta v0.3.0-beta.1" are done.
+
+- **Done (v0.3.0):** [05] Integration test harness — **#58**. Fake HTTP server + HAP stub; polling neutralised with fake timers.
+- **Done (v0.3.0):** [06] Polling lifecycle — **#65**. Polling stoppable on unregister/shutdown; `pollingInterval` config field.
+- **Done (v0.3.0):** Spike C Part 1 — gabbo WebSocket harness — **#66**. Parse/dispatch validated; fake-gabbo test double in place.
+- **Done (v0.3.0):** FirmwareRevision characteristic — **#83** (test), **#85** (fix). SCM `softwareVersion` component correctly sourced.
+- **Done (v0.3.0):** [01] Accessory type — **#72**. `accessoryType: 'switch' | 'lightbulb'` threaded through config → accessory; orphan-service pruning on type change.
+- **Done (v0.3.0):** [02] Volume — Lightbulb path — **#86** (feat), **#91** (race fix). Brightness 0–100 maps to volume; 0 = power off; non-blocking settle.
+- **Done (v0.3.0):** XML escaping fix — **#110**. Escape special chars in fake-soundtouch-server error responses.
 - **Cancelled:** [02] Volume — Switch path. **PR #62 was merged then reverted (#70)** — binary `On` only; volume requires 0–100 range.
-- **Dev:** `prefer-it-over-test` sweep — **#98**. Mechanical `test()` → `it()` rename across all remaining test files. No production code, no release.
-- **Dev (planned):** Static factory enforcement — **#103 (plan)**. Private constructors on all classes + `API.create()` factory. `refactor:` → no release.
-- **Dev (planned):** Structured errors + logLevel — **#100 (plan)**. `ContextError`, native `Error.cause`, `logLevel` config, level-aware `FormattedLogger.error()`. `feat:` → minor.
-- **Dev (planned):** Speaker zones — **#101 (plan)**. `zones` config array, `SoundTouchZoneAccessory`, zone API activation. `feat:` → minor.
-- **Next (unblocked):** Spike C Part 2 — real hardware capture session. Unblocks [07] WebSocket push (plan 06 ✅, Spike C Part 1 ✅).
+- **Done (no release):** `prefer-it-over-test` sweep — **#98**. Mechanical `test()` → `it()` rename across all test files.
+- **In-progress:** CHANGELOG.md — **#111**. Introduce `CHANGELOG.md` + wire `@semantic-release/changelog` / `@semantic-release/git`. `docs:` → no release.
+- **Unblocked (planned):** Static factory enforcement — **#103 (plan)**. Private constructors on all classes + `API.create()` factory. `refactor:` → no release.
+- **Unblocked (planned):** Disabled flag — **(2026-06-21 plan)**. `disabled: true` per-accessory unregisters the speaker from HomeKit without removing config. `feat:` → minor. Goes before WebSocket push to make testing easier.
+- **Unblocked (planned):** Structured errors + logLevel — **#100 (plan)**. `ContextError`, native `Error.cause`, `logLevel` config, level-aware `FormattedLogger.error()`. `feat:` → minor. Goes before WebSocket push so logs are readable during Spike C Part 2.
+- **Unblocked (planned):** Speaker zones — **#101 (plan)**. `zones` config array, `SoundTouchZoneAccessory`, zone API activation. `feat:` → minor.
+- **Unblocked (spike):** Spike C Part 2 — real hardware capture session. Unblocks [07] WebSocket push (plan 06 ✅, Spike C Part 1 ✅). Run after disabled flag + logging land.
+- **Blocked:** [07] WebSocket push — waiting on disabled flag + structured-errors/logLevel (testing prerequisites) and Spike C Part 2.
 - **Blocked:** [03] Source selection (TV-vs-Switch spike), [04] PWA all phases (spikes A/B).
 
 ## Anticipated delivery order
@@ -63,9 +69,10 @@ flowchart TD
 | 4 | **[02] Volume — Lightbulb path** | `feat/volume-control` | ✅ beta v0.3.0-beta.1 (#86, #91) | Brightness 0–100 maps to volume; 0 = power off; non-blocking settle for the `On`/`Brightness` race. |
 | 4.5 | **prefer-it-over-test sweep** | `test/prefer-it-over-test` | ✅ dev (#98) | Mechanical `test()` → `it()` rename across all remaining test files. No production code, no release. |
 | 4.6 | **Static factory enforcement** | `refactor/static-factory-enforcement` | 🟢 Next (unblocked) | Private constructors on all ten classes + `API.create()` factory. `refactor:` → no release. Small, purely mechanical, no new tests. |
-| 4.7 | **Structured errors + logLevel** | `feat/structured-errors-logging` | 🟢 Next (unblocked) | `ContextError` + native `Error.cause` chaining; `logLevel` config replaces `verbose: boolean`; level-aware `FormattedLogger.error()`. `feat:` → minor. No new deps. |
-| 4.8 | **Speaker zones** | `feat/speaker-zones` | 🟢 Next (unblocked) | `zones` config array; `SoundTouchZoneAccessory`; zone API activation at startup sync. `feat:` → minor. Zone API already implemented in `api/zone.ts`. |
-| 5 | **[07] WebSocket push (gabbo)** | `feat/websocket-push` | 🟡 Spike C Part 2 needed | Event-driven refresh via the gabbo channel (port 8080), **augmenting** polling. Spike C Part 2 needs real hardware (device available). Phased: P1 connection+lifecycle, P2 per-event mapping, P3 tune polling + edges. |
+| 4.7 | **Disabled flag** | `feat/disabled-flag` | 🟢 Next (unblocked) | `disabled: true` per-accessory unregisters speaker from HomeKit without removing config. `feat:` → minor. Testing prerequisite for WebSocket push. |
+| 4.8 | **Structured errors + logLevel** | `feat/structured-errors-logging` | 🟢 Next (unblocked) | `ContextError` + native `Error.cause` chaining; `logLevel` config replaces `verbose: boolean`; level-aware `FormattedLogger.error()`. `feat:` → minor. No new deps. Testing prerequisite for WebSocket push. |
+| 4.9 | **Speaker zones** | `feat/speaker-zones` | 🟢 Next (unblocked) | `zones` config array; `SoundTouchZoneAccessory`; zone API activation at startup sync. `feat:` → minor. Zone API already implemented in `api/zone.ts`. |
+| 5 | **[07] WebSocket push (gabbo)** | `feat/websocket-push` | 🔴 Blocked | Blocked on disabled flag + structured-errors/logLevel (testing prerequisites) and Spike C Part 2 (real-device capture). Phased: P1 connection+lifecycle, P2 per-event mapping, P3 tune polling + edges. |
 | 6 | **[03] Source selection** | `feat/source-selection` | 🔴 Blocked (spike) | Independent of 01/02. Blocked on a **spike** (verify Television+InputSource on a real device; choose TV path vs per-source Switch fallback). Cannot be committed until the spike resolves the architecture choice. |
 | 7 | **[04] PWA — Phase 1** | `feat/pwa` | 🔴 Blocked (spike A) | Architecturally separate (new `web/` workspace + embedded HTTP server). Blocked on **spike A** (reverse-engineer the hotspot provisioning HTTP API at `http://192.0.2.1`). Phase 1 must ship before phases 2 and 3 (it creates the web scaffold and embedded server). |
 | 8 | **[04] PWA — Phase 2** | `feat/pwa` | 🔴 Blocked (needs P1) | Group management via the zone API (`/getZone`, `/setZone`, etc. — already implemented in `src/devices/SoundTouch/api/zone.ts`). Needs the phase 1 PWA scaffold and embedded server to be in place. |

--- a/.claude/skills/technical-lead/ROADMAP.md
+++ b/.claude/skills/technical-lead/ROADMAP.md
@@ -4,17 +4,16 @@ Last updated: 2026-06-21 (post v0.3.0 stable release)
 
 This file gives the delivery order and dependency chain across all planned
 features. The individual plan files contain the detail; this file answers
-"what ships in what order and why."
+"what ships in what order and why." Done and cancelled items are removed —
+see `plans/done/` and `plans/cancelled/` for the historical record.
 
 ## Dependency graph
 
 ```mermaid
 flowchart TD
-    HarnessNode["[05] Integration test harness\ntest/integration-harness"]
-    AccessoryTypeNode["[01] Accessory type\nSwitch / Lightbulb"]
-    VolLightbulbNode["[02] Volume – Lightbulb path\nBrightness characteristic"]
-    PollingNode["[06] Polling lifecycle\nfix/polling-lifecycle"]
-    SpikeC{"Spike C: gabbo\nWebSocket feasibility"}
+    DisabledNode["Disabled flag\nfeat/disabled-flag"]
+    LoggingNode["Structured errors + logLevel\nfeat/structured-errors-logging"]
+    SpikeC{"Spike C Part 2: gabbo\nreal-device capture"}
     WSNode["[07] WebSocket push\nfeat/websocket-push"]
     SpikeTV{"Spike: TV vs\nper-Switch fallback"}
     SourceNode["[03] Source selection"]
@@ -24,9 +23,8 @@ flowchart TD
     PWA2Node["[04] PWA – Phase 2\nGroup management"]
     PWA3Node["[04] PWA – Phase 3\nConfig sync"]
 
-    HarnessNode --> AccessoryTypeNode
-    AccessoryTypeNode --> VolLightbulbNode
-    PollingNode --> WSNode
+    DisabledNode --> SpikeC
+    LoggingNode --> SpikeC
     SpikeC --> WSNode
     SpikeTV --> SourceNode
     SpikeA --> PWA1Node
@@ -35,102 +33,61 @@ flowchart TD
     PWA1Node --> PWA3Node
 ```
 
-## Current state (2026-06-21)
-
-**v0.3.0 shipped as stable `latest`.** Beta releases were deleted; v0.3.0 is the current published version. All items previously marked "beta v0.3.0-beta.1" are done.
-
-- **Done (v0.3.0):** [05] Integration test harness — **#58**. Fake HTTP server + HAP stub; polling neutralised with fake timers.
-- **Done (v0.3.0):** [06] Polling lifecycle — **#65**. Polling stoppable on unregister/shutdown; `pollingInterval` config field.
-- **Done (v0.3.0):** Spike C Part 1 — gabbo WebSocket harness — **#66**. Parse/dispatch validated; fake-gabbo test double in place.
-- **Done (v0.3.0):** FirmwareRevision characteristic — **#83** (test), **#85** (fix). SCM `softwareVersion` component correctly sourced.
-- **Done (v0.3.0):** [01] Accessory type — **#72**. `accessoryType: 'switch' | 'lightbulb'` threaded through config → accessory; orphan-service pruning on type change.
-- **Done (v0.3.0):** [02] Volume — Lightbulb path — **#86** (feat), **#91** (race fix). Brightness 0–100 maps to volume; 0 = power off; non-blocking settle.
-- **Done (v0.3.0):** XML escaping fix — **#110**. Escape special chars in fake-soundtouch-server error responses.
-- **Cancelled:** [02] Volume — Switch path. **PR #62 was merged then reverted (#70)** — binary `On` only; volume requires 0–100 range.
-- **Done (no release):** `prefer-it-over-test` sweep — **#98**. Mechanical `test()` → `it()` rename across all test files.
-- **In-progress:** CHANGELOG.md — **#111**. Introduce `CHANGELOG.md` + wire `@semantic-release/changelog` / `@semantic-release/git`. `docs:` → no release.
-- **Unblocked (planned):** Static factory enforcement — **#103 (plan)**. Private constructors on all classes + `API.create()` factory. `refactor:` → no release.
-- **Unblocked (planned):** Disabled flag — **(2026-06-21 plan)**. `disabled: true` per-accessory unregisters the speaker from HomeKit without removing config. `feat:` → minor. Goes before WebSocket push to make testing easier.
-- **Unblocked (planned):** Structured errors + logLevel — **#100 (plan)**. `ContextError`, native `Error.cause`, `logLevel` config, level-aware `FormattedLogger.error()`. `feat:` → minor. Goes before WebSocket push so logs are readable during Spike C Part 2.
-- **Unblocked (planned):** Speaker zones — **#101 (plan)**. `zones` config array, `SoundTouchZoneAccessory`, zone API activation. `feat:` → minor.
-- **Unblocked (spike):** Spike C Part 2 — real hardware capture session. Unblocks [07] WebSocket push (plan 06 ✅, Spike C Part 1 ✅). Run after disabled flag + logging land.
-- **Blocked:** [07] WebSocket push — waiting on disabled flag + structured-errors/logLevel (testing prerequisites) and Spike C Part 2.
-- **Blocked:** [03] Source selection (TV-vs-Switch spike), [04] PWA all phases (spikes A/B).
-
-## Anticipated delivery order
+## Delivery order
 
 | Order | Plan | Branch | Status | Why this position |
 | ----- | ---- | ------ | ------ | ----------------- |
-| 1 | **[05] Integration test harness** | `test/integration-harness` | ✅ beta v0.3.0-beta.1 (#58) | Pure test infrastructure, no release. Gives confidence before shipping any user-facing feature. |
-| 2 | **[06] Polling lifecycle** | `fix/polling-lifecycle` | ✅ beta v0.3.0-beta.1 (#65) | Stop polling on accessory removal/shutdown; configurable interval. `fix:` → patch. |
-| 2.5 | **Spike C Part 1 — gabbo harness** | `spike/gabbo-harness` | ✅ beta v0.3.0-beta.1 (#66) | Validated parse/dispatch; fake-gabbo test double ready. |
-| 2.6 | **FirmwareRevision characteristic** | `test/firmware-revision-coverage` | ✅ beta v0.3.0-beta.1 (#83, #85) | SCM `softwareVersion` component correctly sourced and published. |
-| 3 | **[01] Accessory type** | `feat/accessory-type` | ✅ beta v0.3.0-beta.1 (#72) | `accessoryType: 'switch' \| 'lightbulb'` threaded through config → accessory; orphan-service pruning on type change. `feat:` → minor. |
-| 4 | **[02] Volume — Lightbulb path** | `feat/volume-control` | ✅ beta v0.3.0-beta.1 (#86, #91) | Brightness 0–100 maps to volume; 0 = power off; non-blocking settle for the `On`/`Brightness` race. |
-| 4.5 | **prefer-it-over-test sweep** | `test/prefer-it-over-test` | ✅ dev (#98) | Mechanical `test()` → `it()` rename across all remaining test files. No production code, no release. |
-| 4.6 | **Static factory enforcement** | `refactor/static-factory-enforcement` | 🟢 Next (unblocked) | Private constructors on all ten classes + `API.create()` factory. `refactor:` → no release. Small, purely mechanical, no new tests. |
-| 4.7 | **Disabled flag** | `feat/disabled-flag` | 🟢 Next (unblocked) | `disabled: true` per-accessory unregisters speaker from HomeKit without removing config. `feat:` → minor. Testing prerequisite for WebSocket push. |
-| 4.8 | **Structured errors + logLevel** | `feat/structured-errors-logging` | 🟢 Next (unblocked) | `ContextError` + native `Error.cause` chaining; `logLevel` config replaces `verbose: boolean`; level-aware `FormattedLogger.error()`. `feat:` → minor. No new deps. Testing prerequisite for WebSocket push. |
-| 4.9 | **Speaker zones** | `feat/speaker-zones` | 🟢 Next (unblocked) | `zones` config array; `SoundTouchZoneAccessory`; zone API activation at startup sync. `feat:` → minor. Zone API already implemented in `api/zone.ts`. |
-| 5 | **[07] WebSocket push (gabbo)** | `feat/websocket-push` | 🔴 Blocked | Blocked on disabled flag + structured-errors/logLevel (testing prerequisites) and Spike C Part 2 (real-device capture). Phased: P1 connection+lifecycle, P2 per-event mapping, P3 tune polling + edges. |
-| 6 | **[03] Source selection** | `feat/source-selection` | 🔴 Blocked (spike) | Independent of 01/02. Blocked on a **spike** (verify Television+InputSource on a real device; choose TV path vs per-source Switch fallback). Cannot be committed until the spike resolves the architecture choice. |
-| 7 | **[04] PWA — Phase 1** | `feat/pwa` | 🔴 Blocked (spike A) | Architecturally separate (new `web/` workspace + embedded HTTP server). Blocked on **spike A** (reverse-engineer the hotspot provisioning HTTP API at `http://192.0.2.1`). Phase 1 must ship before phases 2 and 3 (it creates the web scaffold and embedded server). |
-| 8 | **[04] PWA — Phase 2** | `feat/pwa` | 🔴 Blocked (needs P1) | Group management via the zone API (`/getZone`, `/setZone`, etc. — already implemented in `src/devices/SoundTouch/api/zone.ts`). Needs the phase 1 PWA scaffold and embedded server to be in place. |
-| 9 | **[04] PWA — Phase 3** | `feat/pwa` | 🔴 Blocked (spike B) | Homebridge config sync. Blocked on **spike B** (confirm atomic config write path safety under Homebridge). Requires phase 1 scaffold. |
+| 1 | **Static factory enforcement** | `refactor/static-factory-enforcement` | 🟢 Next (unblocked) | Private constructors on all ten classes + `API.create()` factory. `refactor:` → no release. Small, purely mechanical, no new tests. |
+| 2 | **Disabled flag** | `feat/disabled-flag` | 🟢 Next (unblocked) | `disabled: true` per-accessory unregisters speaker from HomeKit without removing config. `feat:` → minor. Testing prerequisite for WebSocket push. |
+| 3 | **Structured errors + logLevel** | `feat/structured-errors-logging` | 🟢 Next (unblocked) | `ContextError` + native `Error.cause` chaining; `logLevel` config replaces `verbose: boolean`; level-aware `FormattedLogger.error()`. `feat:` → minor. Testing prerequisite for WebSocket push. |
+| 4 | **CHANGELOG** | `docs/changelog` | 🔵 In-progress (#111) | Introduce `CHANGELOG.md` + wire `@semantic-release/changelog` / `@semantic-release/git`. `docs:` → no release. |
+| 5 | **Speaker zones** | `feat/speaker-zones` | 🟢 Unblocked | `zones` config array; `SoundTouchZoneAccessory`; zone API activation at startup sync. `feat:` → minor. Zone API already implemented in `api/zone.ts`. |
+| 6 | **Spike C Part 2** | — | 🟡 Unblocked (needs real device) | Real-device gabbo capture session. Run after disabled flag + logging land. Unblocks [07] WebSocket push. |
+| 7 | **[07] WebSocket push (gabbo)** | `feat/websocket-push` | 🔴 Blocked | Blocked on disabled flag + logging (testing prerequisites) and Spike C Part 2. Phased: P1 connection+lifecycle, P2 per-event mapping, P3 tune polling + edges. |
+| 8 | **[03] Source selection** | `feat/source-selection` | 🔴 Blocked (spike) | Blocked on TV-vs-Switch spike (verify Television+InputSource on a real device). |
+| 9 | **[04] PWA — Phase 1** | `feat/pwa` | 🔴 Blocked (spike A) | Blocked on spike A (reverse-engineer hotspot provisioning HTTP API at `http://192.0.2.1`). |
+| 10 | **[04] PWA — Phase 2** | `feat/pwa` | 🔴 Blocked (needs P1) | Group management via zone API. Needs phase 1 scaffold. |
+| 11 | **[04] PWA — Phase 3** | `feat/pwa` | 🔴 Blocked (spike B) | Homebridge config sync. Blocked on spike B + phase 1. |
 
 ## Session cost estimates
 
-Per-plan estimate of how much of a single coding session each unit consumes, by
-the methodology in `SKILL.md` step 5. Cost is driven by iteration loops
-(read → edit → test → lint → fix), not line count. Bands: **Small** (room to
-spare), **Medium** (one fits comfortably), **Heavy** (plan on one per session).
-Update the band after each unit ships and note the variance — see "Calibration"
-below.
+Per-plan estimate of how much of a single coding session each unit consumes.
+Cost is driven by iteration loops (read → edit → test → lint → fix), not line
+count. Bands: **Small** (room to spare), **Medium** (one fits comfortably),
+**Heavy** (plan on one per session).
 
-| Plan | Band | Drivers that set the band | Session guidance |
-| ---- | ---- | ------------------------- | ---------------- |
-| **[05] Integration test harness** | Medium | New test infra (fake HTTP server + Homebridge stub) and a Jest `projects` split; lots of additive code but low iteration risk and no release | ✅ beta v0.3.0-beta.1 |
-| **[06] Polling lifecycle** | Small–Medium | Modifies existing platform + accessory lifecycle (retain wrappers, stop on unregister/shutdown) and threads two config fields; async lifecycle reasoning + a couple of tests | ✅ beta v0.3.0-beta.1 |
-| **[01] Accessory type** | Heavy | Config threading through `DeviceConfiguration`, branching the hardcoded Switch in `createAccessory`, and orphan-service pruning on type change | ✅ beta v0.3.0-beta.1 |
-| **[02] Volume — Lightbulb path** | Small–Medium | `SoundTouchSpeakerBrightnessCharacteristic` + power/volume race fix; `On`/`Brightness` ordering needs careful handling | ✅ beta v0.3.0-beta.1 |
-| **prefer-it-over-test sweep** | Small | Pure mechanical rename, no production code, no iteration risk | ✅ dev (#98) |
-| **Static factory enforcement** | Small | Mechanical: add `private` to 10 constructors, add `API.create()`, update 3 test files. Typecheck is the gate — either it compiles or it doesn't. | 🟢 Next. One sitting, likely half a session. |
-| **Structured errors + logLevel** | Medium | New `ContextError` class + `logLevel` config option threaded through `ExternalPlatformConfig` → `PlatformConfiguration` → `platform.ts`; `FormattedLogger.error()` rewrite for cause-chain traversal. TDD on `ContextError` and the formatter is the main loop. | 🟢 Next. Fits one session. |
-| **Speaker zones** | Heavy | New `ZoneConfig` type + config schema update; `zones` threaded through `PlatformConfiguration`; `SoundTouchZoneAccessory` + `SoundTouchZoneOnCharacteristic`; startup `getZone()` sync per primary; zone set/dissolve via `setZone`/`removeZoneSlave`. Multiple new classes + config schema + integration path. | 🟢 Next. Plan a full session. |
-| **[07] WebSocket push — Phase 1** | Heavy (est.) | New stateful per-device connection (connect/parse/reconnect/teardown), a new `ws`-backed fake-gabbo harness, and async lifecycle threaded through `platform.ts`/accessory; async timing + reconnect is high iteration risk | Plan a full session. Re-estimate after Spike C. Phases 2–3 are Medium. |
-| **[03] Source selection** | TBD (blocked) | Estimate after the TV-vs-Switch spike resolves the architecture | Re-estimate once unblocked. |
-| **[04] PWA — Phase 1–3** | TBD (blocked) | New `web/` workspace + embedded `src/server/`; estimate after spike A | Each phase is its own session at minimum. |
+| Plan | Band | Drivers that set the band |
+| ---- | ---- | ------------------------- |
+| **Static factory enforcement** | Small | Mechanical: add `private` to 10 constructors, add `API.create()`, update 3 test files. Typecheck is the gate. |
+| **Disabled flag** | Small | Additive config field + one branch in `discoverDevices()`. Low iteration risk. |
+| **Structured errors + logLevel** | Medium | New `ContextError` class + `logLevel` config threaded through `ExternalPlatformConfig` → `PlatformConfiguration` → `platform.ts`; `FormattedLogger.error()` rewrite. TDD on `ContextError` and the formatter is the main loop. |
+| **Speaker zones** | Heavy | New `ZoneConfig` type + config schema; `zones` threaded through `PlatformConfiguration`; `SoundTouchZoneAccessory` + `SoundTouchZoneOnCharacteristic`; startup `getZone()` sync; zone set/dissolve via `setZone`/`removeZoneSlave`. |
+| **[07] WebSocket push — Phase 1** | Heavy (est.) | New stateful per-device connection (connect/parse/reconnect/teardown), `ws`-backed fake-gabbo harness, async lifecycle threaded through `platform.ts`/accessory. Re-estimate after Spike C Part 2. |
+| **[03] Source selection** | TBD (blocked) | Estimate after TV-vs-Switch spike resolves the architecture. |
+| **[04] PWA — Phase 1–3** | TBD (blocked) | New `web/` workspace + embedded `src/server/`. Each phase its own session minimum. |
 
-**Realistic capacity per session:** one Medium/Heavy plan to a shippable,
-verified, pushed state; a second only if the first goes smoothly with budget to
-spare. Three in one session is unlikely without compromising the test bar that
-plan 05 exists to raise.
+**Realistic capacity per session:** one Medium/Heavy plan fully verified and
+pushed; a second only if the first reaches green with budget clearly remaining.
 
 ### Calibration
 
-When a unit ships, record actual-vs-estimate here so future estimates sharpen.
-
 | Date | Plan | Estimate | Actual | Variance / note |
 | ---- | ---- | -------- | ------ | --------------- |
-| 2026-06-20 | [05] Integration test harness | Medium | Medium–Heavy | HTTP fake server was trivial as predicted, but two unforeseen drivers pushed it up: the manual homebridge mock provides no Service/Characteristic (HAP stub written from scratch), and polling is hardcoded on (neutralised with fake timers). Lesson: when a test exercises framework wiring, budget for stubbing the framework surface, not just the protocol. |
+| 2026-06-20 | [05] Integration test harness | Medium | Medium–Heavy | HAP stub written from scratch (homebridge mock provides none); polling hardcoded on (neutralised with fake timers). Lesson: budget for stubbing the framework surface when a test exercises framework wiring. |
 | 2026-06-20 | [01] Accessory type | Heavy | Heavy | Full session as estimated. Config threading + orphan pruning touched many files; pruning logic needed extra iteration. |
-| 2026-06-20 | [02] Volume — Lightbulb path | Small–Medium | Small–Medium | Landed as estimated. Race fix was the main loop as predicted; the `On`/`Brightness` ordering required a follow-up fix PR (#91). |
+| 2026-06-20 | [02] Volume — Lightbulb path | Small–Medium | Small–Medium | Landed as estimated. Race fix was the main loop; `On`/`Brightness` ordering required a follow-up fix PR (#91). |
 | 2026-06-21 | prefer-it-over-test sweep | Small | Small | Landed as estimated. Pure mechanical rename, no iteration needed. |
 
 ## Spikes (blockers)
 
-Three features are gated on spikes that must happen on a real device before code
-is written. These are not implementation tasks — they're time-boxed
-investigations with a concrete question to answer.
-
 ### Spike A — SoundTouch setup-mode hotspot HTTP API
-**Blocks:** plan 03 (TV path decision) is independent; plan 04 phase 1 is fully blocked.
+**Blocks:** [04] PWA Phase 1.
 
 What we know:
 - Enter setup mode: hold **PRESET 2 + VOLUME DOWN** until Wi-Fi indicator turns solid amber.
 - Speaker broadcasts "Bose SoundTouch Wi-Fi Network" hotspot.
 - Setup web UI is at `http://192.0.2.1` (port 80). Note: `192.168.1.1` is a different Bose product — do not use.
-- Standard SoundTouch API (port 8090) is also available at `192.0.2.1:8090` during setup.
+- Standard SoundTouch API (port 8090) also available at `192.0.2.1:8090` during setup.
 
 What must be resolved:
 1. Connect a laptop to the hotspot, open browser devtools, walk through WiFi setup. Capture: endpoints, methods, request/response bodies, any tokens.
@@ -139,64 +96,26 @@ What must be resolved:
 4. Does the phone reconnect to the home network automatically?
 
 ### Spike B — Homebridge config write path
-**Blocks:** plan 04 phase 3.
+**Blocks:** [04] PWA Phase 3.
 
 What must be resolved:
 1. `api.user.storagePath()` gives the writable directory — confirm atomic write (write-then-rename) doesn't corrupt Homebridge state.
 2. Does Homebridge Config UI X watch for external config changes and reload, or is a restart always required?
 
-### Spike C — gabbo WebSocket push feasibility
-**Blocks:** plan 07 (WebSocket push). Plan 06 is the *other* prerequisite (shared lifecycle) but is not blocked by this spike.
+### Spike C Part 2 — gabbo WebSocket real-device capture
+**Blocks:** [07] WebSocket push. Part 1 complete (#66). Run after disabled flag + logging land.
 
-**Question to answer:** does the gabbo channel (`ws://<ip>:8080`, sub-protocol
-`gabbo`) deliver the state-change notifications we need, reliably enough to drive
-(or augment) characteristic refresh — and what connection/reconnect/teardown
-semantics must the client implement?
+Run `node scripts/gabbo-probe.mjs <ip>` against the device while toggling volume/power/source/preset from the Bose app. Capture and record in plan 07's findings:
+1. Is the `gabbo` sub-protocol accepted on connect?
+2. Do real frames match the v1.1 reference shapes?
+3. Heartbeat / empty-update cadence and idle-timeout behaviour.
+4. What happens to the socket on standby/power-off — closed? silent? Reconnect trigger?
+5. Reconnect/backoff behaviour after a drop; multi-device behaviour.
 
-What we know (from `soundtouch-api-expert/api-reference.md` → "WebSocket
-notifications"):
-- Open with `new WebSocket("ws://<ip>:8080", "gabbo")`; the speaker pushes
-  `<updates deviceID="…">` frames. Most are tickles (`<volumeUpdated/>`,
-  `<nowPlayingUpdated>…`, `<bassUpdated/>`, `<zoneUpdated/>`, `<infoUpdated/>`,
-  `<sourcesUpdated/>`); a few carry data inline (`presetsUpdated`,
-  `nowPlayingUpdated`, `recentsUpdated`, `nowSelectionUpdated`).
-- Empty `<updates …></updates>` frames act as a heartbeat.
-- Node 22/24 ship a global `WebSocket` (undici) → **client needs no new runtime
-  dependency**. A local fake-gabbo **server** for tests needs `ws` (devDep).
-- **Correction to a prior assumption:** there is currently **no** WebSocket code
-  in the repo. The volume plan's 2026-06-20 finding that an "existing per-device
-  WebSocket connection" could be reused is **wrong** — confirmed by grep. The
-  channel is greenfield.
-
-**Two parts (split by hardware need):**
-
-*Part 1 — no hardware (doable in-sandbox):*
-- Build a throwaway probe client + a minimal `ws`-backed fake-gabbo server that
-  emits the reference frames; prove sub-protocol negotiation, `<updates>`
-  parsing (reuse `api/utils/xml-element.ts`), and tickle→re-GET dispatch.
-- Output: validated parse/dispatch logic + a reusable test double.
-
-*Part 2 — real hardware (needs a Bose SoundTouch speaker):*
-- Run `node scripts/gabbo-probe.mjs <ip>` (to be written): open the socket, log
-  every frame with timestamps for a session while the user toggles
-  volume/power/source/preset from the Bose app.
-- Capture and record in plan 07's findings:
-  1. Is the `gabbo` sub-protocol accepted on connect?
-  2. Do real frames match the v1.1 reference shapes?
-  3. Heartbeat / empty-update cadence and idle-timeout behaviour.
-  4. What happens to the socket on **standby/power-off** — closed? silent? Does
-     it need a reconnect, and on what trigger?
-  5. Reconnect/backoff behaviour after a drop; multi-device behaviour.
-- **Time-box:** one capture session. We'll know by the end which events fire,
-  their real shapes, and the connection lifecycle rules — enough to finalise the
-  reconnect strategy and the polling-fallback interval.
-
-**Status (2026-06-20):** Part 1 complete — gabbo harness shipped in #66 (beta v0.3.0-beta.1). Part 2 unblocked — real device available; run `node scripts/gabbo-probe.mjs <ip>` against the device to capture frames and answer the connection lifecycle questions above.
+**Time-box:** one capture session.
 
 ## Key coupling notes
 
-- **Volume requires Lightbulb — the Switch path was cancelled.** HAP Switch exposes only a binary `On` characteristic; volume is a 0–100 range. `Lightbulb.Brightness` (0–100, where 0 = power off) is the correct mapping. Plan 01 (accessory type) is therefore the prerequisite for plan 02 (volume).
-- **The integration test harness (plan 05) is infrastructure, not a feature.** It has no user impact and no release, but it provides the safety net that makes the subsequent feature PRs lower risk.
-- **The PWA (plan 04) is architecturally independent** from the HomeKit features (plans 01–03). It introduces a new `web/` workspace and a `src/server/` embedded HTTP server — concerns that don't overlap with the HAP characteristic layer. Its phases can proceed in parallel with plans 01–03 once spike A is resolved.
-- **Source selection (plan 03) is the highest-risk HomeKit feature.** The Television+InputSource pattern has real caveats (external publishing, `Active`/`On` power model clash, buried UX). The spike must answer the architecture question before any code is written; the per-source Switch fallback is the documented Plan B if the TV path is too rough.
-- **WebSocket push (plan 07) augments polling — it does not replace it.** Plan 06 makes polling stoppable and configurable; plan 07 then makes WS the primary, instant refresh trigger while polling stays as a relaxed-interval fallback for dropped sockets / missed tickles. The two **share the connection-lifecycle code** (open on init, tear down on unregister/shutdown) and both edit `SoundTouchSpeakerPlatformAccessory.ts`/`platform.ts`, so plan 07 **must serialise after plan 06** — building it earlier would implement the same lifecycle twice and guarantee merge conflicts.
+- **WebSocket push (plan 07) augments polling — it does not replace it.** Polling stays as a relaxed-interval fallback for dropped sockets / missed tickles.
+- **Source selection is the highest-risk HomeKit feature.** The Television+InputSource pattern has real caveats (external publishing, `Active`/`On` power model clash, buried UX). The per-source Switch fallback is Plan B if the TV path is too rough.
+- **The PWA is architecturally independent** from the HomeKit features. It introduces a new `web/` workspace and `src/server/` embedded HTTP server — no overlap with the HAP characteristic layer.

--- a/.claude/skills/technical-lead/ROADMAP.md
+++ b/.claude/skills/technical-lead/ROADMAP.md
@@ -1,6 +1,6 @@
 # Technical Roadmap
 
-Last updated: 2026-06-21 (post v0.3.0 stable release)
+Last updated: 2026-06-21
 
 This file gives the delivery order and dependency chain across all planned
 features. The individual plan files contain the detail; this file answers

--- a/.claude/skills/technical-lead/SKILL.md
+++ b/.claude/skills/technical-lead/SKILL.md
@@ -61,7 +61,7 @@ For each plan in roadmap order, determine:
   no unresolved spike or open decision blocking it.
 - **Blocked:** depends on a spike, a prerequisite plan, or an open decision.
 - **In-progress:** `status: in-progress` — check if it's stalled or moving.
-- **Beta:** `status: beta` — merged to dev and released to the beta channel; awaiting promotion to `latest`. The status comment includes the version (e.g. `# v0.3.0-beta.1`). Skip for planning purposes — work is done; only promotion remains. **However:** if `latest` has already been cut at or above that version (check `package.json` `version` or the ROADMAP "Current state" section), the plan should be updated to `status: done` and moved to `plans/done/` — do this as part of the survey, on the same planning branch as any other roadmap updates.
+- **Beta:** `status: beta` — merged to dev and released to the beta channel; awaiting promotion to `latest`. The status comment includes the version (e.g. `# v0.3.0-beta.1`). Skip for planning purposes — work is done; only promotion remains. **However:** if `latest` has already been cut at or above that version (run `npm view homebridge-soundtouchspeaker dist-tags` to check), update the plan to `status: done # <YYYY-MM-DD>` (the date promotion was confirmed) and move it to `plans/done/` — do this as part of the survey, on the same planning branch as any other roadmap updates.
 - **Done / cancelled:** skip.
 
 The ROADMAP table captures anticipated order, but re-check: if a dependency has
@@ -228,10 +228,11 @@ delivery sequence. If the work is cancelled or found impossible, set
 to `plans/cancelled/`, and likewise remove it from the ROADMAP.
 
 **Closure sweep (do this during every survey):** for each plan in `plans/done/`
-with `status: beta`, check whether `latest` has shipped at or above that version.
-If it has, update the frontmatter to `status: done` and remove the item from
-`ROADMAP.md`. Do not leave done or beta plans in the ROADMAP — they add noise
-and make the active delivery sequence harder to read.
+with `status: beta`, run `npm view homebridge-soundtouchspeaker dist-tags` to
+check whether `latest` has shipped at or above that version. If it has, update
+the frontmatter to `status: done # <YYYY-MM-DD>` (today's date) and remove the
+item from `ROADMAP.md`. Do not leave done or beta plans in the ROADMAP — they
+add noise and make the active delivery sequence harder to read.
 
 When delivery order changes, update `ROADMAP.md`. The roadmap is your
 document — keep it current.

--- a/.claude/skills/technical-lead/SKILL.md
+++ b/.claude/skills/technical-lead/SKILL.md
@@ -221,15 +221,17 @@ opened. If the plan lists additional manual verification steps, list them.
 When handing off to the engineer, set `status: in-progress` in the plan file
 frontmatter. When the PR is merged to dev and a beta release is cut, set
 `status: beta` with the version in a comment (e.g. `# v0.3.0-beta.1`). When
-promoted to `latest`, set `status: done` and move the file to `plans/done/`. If
-the work is cancelled or found impossible, set `status: cancelled`, fill in the
-plan's "If cancelled" section, and move the file to `plans/cancelled/`.
+promoted to `latest`, set `status: done`, move the file to `plans/done/`, and
+**remove the item from `ROADMAP.md` entirely** — done work has no place in the
+delivery sequence. If the work is cancelled or found impossible, set
+`status: cancelled`, fill in the plan's "If cancelled" section, move the file
+to `plans/cancelled/`, and likewise remove it from the ROADMAP.
 
 **Closure sweep (do this during every survey):** for each plan in `plans/done/`
 with `status: beta`, check whether `latest` has shipped at or above that version.
-If it has, update the frontmatter to `status: done`. Do not leave plans at
-`status: beta` after their version has promoted — stale statuses make the
-survey unreliable.
+If it has, update the frontmatter to `status: done` and remove the item from
+`ROADMAP.md`. Do not leave done or beta plans in the ROADMAP — they add noise
+and make the active delivery sequence harder to read.
 
 When delivery order changes, update `ROADMAP.md`. The roadmap is your
 document — keep it current.

--- a/.claude/skills/technical-lead/SKILL.md
+++ b/.claude/skills/technical-lead/SKILL.md
@@ -61,7 +61,7 @@ For each plan in roadmap order, determine:
   no unresolved spike or open decision blocking it.
 - **Blocked:** depends on a spike, a prerequisite plan, or an open decision.
 - **In-progress:** `status: in-progress` — check if it's stalled or moving.
-- **Beta:** `status: beta` — merged to dev and released to the beta channel; awaiting promotion to `latest`. The status comment includes the version (e.g. `# v0.3.0-beta.1`). Skip for planning purposes — work is done; only promotion remains.
+- **Beta:** `status: beta` — merged to dev and released to the beta channel; awaiting promotion to `latest`. The status comment includes the version (e.g. `# v0.3.0-beta.1`). Skip for planning purposes — work is done; only promotion remains. **However:** if `latest` has already been cut at or above that version (check `package.json` `version` or the ROADMAP "Current state" section), the plan should be updated to `status: done` and moved to `plans/done/` — do this as part of the survey, on the same planning branch as any other roadmap updates.
 - **Done / cancelled:** skip.
 
 The ROADMAP table captures anticipated order, but re-check: if a dependency has
@@ -221,8 +221,15 @@ opened. If the plan lists additional manual verification steps, list them.
 When handing off to the engineer, set `status: in-progress` in the plan file
 frontmatter. When the PR is merged to dev and a beta release is cut, set
 `status: beta` with the version in a comment (e.g. `# v0.3.0-beta.1`). When
-promoted to `latest`, set `status: done`. If the work is cancelled or found
-impossible, set `status: cancelled` and fill in the plan's "If cancelled" section.
+promoted to `latest`, set `status: done` and move the file to `plans/done/`. If
+the work is cancelled or found impossible, set `status: cancelled`, fill in the
+plan's "If cancelled" section, and move the file to `plans/cancelled/`.
+
+**Closure sweep (do this during every survey):** for each plan in `plans/done/`
+with `status: beta`, check whether `latest` has shipped at or above that version.
+If it has, update the frontmatter to `status: done`. Do not leave plans at
+`status: beta` after their version has promoted — stale statuses make the
+survey unreliable.
 
 When delivery order changes, update `ROADMAP.md`. The roadmap is your
 document — keep it current.


### PR DESCRIPTION
## What & why

Planning-only update — no production code. `docs:` → no release.

### New plan: disabled flag
`disabled: true` per-accessory config unregisters the speaker from HomeKit without removing its config entry. Testing prerequisite for the WebSocket push work — lets you toggle a speaker off, test locally, toggle back on.

### WebSocket push marked blocked
[`2026-06-20-websocket-push.md`](.claude/skills/architect/plans/2026-06-20-websocket-push.md) marked `status: blocked` — waiting on disabled flag + structured-errors/logLevel to land first (easier testing setup), then Spike C Part 2 (real-device capture).

### Roadmap resequenced
Done items removed from ROADMAP entirely — historical record lives in `plans/done/`. Active delivery order is now:

1. Static factory enforcement
2. **Disabled flag** ← new
3. Structured errors + logLevel
4. CHANGELOG (in-progress)
5. Speaker zones
6. Spike C Part 2 → unblocks WebSocket push

### Plan closure sweep added to technical-lead skill
Step 2 and step 7 of `SKILL.md` now both say: during every survey, run `npm view homebridge-soundtouchspeaker dist-tags` to check if `beta` plans have promoted to `latest`; if so, update to `status: done # <YYYY-MM-DD>` and remove from ROADMAP. Five `beta` plans closed to `done # 2026-06-21` as first application of this rule.