### PR TITLE
fix: config.schema.json trailing comma crashes Homebridge UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Validate config schema
+        run: npm run validate:schema
+
       - name: Lint
         run: npm run lint
 
@@ -117,6 +120,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Validate config schema
+        run: npm run validate:schema
 
       - name: Lint
         run: npm run lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
 npx lint-staged
 npx knip
+npm run validate:schema

--- a/config.schema.json
+++ b/config.schema.json
@@ -34,7 +34,7 @@
             "enum": ["switch", "lightbulb"],
             "default": "switch",
             "description": "Default HomeKit accessory type for all speakers. 'lightbulb' exposes volume via Brightness."
-          },
+          }
         }
       },
       "accessories": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:ci": "jest --ci",
     "test:impacted": "jest --ci --changedSince=origin/${BASE_REF:-dev} --passWithNoTests --coverage=false",
     "knip": "knip",
+    "validate:schema": "node -e \"JSON.parse(require('fs').readFileSync('config.schema.json', 'utf8'))\"",
     "prepare": "husky"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Removes trailing comma on `global.accessoryType` in `config.schema.json` that caused the Homebridge UI to show **"Failed to load plugin config schema."**
- Adds a `validate:schema` npm script (`node -e "JSON.parse(...)"`) to catch invalid JSON early
- Hooks it into the pre-commit hook and both CI jobs (PR validation + regression) so this class of error can't ship again

## Test plan

- [ ] Verify Homebridge UI loads the config schema without error after this change
- [ ] Introduce a trailing comma locally and confirm `npm run validate:schema` exits non-zero
- [ ] Confirm pre-commit hook rejects a commit with invalid `config.schema.json`