### PR TITLE
fix: debounce gabbo WebSocket notifications to avoid redundant refreshes

### DIFF
--- a/src/accessories/SoundTouchSpeakerPlatformAccessory.ts
+++ b/src/accessories/SoundTouchSpeakerPlatformAccessory.ts
@@ -12,10 +12,12 @@ import { SoundTouchSpeakerOnCharacteristic } from './services/SoundTouchSpeakerO
 import { SoundTouchSpeakerBrightnessCharacteristic } from './services/SoundTouchSpeakerBrightnessCharacteristic.js';
 
 const RECONCILIATION_INTERVAL_MS = 5 * 60 * 1000;
+const GABBO_DEBOUNCE_MS = 300;
 
 export class SoundTouchSpeakerPlatformAccessory extends SoundTouchSpeakerCharacteristic {
   private readonly speakerCharacteristics: SoundTouchSpeakerCharacteristic[];
   private _isPolling = false;
+  private _gabboDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
   private constructor({
     speakerCharacteristics,
@@ -46,26 +48,10 @@ export class SoundTouchSpeakerPlatformAccessory extends SoundTouchSpeakerCharact
       //no-op
     });
 
-    this.device.gabbo.on('volumeUpdated', () => {
-      this.refresh().catch((e: unknown) => {
-        this.log.error('Gabbo-triggered refresh failed', e);
-      });
-    });
-    this.device.gabbo.on('nowPlayingUpdated', () => {
-      this.refresh().catch((e: unknown) => {
-        this.log.error('Gabbo-triggered refresh failed', e);
-      });
-    });
-    this.device.gabbo.on('bassUpdated', () => {
-      this.refresh().catch((e: unknown) => {
-        this.log.error('Gabbo-triggered refresh failed', e);
-      });
-    });
-    this.device.gabbo.on('connectionStateUpdated', () => {
-      this.refresh().catch((e: unknown) => {
-        this.log.error('Gabbo-triggered refresh failed', e);
-      });
-    });
+    this.device.gabbo.on('volumeUpdated', () => this._scheduleRefresh());
+    this.device.gabbo.on('nowPlayingUpdated', () => this._scheduleRefresh());
+    this.device.gabbo.on('bassUpdated', () => this._scheduleRefresh());
+    this.device.gabbo.on('connectionStateUpdated', () => this._scheduleRefresh());
 
     this.device.connectGabbo();
 
@@ -82,7 +68,23 @@ export class SoundTouchSpeakerPlatformAccessory extends SoundTouchSpeakerCharact
 
   stopPolling(): void {
     this._isPolling = false;
+    if (this._gabboDebounceTimer !== null) {
+      clearTimeout(this._gabboDebounceTimer);
+      this._gabboDebounceTimer = null;
+    }
     this.device.disconnectGabbo();
+  }
+
+  private _scheduleRefresh(): void {
+    if (this._gabboDebounceTimer !== null) {
+      clearTimeout(this._gabboDebounceTimer);
+    }
+    this._gabboDebounceTimer = setTimeout(() => {
+      this._gabboDebounceTimer = null;
+      this.refresh().catch((e: unknown) => {
+        this.log.error('Gabbo-triggered refresh failed', e);
+      });
+    }, GABBO_DEBOUNCE_MS);
   }
 
   private async _refreshDeviceServices(): Promise<void> {

--- a/src/accessories/__tests__/SoundTouchSpeakerPlatformAccessory.test.ts
+++ b/src/accessories/__tests__/SoundTouchSpeakerPlatformAccessory.test.ts
@@ -4,6 +4,7 @@ import type { SoundTouchSpeakerCharacteristic } from '../services/SoundTouchSpea
 import { LogLevel } from 'homebridge';
 
 const RECONCILIATION_INTERVAL_MS = 5 * 60 * 1000;
+const GABBO_DEBOUNCE_MS = 300;
 
 function build(pollingInterval = 0) {
   const refresh = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
@@ -38,7 +39,7 @@ function build(pollingInterval = 0) {
     speakerCharacteristics: [characteristic],
   });
 
-  return { subject, refresh, homebridgeLog };
+  return { subject, refresh, homebridgeLog, gabboOn };
 }
 
 describe('SoundTouchSpeakerPlatformAccessory', () => {
@@ -111,6 +112,59 @@ describe('SoundTouchSpeakerPlatformAccessory', () => {
       const { subject } = build(0);
 
       expect(() => subject.stopPolling()).not.toThrow();
+    });
+  });
+
+  describe('gabbo notification debouncing', () => {
+    function getCallback(gabboOn: jest.Mock, event: string): () => void {
+      const call = (gabboOn.mock.calls as [string, () => void][]).find(([e]) => e === event);
+      if (!call) throw new Error(`No handler registered for gabbo event: ${event}`);
+      return call[1];
+    }
+
+    it('debounces rapid notifications into a single refresh', async () => {
+      jest.useFakeTimers();
+      const { subject, refresh, gabboOn } = build();
+
+      await subject.init();
+      const fire = getCallback(gabboOn, 'volumeUpdated');
+
+      fire();
+      fire();
+      fire();
+
+      await jest.advanceTimersByTimeAsync(GABBO_DEBOUNCE_MS - 1);
+      expect(refresh).not.toHaveBeenCalled();
+
+      await jest.advanceTimersByTimeAsync(1);
+      expect(refresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('coalesces different gabbo event types into a single refresh', async () => {
+      jest.useFakeTimers();
+      const { subject, refresh, gabboOn } = build();
+
+      await subject.init();
+
+      getCallback(gabboOn, 'volumeUpdated')();
+      getCallback(gabboOn, 'nowPlayingUpdated')();
+      getCallback(gabboOn, 'connectionStateUpdated')();
+
+      await jest.advanceTimersByTimeAsync(GABBO_DEBOUNCE_MS);
+      expect(refresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancels a pending debounced refresh when stopPolling is called', async () => {
+      jest.useFakeTimers();
+      const { subject, refresh, gabboOn } = build();
+
+      await subject.init();
+      getCallback(gabboOn, 'volumeUpdated')();
+
+      subject.stopPolling();
+      await jest.advanceTimersByTimeAsync(GABBO_DEBOUNCE_MS);
+
+      expect(refresh).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## What & why

Multiple gabbo WebSocket events arriving in quick succession (e.g. volume + connection state change on power-on) each independently triggered a full `refresh()` — one HTTP call per characteristic per event. A burst of 3–4 events caused 3–4 redundant API round-trips.

A 300 ms debounce in `_scheduleRefresh()` coalesces any burst into a single `refresh()` call. All four event handlers (`volumeUpdated`, `nowPlayingUpdated`, `bassUpdated`, `connectionStateUpdated`) share the same debounce timer, so mixed-event bursts also converge.

`stopPolling()` clears any pending debounce timer so no refresh fires after the device is unregistered.

## Verification

- `npm run typecheck && npm run lint && npm test` — 282 tests pass (3 new debounce tests added)

---
_Generated by [Claude Code](https://claude.ai/code/session_014sXqcZr8zpTZkmiTFzN5YD)_