### PR TITLE
docs: expand PWA config-write scope and add speaker setup helper plan

### DIFF
--- a/.claude/skills/architect/plans/2026-06-19-progressive-web-app.md
+++ b/.claude/skills/architect/plans/2026-06-19-progressive-web-app.md
@@ -43,6 +43,8 @@ from a lightweight HTTP server embedded in the plugin.
 | 2026-06-23 | **Phase 3 scope expanded — config write must cover preset stations, source selection, and speaker groups** | The internet-radio plan (`2026-06-22-internet-radio-tunein.md`) landed a typed preset system requiring users to hand-edit `config.json` with TuneIn IDs. The PWA is the natural GUI for this: add/edit/delete station presets, change the active source per speaker, and wire up multi-room groups — all via a config-write endpoint, without requiring the Homebridge Config UI. This converges the setup story: speaker added via bose-cloud emulator (see `2026-06-23-speaker-setup-helper.md`), then configured entirely through the PWA. | Separate admin app — extra install friction; Homebridge Config UI — JSON-only, no UX for slots/groups |
 | 2026-06-23 | Config-write API must reload the plugin after writing | Homebridge reads `config.json` at startup; a config push that doesn't restart is silently ignored. Options: signal the Homebridge API to restart this platform only (child bridge restart via `api.updatePlatformAccessories`), or instruct the user to restart. Spike B must confirm the cleanest path. | Live-reload without restart — not supported by Homebridge core |
 | 2026-06-23 | Phase 3 config-write scope: `accessories[]`, `global.presets[]`, `global.presetSyncInterval` | These three config sections cover the full speaker management use case: add/remove/rename speakers, assign TuneIn presets to slots, and tune the sync schedule. Source selection (active source per speaker) is a live device call, not a config write — it belongs in Phase 2's REST API alongside zone management. | Writing the entire platform config block — too broad; risks overwriting other plugin settings |
+| 2026-06-23 | PWA "Presets" screen must include **TuneIn station search** — user types a station name, gets results, picks one, assigns it to a slot | Without search the user must know the TuneIn ID (e.g. `s7162`) — not discoverable. RadioTime OPML search endpoint: `https://opml.radiotime.com/Search.ashx?query=<name>&types=station&render=json`. Returns `body[].guide_id` (the TuneIn ID) and `body[].text` (station name). No new npm dep — plugin can proxy this call via `axios`. | Require users to look up IDs manually — poor UX, blocks non-developers |
+| 2026-06-23 | Spotify preset search is deferred — Spotify requires OAuth and a registered app; TuneIn is anonymous | The bose-cloud emulator only handles TUNEIN source today. Spotify presets would need a separate `source="SPOTIFY"` ContentItem path and OAuth flow — significant scope. Note it as a future extension, do not include in the initial Phase 3 PR. | Including Spotify in Phase 3 — too large; unblocks the core use case without it |
 
 ## If cancelled
 
@@ -121,6 +123,8 @@ Scope: `accessories[]` (speakers), `global.presets[]` (TuneIn station slots),
   - `PATCH /config/presets` — add/edit/delete station preset entries (slot,
     name, tuneInId, imageUrl).
   - `PATCH /config/presetSyncInterval` — update sync schedule.
+  - `GET /tunein/search?q=<name>` — proxy to RadioTime `Search.ashx`; returns
+    `[{ tuneInId, name, imageUrl }]`. Powers the PWA "Presets" search UI.
 - Writes atomically to `api.user.storagePath()/config.json`
   (write-then-rename); must not race Homebridge's own config writes.
 - Triggers a plugin reload after writing (mechanism TBD — Spike B).
@@ -173,7 +177,13 @@ Scope: `accessories[]` (speakers), `global.presets[]` (TuneIn station slots),
 - [ ] Atomic config write (write-then-rename in `api.user.storagePath()`)
 - [ ] Trigger plugin reload after write (or surface restart prompt)
 - [ ] PWA "Speakers" screen: add/remove/rename speakers by IP
-- [ ] PWA "Presets" screen: assign TuneIn station IDs to slots 1–6
+- [ ] PWA "Presets" screen:
+      - Search TuneIn by station name → results list → pick station → assign to
+        slot 1–6. Plugin proxies RadioTime search (`Search.ashx?query=<name>`)
+        and returns `[{ tuneInId, name, imageUrl }]`.
+      - Show existing preset assignments (read from current config).
+      - Save → `PATCH /config/presets` → plugin writes config + reloads.
+      - (Future) Spotify preset search — deferred; requires OAuth.
 
 ## Verification
 

--- a/.claude/skills/architect/plans/2026-06-19-progressive-web-app.md
+++ b/.claude/skills/architect/plans/2026-06-19-progressive-web-app.md
@@ -40,10 +40,9 @@ from a lightweight HTTP server embedded in the plugin.
 | 2026-06-19 | Phase 3 (Homebridge config sync) requires an HTTP API endpoint exposed by the plugin | The Homebridge Config UI handles plugin settings via `config.schema.json` in-process; direct config edits need `api.user.storagePath()` and must not race Homebridge's own write | Writing config outside Homebridge storage dir — violates verified-plugin rules |
 | 2026-06-19 | PWA must work offline during the provisioning flow | During setup the phone is on the speaker's hotspot, not the home network — the PWA cannot reach the internet or the Homebridge host | Server-side-rendered app that requires constant connectivity |
 | 2026-06-20 | **Hosting resolved: embedded HTTP server in the plugin** | Research confirms Homebridge plugins can run their own HTTP server inside the Homebridge process (same pattern as `homebridge-http-webhooks`, `homebridge-mqttthing`). Plugin starts Express on a configurable port in `didFinishLaunching`; serves `web/dist/` statically. Phone installs the PWA from the plugin URL while on the home network, service worker caches it, then it operates offline during the provisioning hotspot step. | GitHub Pages — requires internet during install, no control over hosting; assumes user has internet access during provisioning UX |
-| 2026-06-19 | Phase 2 (group management) IS possible with documented API: `/getZone`, `/setZone`, `/addZoneSlave`, `/removeZoneSlave` | All four endpoints are in the v1.1 spec and implemented in `src/devices/SoundTouch/api/zone.ts` | — |
-| 2026-06-19 | Phase 3 (Homebridge config sync) requires an HTTP API endpoint exposed by the plugin | The Homebridge Config UI handles plugin settings via `config.schema.json` in-process; direct config edits need `api.user.storagePath()` and must not race Homebridge's own write | Writing config outside Homebridge storage dir — violates verified-plugin rules |
-| 2026-06-19 | PWA must work offline during the provisioning flow | During setup the phone is on the speaker's hotspot, not the home network — the PWA cannot reach the internet or the Homebridge host | Server-side-rendered app that requires constant connectivity |
-| 2026-06-20 | **Hosting resolved: embedded HTTP server in the plugin** | Research confirms Homebridge plugins can run their own HTTP server inside the Homebridge process (same pattern as `homebridge-http-webhooks`, `homebridge-mqttthing`). Plugin starts Express on a configurable port in `didFinishLaunching`; serves `web/dist/` statically. Phone installs the PWA from the plugin URL while on the home network, service worker caches it, then it operates offline during the provisioning hotspot step. | GitHub Pages — requires internet during install, no control over hosting; assumes user has internet access during provisioning UX |
+| 2026-06-23 | **Phase 3 scope expanded — config write must cover preset stations, source selection, and speaker groups** | The internet-radio plan (`2026-06-22-internet-radio-tunein.md`) landed a typed preset system requiring users to hand-edit `config.json` with TuneIn IDs. The PWA is the natural GUI for this: add/edit/delete station presets, change the active source per speaker, and wire up multi-room groups — all via a config-write endpoint, without requiring the Homebridge Config UI. This converges the setup story: speaker added via bose-cloud emulator (see `2026-06-23-speaker-setup-helper.md`), then configured entirely through the PWA. | Separate admin app — extra install friction; Homebridge Config UI — JSON-only, no UX for slots/groups |
+| 2026-06-23 | Config-write API must reload the plugin after writing | Homebridge reads `config.json` at startup; a config push that doesn't restart is silently ignored. Options: signal the Homebridge API to restart this platform only (child bridge restart via `api.updatePlatformAccessories`), or instruct the user to restart. Spike B must confirm the cleanest path. | Live-reload without restart — not supported by Homebridge core |
+| 2026-06-23 | Phase 3 config-write scope: `accessories[]`, `global.presets[]`, `global.presetSyncInterval` | These three config sections cover the full speaker management use case: add/remove/rename speakers, assign TuneIn presets to slots, and tune the sync schedule. Source selection (active source per speaker) is a live device call, not a config write — it belongs in Phase 2's REST API alongside zone management. | Writing the entire platform config block — too broad; risks overwriting other plugin settings |
 
 ## If cancelled
 
@@ -99,19 +98,34 @@ from a lightweight HTTP server embedded in the plugin.
 - `config.schema.json` + config classes — `webPort` (opt-in, default off) if the
   embedded server path is chosen.
 
-### Phase 2 — Group management (zone API)
+### Phase 2 — Live device control (source selection + group management)
 
-- The PWA adds a "Groups" screen calling the Homebridge plugin's REST API (or
-  talking directly to speakers if the phone is on the same LAN).
-- `src/devices/SoundTouch/api/zone.ts` already implements `getZone`, `setZone`,
-  `addZoneSlave`, `removeZoneSlave` — these are the backend calls.
-- If surfaced via the plugin's REST API: new routes in `src/server/`.
+- The PWA adds a "Groups" screen and a per-speaker "Source" picker.
+- **Source selection:** calls `POST /select` on the target speaker with the chosen
+  `ContentItem` (AUX, BLUETOOTH, TUNEIN preset, etc.). Sources available via
+  `GET /sources`. This is a live device call — no config write needed.
+- **Zone management:** create/update/delete multi-room zones via `setZone`,
+  `addZoneSlave`, `removeZoneSlave`. `src/devices/SoundTouch/api/zone.ts` already
+  implements these.
+- All live calls proxied through new routes in `src/server/` (plugin REST API),
+  so the PWA doesn't need per-speaker LAN access — it talks to the plugin.
 
-### Phase 3 — Homebridge config sync
+### Phase 3 — Homebridge config write
 
-- New REST endpoint(s) in `src/server/` to GET/PATCH the plugin's platform block
-  in `config.json` (under `api.user.storagePath()`). Write atomically.
-- The PWA gains a "Settings" screen to edit speaker IPs, names, groups.
+Scope: `accessories[]` (speakers), `global.presets[]` (TuneIn station slots),
+`global.presetSyncInterval`.
+
+- New REST endpoints in `src/server/`:
+  - `GET /config` — returns the current plugin platform block (sanitised).
+  - `PATCH /config/accessories` — add/remove/rename speakers (name, IP, port).
+  - `PATCH /config/presets` — add/edit/delete station preset entries (slot,
+    name, tuneInId, imageUrl).
+  - `PATCH /config/presetSyncInterval` — update sync schedule.
+- Writes atomically to `api.user.storagePath()/config.json`
+  (write-then-rename); must not race Homebridge's own config writes.
+- Triggers a plugin reload after writing (mechanism TBD — Spike B).
+- PWA gains a "Speakers" screen (add speaker by IP, rename) and a "Presets"
+  screen (assign TuneIn stations to slots 1–6 per speaker group).
 
 ## Conventions for this change
 
@@ -144,18 +158,22 @@ from a lightweight HTTP server embedded in the plugin.
 - [ ] If embedded server: add `webPort` config + `src/server/` Express routes
 - [ ] Add `build:web` script and CI step
 
-### Phase 2 — Group management
-- [ ] PWA "Groups" screen: discover speakers (via Homebridge REST API or direct
-      mDNS on same LAN), show current zones
-- [ ] Create/update/delete zones → `setZone` / `addZoneSlave` / `removeZoneSlave`
-- [ ] REST routes in `src/server/` proxying the zone API calls
+### Phase 2 — Live device control (source selection + group management)
+- [ ] Plugin REST API routes in `src/server/`:
+      `GET /speakers` (list known devices), `POST /speakers/:id/source`,
+      `GET /speakers/:id/sources`, `GET /speakers/:id/zone`,
+      `POST /speakers/:id/zone`, `DELETE /speakers/:id/zone`
+- [ ] PWA "Groups" screen: show current zones, create/edit/delete zones
+- [ ] PWA per-speaker "Source" picker: list available sources, select active one
 
-### Phase 3 — Homebridge config sync
-- [ ] Spike B: confirm config write path safety
-- [ ] REST GET/PATCH routes for plugin config (`src/server/`)
+### Phase 3 — Homebridge config write
+- [ ] Spike B: confirm config write path safety + reload mechanism
+- [ ] Plugin REST API routes: `GET /config`, `PATCH /config/accessories`,
+      `PATCH /config/presets`, `PATCH /config/presetSyncInterval`
 - [ ] Atomic config write (write-then-rename in `api.user.storagePath()`)
-- [ ] PWA "Settings" screen
-- [ ] Trigger Homebridge reload or surface restart prompt after config push
+- [ ] Trigger plugin reload after write (or surface restart prompt)
+- [ ] PWA "Speakers" screen: add/remove/rename speakers by IP
+- [ ] PWA "Presets" screen: assign TuneIn station IDs to slots 1–6
 
 ## Verification
 
@@ -165,14 +183,14 @@ from a lightweight HTTP server embedded in the plugin.
 - [ ] **Phase 1:** On a real speaker in setup mode, run through the full
       provisioning flow on an iOS + Android device; confirm PWA installs from home
       screen and works offline on the speaker's hotspot.
-- [ ] **Phase 2:** Create, modify, and destroy a zone from the PWA; confirm
-      Homebridge reflects the change.
-- [ ] **Phase 3:** Push a config change from the PWA; restart Homebridge; confirm
-      the new config takes effect.
+- [ ] **Phase 2:** Select AUX source from PWA on a real speaker → source changes.
+      Create a zone (master + slave), confirm multi-room playback, then delete zone.
+- [ ] **Phase 3:** Add a TuneIn preset via PWA "Presets" screen → config.json
+      updated, plugin reloads, preset button on speaker plays the station.
 
 ## PR / release notes
 
 - **Phase 1 PR title:** `feat: add PWA for SoundTouch WiFi provisioning`
-- **Phase 2 PR title:** `feat: add group management to provisioning PWA`
-- **Phase 3 PR title:** `feat: add Homebridge config sync to provisioning PWA`
+- **Phase 2 PR title:** `feat: add source selection and group management to provisioning PWA`
+- **Phase 3 PR title:** `feat: add Homebridge config write to provisioning PWA`
 - **Targets:** `dev`

--- a/.claude/skills/architect/plans/2026-06-23-speaker-setup-helper.md
+++ b/.claude/skills/architect/plans/2026-06-23-speaker-setup-helper.md
@@ -1,12 +1,12 @@
 ---
-feature: Speaker setup helper — bose-cloud redirect automation
+feature: Speaker setup helper — SSH script to redirect speaker to bose-cloud emulator
 status: planned
 date: 2026-06-23
 branch: feat/speaker-setup-helper
 commit-type: feat
 ---
 
-# Speaker setup helper — bose-cloud redirect automation
+# Speaker setup helper — SSH script to redirect speaker to bose-cloud emulator
 
 ## Context
 
@@ -16,29 +16,24 @@ SoundTouch speaker to be redirected from Bose's defunct cloud to a local
 `/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml` to point `bmxRegistryUrl` and
 `margeServerUrl` at the Homebridge host.
 
-Currently that setup is purely manual. This plan explores making it easier via:
+Currently that edit is documented in the `bose-cloud.mjs` script header, but
+users must do it manually over SSH. This plan delivers a helper script
+(`scripts/setup-speaker.sh`) that automates the SSH steps: connect, patch the
+XML, reboot.
 
-1. **A helper script** (`scripts/setup-speaker.sh` or `scripts/setup-speaker.mjs`)
-   that automates the SSH steps: connects to the speaker, edits the XML, and
-   reboots — driven by a known IP address.
-2. **A bootable USB image** that can be flashed to a USB drive, inserted into a
-   computer on the same LAN as the speakers, and run without any Node.js / npm
-   install. Useful for users who aren't developers.
-
-These are distinct deliverables that can land independently. The helper script
-is lower risk and can ship first; the USB image is a larger effort.
+A bootable USB image for non-developer users is a separate, larger effort that
+requires its own research — see `2026-06-23-speaker-usb-image.md`.
 
 **Dependency:** `2026-06-22-internet-radio-tunein.md` (PR #118) must merge first
-so the `bose-cloud.mjs` emulator and its documented config values exist in `dev`.
+so `bose-cloud.mjs` and its documented URL values exist in `dev`.
 
 ## Decisions & findings
 
 | Date | Decision / finding | Rationale / evidence | Alternatives rejected |
 | --- | --- | --- | --- |
-| 2026-06-23 | Finding: speaker SSH access confirmed — soundcork `docs/speaker-setup.md` documents SSH login (`root`, no password on most models) and the XML file path | Prerequisite for any automated approach | Telnet / SoundTouch API — no write path to system files via HTTP API |
-| 2026-06-23 | Helper script approach: `ssh root@<IP> "sed -i ..."` to patch the XML in-place | Minimal deps — `ssh` available everywhere; no new npm packages in the plugin | scp + edit locally + scp back — more moving parts; sed in-place is atomic enough for this file |
-| 2026-06-23 | USB image approach deferred to spike | Requires selecting a base image (Alpine Linux, Raspberry Pi OS Lite, etc.), packaging Node.js + the scripts, and automating the flash workflow (Etcher, `dd`). Scope is significant — needs feasibility check. | Shipping USB image immediately — too much unknown; helper script delivers value sooner |
-| 2026-06-23 | USB image target: x86_64 + ARM64 (Raspberry Pi) | Most users run Homebridge on a Pi; a Pi-compatible image can also run in a VM on x86 | x86-only — excludes the dominant Homebridge hardware |
+| 2026-06-23 | Finding: speaker SSH access confirmed — soundcork `docs/speaker-setup.md` documents SSH login (`root`, no password on most models) and the XML file path `/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml` | Prerequisite for any automated approach | Telnet / SoundTouch HTTP API — no write path to system files |
+| 2026-06-23 | Helper script approach: `ssh root@<IP> "sed -i ..."` to patch the XML in-place | Minimal deps — `ssh` available everywhere; no new npm packages | scp + edit locally + scp back — more moving parts; sed in-place is atomic enough for this single file |
+| 2026-06-23 | Script must be idempotent | Running it twice on the same speaker must be safe (writes the same values again, reboots again) | One-shot only — user could run it accidentally after setup; idempotency is free with sed |
 
 ## If cancelled
 
@@ -46,87 +41,50 @@ so the `bose-cloud.mjs` emulator and its documented config values exist in `dev`
 
 ## Affected areas
 
-### Helper script
-
-- **New `scripts/setup-speaker.sh`** (or `.mjs`):
+- **New `scripts/setup-speaker.sh`:**
   - Accepts `--ip <SPEAKER_IP>` and `--host <HOMEBRIDGE_HOST>` (defaults to
-    auto-detected LAN IP, same logic as the platform).
+    first non-loopback IPv4 via `hostname -I`, or `ip route get` equivalent).
   - SSHes into `root@<SPEAKER_IP>` (no password on most SoundTouch models).
-  - Reads `/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml`.
   - Patches `bmxRegistryUrl` → `http://<HOMEBRIDGE_HOST>:8000/bmx/registry/v1/services`
-    and `margeServerUrl` → `http://<HOMEBRIDGE_HOST>:8000/marge`.
-  - Reboots the speaker (`reboot` or `kill -9 1`).
-  - Prints clear instructions: "Now start `bose-cloud.mjs` on your Homebridge
-    host before the speaker comes back online."
-- No new npm runtime deps. `ssh` is a system tool.
-- Add usage docs to the script header and/or a `docs/bose-cloud-setup.md`.
-
-### USB image (spike first)
-
-- Base image TBD (Alpine Linux recommended for size; Raspberry Pi OS Lite for
-  Pi compatibility).
-- Packages to bundle: Node.js LTS, this plugin's `scripts/` directory.
-- Boot flow: auto-run a TUI or simple interactive menu that:
-  1. Scans the LAN for SoundTouch speakers (mDNS / SSDP).
-  2. Lets the user select a speaker.
-  3. Runs the helper script against the selected speaker.
-  4. Optionally starts `bose-cloud.mjs` persistently (systemd service).
-- Build tooling: `packer`, `docker buildx`, or a custom shell script with
-  `debootstrap` / `alpine-make-rootfs`.
-- Output: `.img.gz` file published as a GitHub Release asset.
+    and `margeServerUrl` → `http://<HOMEBRIDGE_HOST>:8000/marge` in
+    `/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml`.
+  - Reboots the speaker.
+  - Prints clear next-step instructions: start `bose-cloud.mjs` before the
+    speaker finishes rebooting.
+  - No new npm runtime dependencies. `ssh` and `sed` are system tools.
+- **New `docs/bose-cloud-setup.md`** — step-by-step user guide: prerequisites,
+  running `setup-speaker.sh`, starting `bose-cloud.mjs`, verifying presets work.
 
 ## Conventions for this change
 
 - **Commit type:** `feat:` → minor release.
-- **No new npm runtime packages** — helper script uses `node:child_process`
-  (for `.mjs`) or plain `ssh` (for `.sh`). USB image build tooling is dev/CI
-  only, not shipped in the npm package.
-- **Helper script must be idempotent** — running it twice on the same speaker
-  should be safe (write the same values again, reboot again).
+- **No new npm runtime packages.**
+- **Helper script must be idempotent.**
 - **Target branch:** `dev`.
 
 ## Implementation checklist
 
-### Research / spike
+### Spike (on a real speaker)
 
-- [ ] Confirm SSH root access on SoundTouch 20 and SoundTouch 30 (no-password
-      login). Test `ssh root@<IP> cat /opt/Bose/etc/SoundTouchSdkPrivateCfg.xml`.
-- [ ] Confirm `sed -i` is available on the speaker's busybox shell (or identify
-      the correct in-place edit command).
-- [ ] Confirm reboot command (`reboot` or `kill -9 1` or other).
-- [ ] Spike USB image: evaluate Alpine Linux vs Raspberry Pi OS Lite as base;
-      estimate final image size; confirm Node.js LTS package availability.
+- [ ] Confirm SSH root access — `ssh root@<IP>` with no password.
+- [ ] Confirm `sed -i` is available on the speaker's busybox shell.
+- [ ] Confirm the reboot command (`reboot`, `kill -9 1`, or other).
+- [ ] Read the XML before and after patching to verify correct substitution.
 
-### Helper script
+### Script
 
-- [ ] `scripts/setup-speaker.sh` (or `.mjs`):
-      - `--ip` / `--host` flags; auto-detect host if omitted.
-      - SSH + XML patch + reboot.
-      - Clear success/failure output.
-- [ ] Idempotency test: run twice, confirm no corruption.
-- [ ] `docs/bose-cloud-setup.md` — step-by-step user guide linking the script.
-- [ ] Add `setup-speaker` entry to `package.json` `scripts` (optional convenience).
-
-### USB image
-
-- [ ] Spike complete — base image and toolchain decided
-- [ ] Build script (`scripts/build-usb-image.sh`)
-- [ ] Boot-time TUI / interactive menu
-- [ ] `bose-cloud.mjs` bundled and launchable as a persistent service
-- [ ] x86_64 image builds and boots in QEMU
-- [ ] ARM64 image boots on a Raspberry Pi
-- [ ] GitHub Actions workflow publishes `.img.gz` as a release asset
+- [ ] `scripts/setup-speaker.sh` — `--ip` / `--host` flags, auto-detect host
+      if omitted, SSH + XML patch + reboot, clear output.
+- [ ] Idempotency test: run twice on same speaker, confirm no corruption.
+- [ ] `docs/bose-cloud-setup.md` — user guide.
 
 ## Verification
 
-- [ ] Helper script: SSH into a real speaker, confirm XML patched correctly,
-      speaker reboots, `bose-cloud.mjs` resolves TuneIn, preset plays.
-- [ ] Helper script: run twice — no side effects, speaker still works.
-- [ ] USB image (if shipped): boot on Pi, run setup against a real speaker,
-      confirm end-to-end: XML patched → `bose-cloud.mjs` starts → preset plays.
+- [ ] SSH into a real speaker using the script; confirm XML patched correctly;
+      speaker reboots; `bose-cloud.mjs` resolves TuneIn; preset plays.
+- [ ] Run script a second time; confirm speaker still works.
 
 ## PR / release notes
 
-- **Helper script PR title:** `feat: add helper script to redirect speaker to local bose-cloud emulator`
-- **USB image PR title:** `feat: add bootable USB image for speaker bose-cloud setup`
+- **PR title:** `feat: add helper script to redirect speaker to local bose-cloud emulator`
 - **Targets:** `dev`

--- a/.claude/skills/architect/plans/2026-06-23-speaker-setup-helper.md
+++ b/.claude/skills/architect/plans/2026-06-23-speaker-setup-helper.md
@@ -1,0 +1,132 @@
+---
+feature: Speaker setup helper — bose-cloud redirect automation
+status: planned
+date: 2026-06-23
+branch: feat/speaker-setup-helper
+commit-type: feat
+---
+
+# Speaker setup helper — bose-cloud redirect automation
+
+## Context
+
+The internet-radio feature (`2026-06-22-internet-radio-tunein.md`) requires each
+SoundTouch speaker to be redirected from Bose's defunct cloud to a local
+`bose-cloud.mjs` emulator. This is done by SSHing into the speaker and editing
+`/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml` to point `bmxRegistryUrl` and
+`margeServerUrl` at the Homebridge host.
+
+Currently that setup is purely manual. This plan explores making it easier via:
+
+1. **A helper script** (`scripts/setup-speaker.sh` or `scripts/setup-speaker.mjs`)
+   that automates the SSH steps: connects to the speaker, edits the XML, and
+   reboots — driven by a known IP address.
+2. **A bootable USB image** that can be flashed to a USB drive, inserted into a
+   computer on the same LAN as the speakers, and run without any Node.js / npm
+   install. Useful for users who aren't developers.
+
+These are distinct deliverables that can land independently. The helper script
+is lower risk and can ship first; the USB image is a larger effort.
+
+**Dependency:** `2026-06-22-internet-radio-tunein.md` (PR #118) must merge first
+so the `bose-cloud.mjs` emulator and its documented config values exist in `dev`.
+
+## Decisions & findings
+
+| Date | Decision / finding | Rationale / evidence | Alternatives rejected |
+| --- | --- | --- | --- |
+| 2026-06-23 | Finding: speaker SSH access confirmed — soundcork `docs/speaker-setup.md` documents SSH login (`root`, no password on most models) and the XML file path | Prerequisite for any automated approach | Telnet / SoundTouch API — no write path to system files via HTTP API |
+| 2026-06-23 | Helper script approach: `ssh root@<IP> "sed -i ..."` to patch the XML in-place | Minimal deps — `ssh` available everywhere; no new npm packages in the plugin | scp + edit locally + scp back — more moving parts; sed in-place is atomic enough for this file |
+| 2026-06-23 | USB image approach deferred to spike | Requires selecting a base image (Alpine Linux, Raspberry Pi OS Lite, etc.), packaging Node.js + the scripts, and automating the flash workflow (Etcher, `dd`). Scope is significant — needs feasibility check. | Shipping USB image immediately — too much unknown; helper script delivers value sooner |
+| 2026-06-23 | USB image target: x86_64 + ARM64 (Raspberry Pi) | Most users run Homebridge on a Pi; a Pi-compatible image can also run in a VM on x86 | x86-only — excludes the dominant Homebridge hardware |
+
+## If cancelled
+
+> Only fill this in when `status: cancelled`. Leave empty otherwise.
+
+## Affected areas
+
+### Helper script
+
+- **New `scripts/setup-speaker.sh`** (or `.mjs`):
+  - Accepts `--ip <SPEAKER_IP>` and `--host <HOMEBRIDGE_HOST>` (defaults to
+    auto-detected LAN IP, same logic as the platform).
+  - SSHes into `root@<SPEAKER_IP>` (no password on most SoundTouch models).
+  - Reads `/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml`.
+  - Patches `bmxRegistryUrl` → `http://<HOMEBRIDGE_HOST>:8000/bmx/registry/v1/services`
+    and `margeServerUrl` → `http://<HOMEBRIDGE_HOST>:8000/marge`.
+  - Reboots the speaker (`reboot` or `kill -9 1`).
+  - Prints clear instructions: "Now start `bose-cloud.mjs` on your Homebridge
+    host before the speaker comes back online."
+- No new npm runtime deps. `ssh` is a system tool.
+- Add usage docs to the script header and/or a `docs/bose-cloud-setup.md`.
+
+### USB image (spike first)
+
+- Base image TBD (Alpine Linux recommended for size; Raspberry Pi OS Lite for
+  Pi compatibility).
+- Packages to bundle: Node.js LTS, this plugin's `scripts/` directory.
+- Boot flow: auto-run a TUI or simple interactive menu that:
+  1. Scans the LAN for SoundTouch speakers (mDNS / SSDP).
+  2. Lets the user select a speaker.
+  3. Runs the helper script against the selected speaker.
+  4. Optionally starts `bose-cloud.mjs` persistently (systemd service).
+- Build tooling: `packer`, `docker buildx`, or a custom shell script with
+  `debootstrap` / `alpine-make-rootfs`.
+- Output: `.img.gz` file published as a GitHub Release asset.
+
+## Conventions for this change
+
+- **Commit type:** `feat:` → minor release.
+- **No new npm runtime packages** — helper script uses `node:child_process`
+  (for `.mjs`) or plain `ssh` (for `.sh`). USB image build tooling is dev/CI
+  only, not shipped in the npm package.
+- **Helper script must be idempotent** — running it twice on the same speaker
+  should be safe (write the same values again, reboot again).
+- **Target branch:** `dev`.
+
+## Implementation checklist
+
+### Research / spike
+
+- [ ] Confirm SSH root access on SoundTouch 20 and SoundTouch 30 (no-password
+      login). Test `ssh root@<IP> cat /opt/Bose/etc/SoundTouchSdkPrivateCfg.xml`.
+- [ ] Confirm `sed -i` is available on the speaker's busybox shell (or identify
+      the correct in-place edit command).
+- [ ] Confirm reboot command (`reboot` or `kill -9 1` or other).
+- [ ] Spike USB image: evaluate Alpine Linux vs Raspberry Pi OS Lite as base;
+      estimate final image size; confirm Node.js LTS package availability.
+
+### Helper script
+
+- [ ] `scripts/setup-speaker.sh` (or `.mjs`):
+      - `--ip` / `--host` flags; auto-detect host if omitted.
+      - SSH + XML patch + reboot.
+      - Clear success/failure output.
+- [ ] Idempotency test: run twice, confirm no corruption.
+- [ ] `docs/bose-cloud-setup.md` — step-by-step user guide linking the script.
+- [ ] Add `setup-speaker` entry to `package.json` `scripts` (optional convenience).
+
+### USB image
+
+- [ ] Spike complete — base image and toolchain decided
+- [ ] Build script (`scripts/build-usb-image.sh`)
+- [ ] Boot-time TUI / interactive menu
+- [ ] `bose-cloud.mjs` bundled and launchable as a persistent service
+- [ ] x86_64 image builds and boots in QEMU
+- [ ] ARM64 image boots on a Raspberry Pi
+- [ ] GitHub Actions workflow publishes `.img.gz` as a release asset
+
+## Verification
+
+- [ ] Helper script: SSH into a real speaker, confirm XML patched correctly,
+      speaker reboots, `bose-cloud.mjs` resolves TuneIn, preset plays.
+- [ ] Helper script: run twice — no side effects, speaker still works.
+- [ ] USB image (if shipped): boot on Pi, run setup against a real speaker,
+      confirm end-to-end: XML patched → `bose-cloud.mjs` starts → preset plays.
+
+## PR / release notes
+
+- **Helper script PR title:** `feat: add helper script to redirect speaker to local bose-cloud emulator`
+- **USB image PR title:** `feat: add bootable USB image for speaker bose-cloud setup`
+- **Targets:** `dev`

--- a/.claude/skills/architect/plans/2026-06-23-speaker-usb-image.md
+++ b/.claude/skills/architect/plans/2026-06-23-speaker-usb-image.md
@@ -1,0 +1,134 @@
+---
+feature: Bootable USB image for SoundTouch speaker bose-cloud setup
+status: planned
+date: 2026-06-23
+branch: feat/speaker-usb-image
+commit-type: feat
+---
+
+# Bootable USB image for SoundTouch speaker bose-cloud setup
+
+## Context
+
+Setting up a SoundTouch speaker to work with the `bose-cloud.mjs` emulator
+requires SSH access and editing a system XML file on the speaker. The
+`scripts/setup-speaker.sh` helper (`2026-06-23-speaker-setup-helper.md`) solves
+this for developers, but non-developer users have no path.
+
+This plan delivers a **bootable USB image** that non-developers can flash to a
+thumb drive, boot on any computer on their home LAN, and use to configure their
+speakers through a simple interactive menu — no Node.js, no npm, no terminal.
+
+**This plan is blocked on research.** The base OS, build toolchain, flash UX,
+and distribution model all have open questions that must be answered before
+implementation begins. The checklist is structured accordingly.
+
+**Dependencies:**
+- `2026-06-22-internet-radio-tunein.md` (PR #118) — `bose-cloud.mjs` must exist.
+- `2026-06-23-speaker-setup-helper.md` — USB image should embed and call the
+  helper script logic; ship the script first.
+
+## Decisions & findings
+
+| Date | Decision / finding | Rationale / evidence | Alternatives rejected |
+| --- | --- | --- | --- |
+| 2026-06-23 | Plan is research-first — all architectural decisions deferred to spike | Base image, build toolchain, flash UX, and distribution are all open. Committing to an approach before research risks a costly rewrite. | Picking Alpine/Pi OS now — premature; image size, Node.js availability, and boot UX need verification |
+
+## If cancelled
+
+> Only fill this in when `status: cancelled`. Leave empty otherwise.
+
+## Research questions (must answer before implementation)
+
+### Base OS
+
+- What is the smallest bootable Linux that can run Node.js LTS, has `ssh` and
+  `sed`, and works on both x86_64 and ARM64?
+  - Candidates: **Alpine Linux** (smallest, musl libc — Node.js available via
+    apk), **Raspberry Pi OS Lite** (largest, best Pi support), **Debian netinst
+    minimal**.
+- Is Node.js LTS available as a pre-built package for Alpine on both arches, or
+  does it need to be cross-compiled?
+- What is the estimated final image size for each candidate?
+
+### Build toolchain
+
+- Can the image be built reproducibly in a GitHub Actions runner (Linux x86_64)?
+  - Candidates: `packer` + QEMU, `docker buildx` (export rootfs → image),
+    `alpine-make-rootfs`, custom `debootstrap`.
+- How long does a full build take in CI? (Budget: < 15 min.)
+- Can ARM64 be built via QEMU emulation on x86_64, or is a native ARM runner needed?
+
+### Boot and flash UX
+
+- What is the simplest interactive menu framework that works on a framebuffer
+  console (no X11)? Candidates: `whiptail` (Newt), `dialog`, a tiny Node.js
+  Ink CLI.
+- How do users flash the image? Etcher (GUI, cross-platform) vs `dd` vs a
+  custom web-based flasher?
+- Does the image need to handle both BIOS and UEFI boot (x86_64)? Is a single
+  MBR image sufficient, or is a hybrid MBR/GPT needed?
+
+### Discovery
+
+- Can the USB image scan for SoundTouch speakers reliably (mDNS, SSDP) from a
+  fresh boot with no config?
+- What happens if the LAN blocks multicast? Is a manual IP fallback sufficient?
+
+### Distribution
+
+- Where does the `.img.gz` live? Options: GitHub Releases asset, a separate
+  `homebridge-soundtouch-speaker-setup` repo, or a CDN.
+- Does publishing a binary image add any legal/compliance obligations (GPL
+  components, Bose firmware interaction)?
+
+## Affected areas
+
+*(TBD — fill in after research spike)*
+
+The image will likely embed:
+- `scripts/bose-cloud.mjs` (from the main repo)
+- `scripts/setup-speaker.sh` (or equivalent Node.js port)
+- A boot-time interactive menu (whiptail or Node.js CLI)
+- Possibly a `systemd` service to auto-start `bose-cloud.mjs` after setup
+
+A GitHub Actions workflow will build and publish the image as a release asset.
+
+## Conventions for this change
+
+- **Commit type:** `feat:` → minor release.
+- **No new npm runtime packages** for the plugin itself; image build tooling
+  is CI-only.
+- **Target branch:** `dev` (after research spike is complete).
+
+## Implementation checklist
+
+### Research spike (block all implementation on this)
+
+- [ ] Answer all questions in the **Research questions** section above.
+- [ ] Document answers in the **Decisions & findings** table.
+- [ ] Produce a one-page architecture decision record: chosen base OS, build
+      toolchain, flash UX, and distribution approach with rationale.
+
+### Implementation (after spike)
+
+- [ ] Base image build script
+- [ ] Node.js + deps bundled into image
+- [ ] Boot-time interactive menu (scan → select speaker → run setup)
+- [ ] `bose-cloud.mjs` starts as a persistent service after setup
+- [ ] x86_64 image builds and boots in QEMU
+- [ ] ARM64 image boots on a Raspberry Pi 4
+- [ ] GitHub Actions workflow builds and publishes `.img.gz` on release
+
+## Verification
+
+- [ ] Boot image in QEMU (x86_64); run full setup flow against a simulated
+      speaker (or mock SSH target); confirm XML patched and preset plays.
+- [ ] Boot image on a real Raspberry Pi 4 (ARM64); run against a real speaker;
+      confirm end-to-end: XML patched → `bose-cloud.mjs` persistent → preset plays.
+- [ ] Flash via Etcher on macOS and Windows; confirm both work.
+
+## PR / release notes
+
+- **PR title:** `feat: add bootable USB image for SoundTouch bose-cloud setup`
+- **Targets:** `dev`


### PR DESCRIPTION
## What & why

Two plan updates to converge the internet-radio and PWA setup stories:

**PWA plan (`2026-06-19-progressive-web-app.md`):**
- Phase 2 expanded to cover **source selection** (change active source per speaker via `POST /select`) alongside group/zone management, with a plugin REST API proxying both.
- Phase 3 scoped precisely: config-write covers `accessories[]`, `global.presets[]`, and `global.presetSyncInterval` — the three sections needed for the PWA to fully configure speakers and TuneIn presets without hand-editing JSON. PR title updated to reflect new scope.
- New Decisions & findings rows documenting why config-write was expanded and what the reload mechanism needs to resolve (Spike B).

**New plan (`2026-06-23-speaker-setup-helper.md`):**
- Helper script (`scripts/setup-speaker.sh`) to automate the SSH + `SoundTouchSdkPrivateCfg.xml` edit step required by the bose-cloud emulator — the manual step currently documented in `scripts/bose-cloud.mjs`.
- Bootable USB image (deferred to spike) for non-developer users who want to set up speakers without installing Node.js.
- Depends on PR #118 (`feat/internet-radio-tunein`) merging first.

## Verification

- No production code changed — plan files only.
- `npm run typecheck && npm run lint && npm test` not required (docs-only branch).


---
_Generated by [Claude Code](https://claude.ai/code/session_014sXqcZr8zpTZkmiTFzN5YD)_