### PR TITLE
fix: map gabbo events to specific characteristics instead of full refresh

### DIFF
--- a/src/accessories/SoundTouchSpeakerPlatformAccessory.ts
+++ b/src/accessories/SoundTouchSpeakerPlatformAccessory.ts
@@ -7,17 +7,16 @@ import {
   ServiceType,
   SoundTouchSpeakerCharacteristic,
 } from './services/SoundTouchSpeakerCharacteristic.js';
+import type { GabboUpdateType } from '../devices/SoundTouch/api/GabboClient.js';
 import { SoundTouchSpeakerInformationCharacteristic } from './services/SoundTouchSpeakerInformationCharacteristic.js';
 import { SoundTouchSpeakerOnCharacteristic } from './services/SoundTouchSpeakerOnCharacteristic.js';
 import { SoundTouchSpeakerBrightnessCharacteristic } from './services/SoundTouchSpeakerBrightnessCharacteristic.js';
 
 const RECONCILIATION_INTERVAL_MS = 5 * 60 * 1000;
-const GABBO_DEBOUNCE_MS = 300;
 
 export class SoundTouchSpeakerPlatformAccessory extends SoundTouchSpeakerCharacteristic {
   private readonly speakerCharacteristics: SoundTouchSpeakerCharacteristic[];
   private _isPolling = false;
-  private _gabboDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
   private constructor({
     speakerCharacteristics,
@@ -48,10 +47,17 @@ export class SoundTouchSpeakerPlatformAccessory extends SoundTouchSpeakerCharact
       //no-op
     });
 
-    this.device.gabbo.on('volumeUpdated', () => this._scheduleRefresh());
-    this.device.gabbo.on('nowPlayingUpdated', () => this._scheduleRefresh());
-    this.device.gabbo.on('bassUpdated', () => this._scheduleRefresh());
-    this.device.gabbo.on('connectionStateUpdated', () => this._scheduleRefresh());
+    const eventMap = new Map<GabboUpdateType, SoundTouchSpeakerCharacteristic[]>();
+    for (const characteristic of this.speakerCharacteristics) {
+      for (const event of characteristic.gabboEvents) {
+        const list = eventMap.get(event) ?? [];
+        list.push(characteristic);
+        eventMap.set(event, list);
+      }
+    }
+    for (const [event, characteristics] of eventMap) {
+      this.device.gabbo.on(event, () => this._refreshCharacteristics(characteristics));
+    }
 
     this.device.connectGabbo();
 
@@ -68,23 +74,17 @@ export class SoundTouchSpeakerPlatformAccessory extends SoundTouchSpeakerCharact
 
   stopPolling(): void {
     this._isPolling = false;
-    if (this._gabboDebounceTimer !== null) {
-      clearTimeout(this._gabboDebounceTimer);
-      this._gabboDebounceTimer = null;
-    }
     this.device.disconnectGabbo();
   }
 
-  private _scheduleRefresh(): void {
-    if (this._gabboDebounceTimer !== null) {
-      clearTimeout(this._gabboDebounceTimer);
-    }
-    this._gabboDebounceTimer = setTimeout(() => {
-      this._gabboDebounceTimer = null;
-      this.refresh().catch((e: unknown) => {
-        this.log.error('Gabbo-triggered refresh failed', e);
-      });
-    }, GABBO_DEBOUNCE_MS);
+  private _refreshCharacteristics(characteristics: SoundTouchSpeakerCharacteristic[]): void {
+    Promise.allSettled(characteristics.map((c) => c.refresh())).then((results) => {
+      for (const result of results) {
+        if (result.status === 'rejected') {
+          this.log.error('Gabbo-triggered refresh failed', result.reason);
+        }
+      }
+    });
   }
 
   private async _refreshDeviceServices(): Promise<void> {

--- a/src/accessories/__tests__/SoundTouchSpeakerPlatformAccessory.test.ts
+++ b/src/accessories/__tests__/SoundTouchSpeakerPlatformAccessory.test.ts
@@ -1,27 +1,27 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import { SoundTouchSpeakerPlatformAccessory } from '../SoundTouchSpeakerPlatformAccessory.js';
 import type { SoundTouchSpeakerCharacteristic } from '../services/SoundTouchSpeakerCharacteristic.js';
+import type { GabboUpdateType } from '../../devices/SoundTouch/api/GabboClient.js';
 import { LogLevel } from 'homebridge';
 
 const RECONCILIATION_INTERVAL_MS = 5 * 60 * 1000;
-const GABBO_DEBOUNCE_MS = 300;
 
-function build(pollingInterval = 0) {
+function buildCharacteristic(gabboEvents: readonly GabboUpdateType[] = []) {
   const refresh = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
   const init = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
-  const characteristic = { init, refresh } as unknown as SoundTouchSpeakerCharacteristic;
+  return { characteristic: { init, refresh, gabboEvents } as unknown as SoundTouchSpeakerCharacteristic, refresh, init };
+}
+
+function build(opts: { pollingInterval?: number; gabboEvents?: readonly GabboUpdateType[] } = {}) {
+  const { pollingInterval = 0, gabboEvents = [] } = opts;
+  const { characteristic, refresh } = buildCharacteristic(gabboEvents);
 
   const homebridgeLog = jest.fn();
   const gabboOn = jest.fn();
-  const gabboDevice = {
-    on: gabboOn,
-    connect: jest.fn(),
-    disconnect: jest.fn(),
-  };
   const device = {
     name: 'Kitchen',
     configuration: { pollingInterval },
-    gabbo: gabboDevice,
+    gabbo: { on: gabboOn, connect: jest.fn(), disconnect: jest.fn() },
     connectGabbo: jest.fn(),
     disconnectGabbo: jest.fn(),
   };
@@ -42,6 +42,12 @@ function build(pollingInterval = 0) {
   return { subject, refresh, homebridgeLog, gabboOn };
 }
 
+function getCallback(gabboOn: jest.Mock, event: string): () => void {
+  const call = (gabboOn.mock.calls as [string, () => void][]).find(([e]) => e === event);
+  if (!call) throw new Error(`No handler registered for gabbo event: ${event}`);
+  return call[1];
+}
+
 describe('SoundTouchSpeakerPlatformAccessory', () => {
   afterEach(() => {
     jest.useRealTimers();
@@ -50,7 +56,7 @@ describe('SoundTouchSpeakerPlatformAccessory', () => {
   describe('reconciliation polling', () => {
     it('always starts the reconciliation loop on init regardless of pollingInterval config', async () => {
       jest.useFakeTimers();
-      const { subject, refresh } = build(0);
+      const { subject, refresh } = build();
 
       await subject.init();
       await jest.advanceTimersByTimeAsync(RECONCILIATION_INTERVAL_MS);
@@ -60,7 +66,7 @@ describe('SoundTouchSpeakerPlatformAccessory', () => {
 
     it('does not fire before the reconciliation interval elapses', async () => {
       jest.useFakeTimers();
-      const { subject, refresh } = build(0);
+      const { subject, refresh } = build();
 
       await subject.init();
       await jest.advanceTimersByTimeAsync(RECONCILIATION_INTERVAL_MS - 1);
@@ -70,7 +76,7 @@ describe('SoundTouchSpeakerPlatformAccessory', () => {
 
     it('logs a deprecation warning when pollingInterval is configured', async () => {
       jest.useFakeTimers();
-      const { subject, homebridgeLog } = build(5000);
+      const { subject, homebridgeLog } = build({ pollingInterval: 5000 });
 
       await subject.init();
 
@@ -82,7 +88,7 @@ describe('SoundTouchSpeakerPlatformAccessory', () => {
 
     it('does not log a deprecation warning when pollingInterval is 0', async () => {
       jest.useFakeTimers();
-      const { subject, homebridgeLog } = build(0);
+      const { subject, homebridgeLog } = build({ pollingInterval: 0 });
 
       await subject.init();
 
@@ -94,7 +100,7 @@ describe('SoundTouchSpeakerPlatformAccessory', () => {
 
     it('stops the reconciliation loop after stopPolling is called', async () => {
       jest.useFakeTimers();
-      const { subject, refresh } = build(0);
+      const { subject, refresh } = build();
 
       await subject.init();
       await jest.advanceTimersByTimeAsync(RECONCILIATION_INTERVAL_MS);
@@ -109,61 +115,54 @@ describe('SoundTouchSpeakerPlatformAccessory', () => {
     });
 
     it('is safe to call stopPolling before init', () => {
-      const { subject } = build(0);
+      const { subject } = build();
 
       expect(() => subject.stopPolling()).not.toThrow();
     });
   });
 
-  describe('gabbo notification debouncing', () => {
-    function getCallback(gabboOn: jest.Mock, event: string): () => void {
-      const call = (gabboOn.mock.calls as [string, () => void][]).find(([e]) => e === event);
-      if (!call) throw new Error(`No handler registered for gabbo event: ${event}`);
-      return call[1];
-    }
-
-    it('debounces rapid notifications into a single refresh', async () => {
+  describe('gabbo event subscriptions', () => {
+    it('subscribes only to events declared by characteristics', async () => {
       jest.useFakeTimers();
-      const { subject, refresh, gabboOn } = build();
-
-      await subject.init();
-      const fire = getCallback(gabboOn, 'volumeUpdated');
-
-      fire();
-      fire();
-      fire();
-
-      await jest.advanceTimersByTimeAsync(GABBO_DEBOUNCE_MS - 1);
-      expect(refresh).not.toHaveBeenCalled();
-
-      await jest.advanceTimersByTimeAsync(1);
-      expect(refresh).toHaveBeenCalledTimes(1);
-    });
-
-    it('coalesces different gabbo event types into a single refresh', async () => {
-      jest.useFakeTimers();
-      const { subject, refresh, gabboOn } = build();
+      const { subject, gabboOn } = build({ gabboEvents: ['volumeUpdated'] });
 
       await subject.init();
 
-      getCallback(gabboOn, 'volumeUpdated')();
-      getCallback(gabboOn, 'nowPlayingUpdated')();
-      getCallback(gabboOn, 'connectionStateUpdated')();
-
-      await jest.advanceTimersByTimeAsync(GABBO_DEBOUNCE_MS);
-      expect(refresh).toHaveBeenCalledTimes(1);
+      const registeredEvents = (gabboOn.mock.calls as [string, unknown][]).map(([e]) => e);
+      expect(registeredEvents).toContain('volumeUpdated');
+      expect(registeredEvents).not.toContain('connectionStateUpdated');
+      expect(registeredEvents).not.toContain('nowPlayingUpdated');
+      expect(registeredEvents).not.toContain('bassUpdated');
     });
 
-    it('cancels a pending debounced refresh when stopPolling is called', async () => {
+    it('does not register any gabbo handlers when no characteristic declares events', async () => {
       jest.useFakeTimers();
-      const { subject, refresh, gabboOn } = build();
+      const { subject, gabboOn } = build({ gabboEvents: [] });
+
+      await subject.init();
+
+      expect(gabboOn).not.toHaveBeenCalled();
+    });
+
+    it('calls refresh on the characteristic when its declared event fires', async () => {
+      jest.useFakeTimers();
+      const { subject, refresh, gabboOn } = build({ gabboEvents: ['volumeUpdated'] });
 
       await subject.init();
       getCallback(gabboOn, 'volumeUpdated')();
+      await jest.advanceTimersByTimeAsync(0);
 
-      subject.stopPolling();
-      await jest.advanceTimersByTimeAsync(GABBO_DEBOUNCE_MS);
+      expect(refresh).toHaveBeenCalledTimes(1);
+    });
 
+    it('does not call refresh when an unsubscribed event fires', async () => {
+      jest.useFakeTimers();
+      const { subject, refresh, gabboOn } = build({ gabboEvents: ['volumeUpdated'] });
+
+      await subject.init();
+
+      const registeredEvents = (gabboOn.mock.calls as [string, unknown][]).map(([e]) => e);
+      expect(registeredEvents).not.toContain('connectionStateUpdated');
       expect(refresh).not.toHaveBeenCalled();
     });
   });

--- a/src/accessories/services/SoundTouchSpeakerBrightnessCharacteristic.ts
+++ b/src/accessories/services/SoundTouchSpeakerBrightnessCharacteristic.ts
@@ -7,8 +7,10 @@ import {
 import { SoundTouchDevice } from '../../devices/SoundTouch/SoundTouchDevice.js';
 import { SoundTouchHomebridgePlatform } from '../../platform.js';
 import { SoundTouchSpeakerCharacteristic } from './SoundTouchSpeakerCharacteristic.js';
+import type { GabboUpdateType } from '../../devices/SoundTouch/api/GabboClient.js';
 
 export class SoundTouchSpeakerBrightnessCharacteristic extends SoundTouchSpeakerCharacteristic {
+  override readonly gabboEvents: readonly GabboUpdateType[] = ['volumeUpdated'];
   private readonly service: Service;
   private characteristic: Characteristic;
 

--- a/src/accessories/services/SoundTouchSpeakerCharacteristic.ts
+++ b/src/accessories/services/SoundTouchSpeakerCharacteristic.ts
@@ -3,6 +3,7 @@ import { SoundTouchHomebridgePlatform } from '../../platform.js';
 import { CharacteristicValue, PlatformAccessory } from 'homebridge';
 import { DeviceLogger, Logger } from '../../utils/FormattedLogger.js';
 import { AppError } from '../../errors.js';
+import type { GabboUpdateType } from '../../devices/SoundTouch/api/GabboClient.js';
 
 export enum ServiceType {
   'ON_OFF' = 'ON',
@@ -71,6 +72,8 @@ export abstract class SoundTouchSpeakerCharacteristic {
       }
     };
   }
+
+  readonly gabboEvents: readonly GabboUpdateType[] = [];
 
   init(): Promise<void> {
     return Promise.resolve();

--- a/src/accessories/services/SoundTouchSpeakerOnCharacteristic.ts
+++ b/src/accessories/services/SoundTouchSpeakerOnCharacteristic.ts
@@ -8,8 +8,10 @@ import { SoundTouchDevice } from '../../devices/SoundTouch/SoundTouchDevice.js';
 import { SoundTouchHomebridgePlatform } from '../../platform.js';
 import { KeyValue } from '../../devices/SoundTouch/api/index.js';
 import { SoundTouchSpeakerCharacteristic } from './SoundTouchSpeakerCharacteristic.js';
+import type { GabboUpdateType } from '../../devices/SoundTouch/api/GabboClient.js';
 
 export class SoundTouchSpeakerOnCharacteristic extends SoundTouchSpeakerCharacteristic {
+  override readonly gabboEvents: readonly GabboUpdateType[] = ['connectionStateUpdated'];
   private readonly service: Service;
 
   private characteristic: Characteristic;


### PR DESCRIPTION
## What & why

Every gabbo WebSocket event previously triggered a full `refresh()` across all characteristics. A `volumeUpdated` notification would redundantly call `SoundTouchSpeakerOnCharacteristic.refresh()`, and vice versa. `nowPlayingUpdated` and `bassUpdated` were subscribed to even though no characteristic used them.

Each characteristic now declares `gabboEvents: readonly GabboUpdateType[]` on the base class (default `[]`). The platform builds an `event → characteristics[]` map at `init()` time and registers only the subscriptions that are needed:

- `volumeUpdated` → `BrightnessCharacteristic` only
- `connectionStateUpdated` → `OnCharacteristic` only
- `nowPlayingUpdated`, `bassUpdated` — not subscribed until a characteristic needs them

Future characteristics opt in by overriding `gabboEvents` — no changes to the platform wiring required.

## Verification

- `npm run typecheck && npm run lint && npm test` — 283 tests pass (4 new targeted-subscription tests added)

---
_Generated by [Claude Code](https://claude.ai/code/session_014sXqcZr8zpTZkmiTFzN5YD)_