### PR TITLE
chore: promote dev → beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Validate config schema
+        run: npm run validate:schema
+
       - name: Lint
         run: npm run lint
 
@@ -117,6 +120,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Validate config schema
+        run: npm run validate:schema
 
       - name: Lint
         run: npm run lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
 npx lint-staged
 npx knip
+npm run validate:schema

--- a/README.md
+++ b/README.md
@@ -113,17 +113,19 @@ Each accessory must be matched to a device using either `ip` or `room`. If both 
 * `ip`: The ip address of your device on your network.
 * `port`: The port used to reach the device. Only used with `ip`. __default__: **8090**
 * `room`: Must match exactly the name of the SoundTouch device (as set in the Bose app). Ignored if `ip` is set.
-* `pollingInterval`: Poll this device every interval in milliseconds. Overrides the global value.
 * `accessoryType`: Override the HomeKit accessory type for this speaker — `switch` or `lightbulb`. Overrides the global value.
+* `disabled`: When `true`, removes this speaker from HomeKit without deleting the config entry. Set back to `false` to re-register. __default__: **false**
+* `pollingInterval`: ~~Deprecated — no longer used and can be removed from your config.~~
 
 
 ### Global element
 Default configuration applied to all accessories. Any value here can be overridden per accessory.
 
 *Optional fields*
-* `verbose`: Log all device information __default__: **false**
-* `pollingInterval`: Poll each device every interval in milliseconds __default__: **2000**
+* `logLevel`: Minimum log level written to the Homebridge console — `debug`, `info`, `warn`, or `error`. __default__: **info**
 * `accessoryType`: HomeKit accessory type for all speakers — `switch` (default) or `lightbulb`. The `lightbulb` type exposes volume via the Brightness characteristic. __default__: **switch**
+* `verbose`: ~~Deprecated — use `logLevel: "debug"` instead.~~
+* `pollingInterval`: ~~Deprecated — no longer used and can be removed from your config.~~
 
 ## References
 * [SoundTouch Web API](https://assets.bosecreative.com/m/496577402d128874/original/SoundTouch-Web-API.pdf) — Bose's official API specification this plugin is built against.

--- a/config.schema.json
+++ b/config.schema.json
@@ -34,7 +34,7 @@
             "enum": ["switch", "lightbulb"],
             "default": "switch",
             "description": "Default HomeKit accessory type for all speakers. 'lightbulb' exposes volume via Brightness."
-          },
+          }
         }
       },
       "accessories": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:ci": "jest --ci",
     "test:impacted": "jest --ci --changedSince=origin/${BASE_REF:-dev} --passWithNoTests --coverage=false",
     "knip": "knip",
+    "validate:schema": "node -e \"JSON.parse(require('fs').readFileSync('config.schema.json', 'utf8'))\"",
     "prepare": "husky"
   },
   "devDependencies": {


### PR DESCRIPTION
## Release Readiness — `dev` → `beta`

| Check | Status | Notes |
|---|---|---|
| Build | ✅ | Clean compile |
| Tests | ✅ | 335/335 passed |
| Lint | ✅ | Exit 0, no warnings |
| Package version placeholder | ✅ | `0.0.0-development` |
| Schema ↔ README alignment | ✅ | Fixed in #129 and #130 |
| No stale "future" language | ✅ | None found |
| Conventional commits | ✅ | All commits pass |

## Commits since last beta release

- `fix: config.schema.json trailing comma crashes Homebridge UI (#129)`
- `docs: align README with current config schema (#130)`

## Notes

- `docs:` commits do not trigger a semantic-release version bump — the beta channel will not publish a new npm release for this promotion unless additional `fix:`/`feat:` commits land before merge.
- Do **not** delete the `beta` branch after merge.