### PR TITLE
fix: skip disabled accessories before any network calls

### DIFF
--- a/src/__tests__/platform.test.ts
+++ b/src/__tests__/platform.test.ts
@@ -74,20 +74,21 @@ describe('SoundTouchHomebridgePlatform', () => {
       expect(registerPlatformAccessories).toHaveBeenCalledTimes(1);
     });
 
-    it('skips a disabled device without registering it', async () => {
-      const device = buildDevice({ id: 'dev2', name: 'Lounge', disabled: true });
+    it('registers nothing when searchDevices returns an empty list', async () => {
+      // Disabled devices are filtered out by searchDevices() before discoverDevices sees them.
       const { platform, registerPlatformAccessories } = buildPlatform();
-      jest.spyOn(platform, 'searchDevices').mockResolvedValue([device]);
+      jest.spyOn(platform, 'searchDevices').mockResolvedValue([]);
 
       await platform.discoverDevices();
 
       expect(registerPlatformAccessories).not.toHaveBeenCalled();
     });
 
-    it('unregisters a cached accessory when its device is disabled', async () => {
-      const device = buildDevice({ id: 'dev3', name: 'Bedroom', disabled: true });
+    it('unregisters a cached accessory that is absent from discovery results', async () => {
+      // Disabled devices are excluded from searchDevices() results; the stale-pruning
+      // loop in discoverDevices() then unregisters any cached accessory not rediscovered.
       const { platform, unregisterPlatformAccessories } = buildPlatform();
-      jest.spyOn(platform, 'searchDevices').mockResolvedValue([device]);
+      jest.spyOn(platform, 'searchDevices').mockResolvedValue([]);
 
       const cachedAccessory = { displayName: 'Bedroom', UUID: 'uuid:dev3', context: {} };
       platform.configureAccessory(cachedAccessory as never);

--- a/src/devices/SoundTouch/SoundTouchDevice.ts
+++ b/src/devices/SoundTouch/SoundTouchDevice.ts
@@ -135,6 +135,11 @@ export class SoundTouchDevice implements BaseDevice {
           }
         );
 
+        if (accessoryConfig.disabled) {
+          logger.info(`[${info.name}] Skipping disabled accessory`);
+          continue;
+        }
+
         const device = await SoundTouchDevice.fromDiscoveredAccessory({
           api,
           info,

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -93,8 +93,16 @@ export class SoundTouchHomebridgePlatform implements DynamicPlatformPlugin {
       });
     }
 
+    const enabledAccessories = this.configuration.accessories.filter((a) => {
+      if (a.disabled) {
+        this.logger.info('Skipping disabled accessory:', a.name ?? '(unnamed)');
+        return false;
+      }
+      return true;
+    });
+
     const results = await Promise.allSettled(
-      this.configuration.accessories.map((accessoryConfig) =>
+      enabledAccessories.map((accessoryConfig) =>
         SoundTouchDevice.fromConfiguredAccessory({
           accessoryConfig,
           logger: this.logger,
@@ -106,7 +114,7 @@ export class SoundTouchHomebridgePlatform implements DynamicPlatformPlugin {
       if (result.status === 'fulfilled') {
         return [result.value];
       }
-      const name = this.configuration.accessories[index]?.name ?? '(unknown)';
+      const name = enabledAccessories[index]?.name ?? '(unknown)';
       this.logger.error(AppError.create({ name: 'LoadAccessoryFailed', accessory: name, cause: result.reason }));
       return [];
     });
@@ -128,21 +136,6 @@ export class SoundTouchHomebridgePlatform implements DynamicPlatformPlugin {
     for (const device of accessories) {
       const uuid = this.api.hap.uuid.generate(device.id);
 
-      if (device.configuration.disabled) {
-        this.logger.info('Skipping disabled accessory:', device.name);
-        const cachedAccessory = this._accessories.get(uuid);
-        if (cachedAccessory) {
-          this.logger.info(
-            'Unregistering cached disabled accessory:',
-            cachedAccessory.displayName
-          );
-          this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [
-            cachedAccessory,
-          ]);
-        }
-        continue;
-      }
-
       const existingAccessory = this._accessories.get(uuid);
 
       try {
@@ -163,7 +156,7 @@ export class SoundTouchHomebridgePlatform implements DynamicPlatformPlugin {
 
           const accessory = new this.api.platformAccessory(device.name, uuid);
 
-          accessory.context.device = device;
+          accessory.context.deviceId = device.id;
 
           const wrapper = await SoundTouchSpeakerPlatformAccessory.create({
             platform: this,


### PR DESCRIPTION
## What & why

Disabled accessories (both configured via `ip`/`room` and auto-discovered) were previously connected to the network before being filtered out. This caused unnecessary TCP connections and `/info` fetches, plus a `GabboClient` WebSocket connection, for every disabled device on every Homebridge startup.

- **Configured path:** `searchDevices()` now filters disabled accessories *before* calling `SoundTouchDevice.fromConfiguredAccessory()`, so no connection is ever opened.
- **Discovery path:** `discoverAllAccessories()` checks `accessoryConfig.disabled` immediately after `getOrCreateDeviceConfiguration()`, before `fromDiscoveredAccessory()` creates the device and its `GabboClient`.

Also fixes a circular JSON serialization error (`Converting circular structure to JSON → 'Timeout' → '_idlePrev'`): `accessory.context.device` was storing the live `SoundTouchDevice` object (which contains a `GabboClient` with active `setTimeout` handles). Changed to store only `device.id` as `context.deviceId`.

## Verification

- `npm run typecheck && npm run lint && npm test` — 279 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_014sXqcZr8zpTZkmiTFzN5YD)_