### PR TITLE
chore: reset version to 0.0.0-development

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "homebridge-soundtouchspeaker",
   "displayName": "SoundTouch Speaker",
   "type": "module",
-  "version": "0.2.4-beta.2",
+  "version": "0.0.0-development",
   "description": "Updates homebridge-soundtouch-platform to work on latest homebridge.",
   "author": "Andrew Trainor",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What & why

Resets `package.json` version from `0.2.4-beta.2` back to `0.0.0-development` so semantic-release can manage the version automatically on merge.

## Verification

- [x] Single-line change to `package.json`

---
_Generated by [Claude Code](https://claude.ai/code/session_014sXqcZr8zpTZkmiTFzN5YD)_