### PR TITLE
refactor: enforce private constructors and add static factory methods

### DIFF
--- a/src/PlatformConfiguration.ts
+++ b/src/PlatformConfiguration.ts
@@ -16,7 +16,7 @@ export class PlatformConfiguration {
   pollingInterval: number;
   verbose: boolean;
 
-  constructor(props: {
+  private constructor(props: {
     name: string;
     discoverAllAccessories: boolean;
     accessories: DeviceConfiguration[] | undefined;

--- a/src/accessories/SoundTouchSpeakerPlatformAccessory.ts
+++ b/src/accessories/SoundTouchSpeakerPlatformAccessory.ts
@@ -14,7 +14,7 @@ export class SoundTouchSpeakerPlatformAccessory extends SoundTouchSpeakerCharact
   private readonly speakerCharacteristics: SoundTouchSpeakerCharacteristic[];
   private _isPolling = false;
 
-  constructor({
+  private constructor({
     speakerCharacteristics,
     ...props
   }: {
@@ -67,6 +67,15 @@ export class SoundTouchSpeakerPlatformAccessory extends SoundTouchSpeakerCharact
         this.log.error('Polling refresh failed', e);
       }
     }
+  }
+
+  static createWithCharacteristics(props: {
+    accessory: PlatformAccessory;
+    device: SoundTouchDevice;
+    platform: SoundTouchHomebridgePlatform;
+    speakerCharacteristics: SoundTouchSpeakerCharacteristic[];
+  }): SoundTouchSpeakerPlatformAccessory {
+    return new SoundTouchSpeakerPlatformAccessory(props);
   }
 
   static async createAccessory(props: {

--- a/src/accessories/__tests__/SoundTouchSpeakerPlatformAccessory.test.ts
+++ b/src/accessories/__tests__/SoundTouchSpeakerPlatformAccessory.test.ts
@@ -12,7 +12,7 @@ function build(pollingInterval: number) {
     logger: { homebridgeLogger: { log: jest.fn() }, requiredLogLevel: 'debug' },
   };
 
-  const subject = new SoundTouchSpeakerPlatformAccessory({
+  const subject = SoundTouchSpeakerPlatformAccessory.createWithCharacteristics({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     accessory: {} as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/accessories/services/SoundTouchSpeakerBrightnessCharacteristic.ts
+++ b/src/accessories/services/SoundTouchSpeakerBrightnessCharacteristic.ts
@@ -12,7 +12,7 @@ export class SoundTouchSpeakerBrightnessCharacteristic extends SoundTouchSpeaker
   private readonly service: Service;
   private characteristic: Characteristic;
 
-  constructor({
+  private constructor({
     service,
     ...props
   }: {

--- a/src/accessories/services/SoundTouchSpeakerInformationCharacteristic.ts
+++ b/src/accessories/services/SoundTouchSpeakerInformationCharacteristic.ts
@@ -7,7 +7,7 @@ const SOUNDTOUCH_MANUFACTURER = 'Bose';
 
 export class SoundTouchSpeakerInformationCharacteristic extends SoundTouchSpeakerCharacteristic {
 
-  constructor(props: {
+  private constructor(props: {
     device: SoundTouchDevice;
     accessory: PlatformAccessory;
     platform: SoundTouchHomebridgePlatform;

--- a/src/accessories/services/SoundTouchSpeakerOnCharacteristic.ts
+++ b/src/accessories/services/SoundTouchSpeakerOnCharacteristic.ts
@@ -14,7 +14,7 @@ export class SoundTouchSpeakerOnCharacteristic extends SoundTouchSpeakerCharacte
 
   private characteristic: Characteristic;
 
-  constructor({
+  private constructor({
     service,
     ...props
   }: {

--- a/src/accessories/services/__tests__/SoundTouchSpeakerBrightnessCharacteristic.test.ts
+++ b/src/accessories/services/__tests__/SoundTouchSpeakerBrightnessCharacteristic.test.ts
@@ -7,7 +7,7 @@ class FakeHapStatusError extends Error {
   }
 }
 
-function build({ volume = 50 }: { volume?: number } = {}) {
+async function build({ volume = 50 }: { volume?: number } = {}) {
   const updateValue = jest.fn();
   const hapCharacteristic = {
     value: volume as number | boolean,
@@ -56,7 +56,7 @@ function build({ volume = 50 }: { volume?: number } = {}) {
     logger: { homebridgeLogger: { log: jest.fn() }, requiredLogLevel: 'debug' },
   };
 
-  const subject = new SoundTouchSpeakerBrightnessCharacteristic({
+  const subject = await SoundTouchSpeakerBrightnessCharacteristic.create({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     service: service as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -84,7 +84,7 @@ describe('SoundTouchSpeakerBrightnessCharacteristic', () => {
 
   describe('#init', () => {
     it('refreshes the characteristic value on init', async () => {
-      const { subject, hapCharacteristic, updateValue } = build({ volume: 42 });
+      const { subject, hapCharacteristic, updateValue } = await build({ volume: 42 });
       hapCharacteristic.value = 0;
 
       await subject.init();
@@ -95,7 +95,7 @@ describe('SoundTouchSpeakerBrightnessCharacteristic', () => {
 
   describe('#refresh', () => {
     it('updates the HAP value with the actual volume from the device', async () => {
-      const { subject, hapCharacteristic, updateValue } = build({ volume: 60 });
+      const { subject, hapCharacteristic, updateValue } = await build({ volume: 60 });
       hapCharacteristic.value = 40;
 
       await subject.refresh();
@@ -104,7 +104,7 @@ describe('SoundTouchSpeakerBrightnessCharacteristic', () => {
     });
 
     it('does not update the HAP value when it has not changed', async () => {
-      const { subject, hapCharacteristic, updateValue } = build({ volume: 50 });
+      const { subject, hapCharacteristic, updateValue } = await build({ volume: 50 });
       hapCharacteristic.value = 50;
 
       await subject.refresh();
@@ -113,7 +113,7 @@ describe('SoundTouchSpeakerBrightnessCharacteristic', () => {
     });
 
     it('does not throw when the device returns no volume', async () => {
-      const { subject, getVolume } = build();
+      const { subject, getVolume } = await build();
       getVolume.mockResolvedValue(undefined as never);
 
       await expect(subject.refresh()).resolves.not.toThrow();
@@ -122,7 +122,7 @@ describe('SoundTouchSpeakerBrightnessCharacteristic', () => {
 
   describe('#getBrightness', () => {
     it('returns the actual volume from the device', async () => {
-      const { subject } = build({ volume: 75 });
+      const { subject } = await build({ volume: 75 });
 
       const result = await subject.getBrightness();
 
@@ -130,7 +130,7 @@ describe('SoundTouchSpeakerBrightnessCharacteristic', () => {
     });
 
     it('throws HapStatusError when the device is unreachable', async () => {
-      const { subject, getVolume } = build();
+      const { subject, getVolume } = await build();
       getVolume.mockRejectedValue(new Error('network error'));
 
       await expect(subject.getBrightness()).rejects.toBeInstanceOf(
@@ -142,7 +142,7 @@ describe('SoundTouchSpeakerBrightnessCharacteristic', () => {
   describe('#setBrightness', () => {
     describe('when value is 0', () => {
       it('is a no-op — power-off is owned by setOn', async () => {
-        const { subject, pressKey, setVolume } = build();
+        const { subject, pressKey, setVolume } = await build();
 
         await subject.setBrightness(0);
 
@@ -153,7 +153,7 @@ describe('SoundTouchSpeakerBrightnessCharacteristic', () => {
 
     describe('when value is greater than 0', () => {
       it('sets the volume to the given value', async () => {
-        const { subject, setVolume } = build();
+        const { subject, setVolume } = await build();
 
         await subject.setBrightness(65);
 
@@ -161,7 +161,7 @@ describe('SoundTouchSpeakerBrightnessCharacteristic', () => {
       });
 
       it('throws HapStatusError when the volume set fails', async () => {
-        const { subject, setVolume } = build();
+        const { subject, setVolume } = await build();
         setVolume.mockRejectedValue(new Error('network error'));
 
         await expect(subject.setBrightness(65)).rejects.toBeInstanceOf(

--- a/src/devices/SoundTouch/SoundTouchDevice.ts
+++ b/src/devices/SoundTouch/SoundTouchDevice.ts
@@ -29,7 +29,7 @@ export class SoundTouchDevice implements BaseDevice {
   id: string;
   name: string;
 
-  constructor(props: SoundTouchSpeakerPlatformAccessoryProps) {
+  private constructor(props: SoundTouchSpeakerPlatformAccessoryProps) {
     this.api = props.api;
     this.model = props.model;
     this.version = props.version;
@@ -147,7 +147,7 @@ export class SoundTouchDevice implements BaseDevice {
   }): Promise<SoundTouchDevice> {
     let api;
     if (accessoryConfig.ip) {
-      api = new SoundTouchApi(accessoryConfig.ip, accessoryConfig.port);
+      api = SoundTouchApi.create(accessoryConfig.ip, accessoryConfig.port);
     } else if (accessoryConfig.room) {
       api = await SoundTouchDiscovery.find(accessoryConfig.room);
       if (!api) {

--- a/src/devices/SoundTouch/SoundTouchDeviceConfiguration.ts
+++ b/src/devices/SoundTouch/SoundTouchDeviceConfiguration.ts
@@ -34,7 +34,7 @@ export class DeviceConfiguration {
   readonly verboseLogging: boolean;
   readonly accessoryType: AccessoryType;
 
-  constructor(props: {
+  private constructor(props: {
     type: 'room' | 'ip' | 'discovered';
     name?: string;
     room?: string;

--- a/src/devices/SoundTouch/api/__tests__/api.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/api.test.ts
@@ -15,7 +15,7 @@ describe('API', () => {
   beforeEach(() => {
     const instance = axios.create();
     mock = new MockAdapter(instance);
-    api = new API(HOST, 8090, instance);
+    api = API.create(HOST, 8090, instance);
   });
 
   afterEach(() => {
@@ -32,7 +32,7 @@ describe('API', () => {
     it('honours a custom port', async () => {
       const instance = axios.create();
       const customMock = new MockAdapter(instance);
-      const customApi = new API('10.0.0.9', 9999, instance);
+      const customApi = API.create('10.0.0.9', 9999, instance);
       customMock
         .onGet('http://10.0.0.9:9999/volume')
         .reply(200, '<volume deviceID="D"></volume>');

--- a/src/devices/SoundTouch/api/__tests__/error.test.ts
+++ b/src/devices/SoundTouch/api/__tests__/error.test.ts
@@ -55,7 +55,7 @@ describe('APIErrors', () => {
   });
 
   it('is an Error carrying device id and a descriptive message', () => {
-    const errors = new APIErrors(
+    const errors = APIErrors.create(
       [{ value: 1, name: 'A', severity: 'High' }],
       'DEV1'
     );

--- a/src/devices/SoundTouch/api/api-discovery.ts
+++ b/src/devices/SoundTouch/api/api-discovery.ts
@@ -9,7 +9,7 @@ function _APIFromService(service?: any): API | undefined {
     service.addresses.length > 0
   ) {
     const ipAddress = service.addresses[0];
-    return new API(ipAddress, service.port);
+    return API.create(ipAddress, service.port);
   }
   return undefined;
 }

--- a/src/devices/SoundTouch/api/api.ts
+++ b/src/devices/SoundTouch/api/api.ts
@@ -43,7 +43,15 @@ export class API {
   private readonly builder: XMLBuilder;
   private readonly axiosInstance: AxiosInstance;
 
-  constructor(
+  static create(
+    host: string,
+    port: number = 8090,
+    axiosInstance?: AxiosInstance
+  ): API {
+    return new API(host, port, axiosInstance);
+  }
+
+  private constructor(
     host: string,
     port: number = 8090,
     axiosInstance?: AxiosInstance
@@ -255,7 +263,7 @@ export class API {
       if (errElement) {
         const err = errorFromElement(errElement);
         if (err) {
-          throw new APIErrors([err]);
+          throw APIErrors.create([err]);
         }
       }
     }

--- a/src/devices/SoundTouch/api/error.ts
+++ b/src/devices/SoundTouch/api/error.ts
@@ -22,10 +22,14 @@ export class APIErrors extends Error {
   readonly deviceId?: string;
   readonly errors: APIError[];
 
-  constructor(errors: APIError[], deviceId?: string) {
+  private constructor(errors: APIError[], deviceId?: string) {
     super(`Occurred on device ${deviceId}: ${JSON.stringify(errors)}`);
     this.deviceId = deviceId;
     this.errors = errors;
+  }
+
+  static create(errors: APIError[], deviceId?: string): APIErrors {
+    return new APIErrors(errors, deviceId);
   }
 
   static fromElement(element: XMLElement): APIErrors | undefined {

--- a/src/utils/FormattedLogger.ts
+++ b/src/utils/FormattedLogger.ts
@@ -13,7 +13,7 @@ export class Logger implements Partial<Logging> {
   readonly homebridgeLogger: Logging;
   readonly requiredLogLevel: LogLevel;
 
-  constructor({
+  protected constructor({
     homebridgeLogger,
     level,
   }: {
@@ -73,7 +73,7 @@ export class Logger implements Partial<Logging> {
 export class DeviceLogger extends Logger {
   readonly device: SoundTouchDevice;
 
-  constructor({
+  private constructor({
     homebridgeLogger,
     level,
     device,


### PR DESCRIPTION
## What & why

Enforces the static factory pattern across all classes: constructors are `private` (or `protected` where subclassing requires it), and every class exposes a named `static create()` / `static fromX()` factory as the sole public construction path.

Changes:
- `API` → `private constructor` + `static create(host, port, axiosInstance?)`
- `APIErrors` → `private constructor` + `static create(errors, deviceId?)`
- `Logger` → `protected constructor` (subclassed by `DeviceLogger`)
- `DeviceLogger` → `private constructor`
- `SoundTouchSpeakerPlatformAccessory` → `private constructor` + `static createWithCharacteristics()` for test injection
- All characteristic classes (`On`, `Brightness`, `Information`) → `private constructor`
- `PlatformConfiguration`, `SoundTouchDeviceConfiguration` → `private constructor`
- All call sites updated (`SoundTouchDevice`, `api-discovery`, tests)

## Verification

`npm run typecheck && npm run lint && npm test` — 236 tests passing ✓  
`npm run knip` — no unused exports or files ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_014sXqcZr8zpTZkmiTFzN5YD)_