### PR TITLE
docs: mark internet-radio-tunein plan as done

### DIFF
--- a/.claude/skills/architect/plans/done/2026-06-22-internet-radio-tunein.md
+++ b/.claude/skills/architect/plans/done/2026-06-22-internet-radio-tunein.md
@@ -1,6 +1,6 @@
 ---
 feature: Internet radio via TuneIn
-status: in-progress
+status: done
 date: 2026-06-22
 branch: feat/internet-radio-tunein
 commit-type: feat


### PR DESCRIPTION
Moves the internet radio / TuneIn plan to `plans/done/` and updates its status to `done` following the merge of #118.