### PR TITLE
fix: mark verbose config property as deprecated in schema

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -21,7 +21,8 @@
           },
           "verbose": {
             "type": "boolean",
-            "default": false
+            "default": false,
+            "description": "DEPRECATED — use logLevel: \"debug\" instead."
           },
           "logLevel": {
             "type": "string",


### PR DESCRIPTION
## Summary

- Adds a deprecation description to `global.verbose` in `config.schema.json` to match the README, which already marks it deprecated in favour of `logLevel: "debug"`

## Context

The `docs: align README with current config schema` commit (#130) updated the README but left the schema itself without a deprecation notice on `verbose`. This commit closes that gap.

This also serves as the release-triggering `fix:` commit for the beta channel — the prior dev→beta promotion PR (#131) was accidentally squash-merged, collapsing the original `fix:` commit into a `chore:` PR title and preventing semantic-release from publishing a new beta.

## Test plan

- [ ] `npm run validate:schema` passes
- [ ] Homebridge UI config schema loads without error
- [ ] Merging dev→beta with a **merge commit** (not squash) publishes a new `@beta` release