### PR TITLE
fix: skip reconciliation poll when speaker is offline

### DIFF
--- a/src/accessories/SoundTouchSpeakerPlatformAccessory.ts
+++ b/src/accessories/SoundTouchSpeakerPlatformAccessory.ts
@@ -92,6 +92,10 @@ export class SoundTouchSpeakerPlatformAccessory extends SoundTouchSpeakerCharact
       await new Promise((resolve) =>
         setTimeout(resolve, RECONCILIATION_INTERVAL_MS)
       );
+      if (!this.device.gabbo.isConnected) {
+        this.log.debug(`${this.accessory.displayName} offline — skipping reconciliation poll`);
+        continue;
+      }
       try {
         await this.refresh();
       } catch (e: unknown) {

--- a/src/accessories/__tests__/SoundTouchSpeakerPlatformAccessory.test.ts
+++ b/src/accessories/__tests__/SoundTouchSpeakerPlatformAccessory.test.ts
@@ -12,8 +12,8 @@ function buildCharacteristic(gabboEvents: readonly GabboUpdateType[] = []) {
   return { characteristic: { init, refresh, gabboEvents } as unknown as SoundTouchSpeakerCharacteristic, refresh, init };
 }
 
-function build(opts: { pollingInterval?: number; gabboEvents?: readonly GabboUpdateType[] } = {}) {
-  const { pollingInterval = 0, gabboEvents = [] } = opts;
+function build(opts: { pollingInterval?: number; gabboEvents?: readonly GabboUpdateType[]; isConnected?: boolean } = {}) {
+  const { pollingInterval = 0, gabboEvents = [], isConnected = true } = opts;
   const { characteristic, refresh } = buildCharacteristic(gabboEvents);
 
   const homebridgeLog = jest.fn();
@@ -21,7 +21,7 @@ function build(opts: { pollingInterval?: number; gabboEvents?: readonly GabboUpd
   const device = {
     name: 'Kitchen',
     configuration: { pollingInterval },
-    gabbo: { on: gabboOn, connect: jest.fn(), disconnect: jest.fn() },
+    gabbo: { on: gabboOn, connect: jest.fn(), disconnect: jest.fn(), isConnected },
     connectGabbo: jest.fn(),
     disconnectGabbo: jest.fn(),
   };
@@ -112,6 +112,26 @@ describe('SoundTouchSpeakerPlatformAccessory', () => {
       await jest.advanceTimersByTimeAsync(RECONCILIATION_INTERVAL_MS * 3);
 
       expect(refresh.mock.calls).toHaveLength(callsAfterDrain);
+    });
+
+    it('skips refresh when the Gabbo socket is not connected', async () => {
+      jest.useFakeTimers();
+      const { subject, refresh } = build({ isConnected: false });
+
+      await subject.init();
+      await jest.advanceTimersByTimeAsync(RECONCILIATION_INTERVAL_MS);
+
+      expect(refresh).not.toHaveBeenCalled();
+    });
+
+    it('calls refresh when the Gabbo socket is connected', async () => {
+      jest.useFakeTimers();
+      const { subject, refresh } = build({ isConnected: true });
+
+      await subject.init();
+      await jest.advanceTimersByTimeAsync(RECONCILIATION_INTERVAL_MS);
+
+      expect(refresh).toHaveBeenCalledTimes(1);
     });
 
     it('is safe to call stopPolling before init', () => {


### PR DESCRIPTION
## What & why

The 5-minute reconciliation loop fires HTTP requests for every characteristic even when a speaker is powered off or unreachable, producing repeated `PollingRefreshFailed` warnings and wasting network resources.

The fix checks `device.gabbo.isConnected` before calling `refresh()`. Gabbo auto-reconnects every 5 seconds, so polling resumes automatically when the device comes back online — no manual intervention needed. Skipped cycles are logged at `debug` level (visible with `verbose: true`).

## Verification

- [x] `npm run typecheck && npm run lint && npm test` — 285 tests, all green
- [ ] `npm run watch` — take a speaker offline mid-session; confirm no `PollingRefreshFailed` warnings; bring it back and confirm refreshes resume